### PR TITLE
XSLT pipeline for project corpus

### DIFF
--- a/scripts/ANHDraftsXML/XMLtransformed/ANHfinalDraft.xml
+++ b/scripts/ANHDraftsXML/XMLtransformed/ANHfinalDraft.xml
@@ -1,0 +1,6949 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>STAR WARS Episode IV A NEW HOPE </title>
+      <author>From the JOURNAL OF THE WHILLS By George Lucas</author>
+      <draft>Revised Fourth Draft</draft>
+      <date>January 15, 1976</date>
+   </metadata>
+						LUCASFILM LTD.
+					 ----------------------
+A long time ago, in a galaxy far, far, away...
+	A vast sea of stars serves as the backdrop for the main
+	title. War drums echo through the heavens as a rollup 
+	slowly crawls into infinity.
+   It is a period of civil war. Rebel spaceships, striking from a
+hidden base, have won their first victory against the evil Galactic
+Empire.
+   During the battle, Rebel spies managed to steal secret plans to the
+Empire's ultimate weapon, the Death Star, an armored space station
+with enough power to destroy an entire planet.
+   Pursued by the Empire's sinister agents, Princess Leia races home
+aboard her starship, custodian of the stolen plans that can save her
+people and restore freedom to the galaxy...
+	The awesome yellow planet of Tatooine emerges from a total
+	eclipse, her two moons glowing against the darkness. A tiny
+	silver spacecraft, a Rebel Blockade Runner firing lasers from
+	the back of the ship, races through space. It is pursed by a
+	giant Imperial Stardestroyer. Hundreds of deadly laserbolts
+	streak from the Imperial Stardestroyer, causing the main solar
+	fin of the Rebel craft to disintegrate.
+
+
+
+<scene n="1">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- MAIN PASSAGEWAY.
+	An explosion rocks the ship as two robots, Artoo-Detoo (R2-D2)
+	and See-Threepio (C-3PO) struggle to make their way through the
+	shaking, bouncing passageway. Both robots are old and battered. 
+	Artoo is a short, claw-armed tripod. His face is a mass of
+	computer lights surrounding a radar eye. Threepio, on the
+	other hand, is a tall, slender robot of human proportions. He
+	has a gleaming bronze-like metallic surface of an Art Deco
+	design. 
+		 Another blast shakes them as they struggle along their
+	way.
+</sd>
+      <sp spk="THREEPIO"> Did you hear that? They've shut down the main reactor. We'll
+be destroyed for sure. This is madness!
+		</sp>
+      <sd> Rebel troopers rush past the robots and take up positions
+	in the main passageway. They aim their weapons toward the door.
+</sd>
+      <sp spk="THREEPIO"> We're doomed!
+		</sp>
+      <sd> The little R2 unit makes a series of electronic sounds that
+	only another robot could understand.
+</sd>
+      <sp spk="THREEPIO"> There'll be no escape for the Princess this time.
+		</sp>
+      <sd> Artoo continues making beeping sounds. Tension mounts as
+	loud metallic latches clank and the scream of heavy equipment
+	are heard moving around the outside hull of the ship.
+</sd>
+      <sp spk="THREEPIO"> What's that?
+</sp>
+   </scene>
+   <scene n="2">
+      <sd>EXTERIOR: SPACECRAFT IN SPACE.
+	The Imperial craft has easily overtaken the Rebel Blockade
+	Runner. The smaller Rebel ship is being drawn into the
+	underside dock of the giant Imperial starship.
+</sd>
+   </scene>
+   <scene n="3">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	The nervous Rebel troopers aim their weapons. Suddenly a
+	tremendous blast opens up a hole in the main passageway and a
+	score of fearsome armored spacesuited stormtroopers make their
+	way into the smoke-filled corridor.
+		 In a few minutes the entire passageway is ablaze with
+	laserfire. The deadly bolts ricochet in wild random patterns
+	creating huge explosions. Stormtroopers scatter and duck
+	behind storage lockers. Laserbolts hit several Rebel soldiers
+	who scream and stagger through the smoke, holding shattered
+	arms and faces.
+		 An explosion hits near the robots.
+</sd>
+      <sp spk="THREEPIO"> I should have known better than to trust the logic of a
+half-sized thermocapsulary dehousing assister...
+		</sp>
+      <sd> Artoo counters with an angry rebuttal as the battle rages
+	around the two hapless robots.
+</sd>
+   </scene>
+   <scene n="4">
+      <sd>EXTERIOR: TATOOINE -- DESERT WASTELAND -- DAY.
+	A death-white wasteland stretches from horizon to horizon. The
+	tremendous heat of two huge twin suns settle on a lone figure,
+	Luke Skywalker, a farm boy with heroic aspirations who looks
+	much younger than his eighteen years. His shaggy hair and
+	baggy tunic give him the air of a simple but lovable lad with
+	a prize-winning smile.
+		 A light wind whips at him as he adjusts several valves on a
+	large battered moisture vaporator which sticks out of the
+	desert floor much like an oil pipe with valves. He is aided by
+	a beatup tread-robot with six claw arms. The little robot
+	appears to be barely functioning and moves with jerky motions.
+	A bright sparkle in the morning sky catches Luke's eye and he
+	instinctively grabs a pair of electrobinoculars from his utility
+	belt. He stands transfixed for a few moments studying the
+	heavens, then dashed toward his dented, crudely repaired
+	Landspeeder (an auto-like transport that travels a few feet
+	above the ground on a magnetic-field). He motions for the tiny
+	robot to follow him.
+</sd>
+      <sp spk="LUKE"> Hurry up! Come with me! What are you waiting for?! Get in gear!
+		</sp>
+      <sd> The robot scoots around in a tight circle, stops short, and
+	smoke begins to pour out of every joint. Luke throws his arms
+	up in disgust. Exasperated, the young farm boy jumps into his
+	Landspeeder leaving the smoldering robot to hum madly.
+</sd>
+   </scene>
+   <scene n="5">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- MAIN HALLWAY.
+	The awesome, seven-foot-tall Dark Lord of the Sith makes his
+	way into the blinding light of the main passageway. This is
+	Darth Vader, right hand of the Emperor. His face is obscured
+	by his flowing black robes and grotesque breath mask, which
+	stands out next to the fascist white armored suits of the
+	Imperial stormtroopers. Everyone instinctively backs away from
+	the imposing warrior and a deathly quiet sweeps through the
+	Rebel troops. Several of the Rebel troops break and run in a
+	frenzied panic.
+</sd>
+   </scene>
+   <scene n="6">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	A woman's hand puts a card into an opening in Artoo's dome.
+	Artoo makes beeping sounds.
+</sd>
+   </scene>
+   <scene n="7">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	Threepio stands in a hallway, somewhat bewildered. Artoo is
+	nowhere in sight. The pitiful screams of the doomed Rebel
+	soldiers can be heard in the distance.
+</sd>
+      <sp spk="THREEPIO"> Artoo! Artoo-Detoo, where are you?
+		</sp>
+      <sd> A familiar clanking sound attacks Threepio's attention and
+	he spots little Artoo at the end of the hallway in a
+	smoke-filled alcove. A beautiful young girl (about sixteen
+	years old) stands in front of Artoo. Surreal and out of place,
+	dreamlike and half hidden in the smoke, she finishes adjusting
+	something on Artoo's computer face, then watches as the little
+	robot joins his companion.
+</sd>
+      <sp spk="THREEPIO"> At last! Where have you been?</sp>
+      <sd>Stormtroopers can be heard battling in the distance.
+</sd>
+      <sp spk="THREEPIO"> They're heading in this direction. What are we going to do?
+We'll be sent to the spice mine of Kessel or smashed into who knows
+what!
+		</sp>
+      <sd> Artoo scoots past his bronze friend and races down the
+	subhallway. Threepio chases after him.
+</sd>
+      <sp spk="THREEPIO"> Wait a minute, where are you going?
+		</sp>
+      <sd> Artoo responds with electronic beeps.
+</sd>
+   </scene>
+   <scene n="8">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- CORRIDOR
+	The evil Darth Vader stands amid the broken and twisted bodies
+	of his foes. He grabs a wounded Rebel Officer by the neck as
+	an Imperial Officer rushes up to the Dark Lord.
+</sd>
+      <sp spk="IMPERIAL OFFICER"> The Death Star plans are not in the main computer.
+		</sp>
+      <sd> Vader squeezes the neck of the Rebel Officer, who struggles
+	in vain.
+</sd>
+      <sp spk="VADER"> Where are those transmissions you intercepted?
+		</sp>
+      <sd> Vader lifts the Rebel off his feet by his throat.
+</sd>
+      <sp spk="VADER"> What have you done with those plans?
+</sp>
+      <sp spk="REBEL OFFICER"> We intercepted no transmissions. Aaah....This is a
+consular ship. Were on a diplomatic mission.
+</sp>
+      <sp spk="VADER"> If this is a consular ship...were is the Ambassador?
+		</sp>
+      <sd> The Rebel refuses to speak but eventually cries out as the
+	Dark Lord begins to squeeze the officer's throat, creating a
+	gruesome snapping and choking, until the soldier goes limp.
+	Vader tosses the dead soldier against the wall and turns to
+	his troops.
+</sd>
+      <sp spk="VADER"> Commander, tear this ship apart until you've found those plans
+and bring me the Ambassador. I want her alive!
+		</sp>
+      <sd> The stormtroopers scurry into the subhallways.
+</sd>
+   </scene>
+   <scene n="9">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- SUBHALLWAY.
+	The lovely young girl huddles in a small alcove as the
+	stormtroopers search through the ship. She is Princess Leia
+	Organa, a member of the Alderaan Senate. The fear in her eyes
+	slowly gives way to anger as the muted crushing sounds of the
+	approaching stormtroopers grow louder. One of the troopers
+	spots her.
+</sd>
+      <sp spk="TROOPER"> There she is! Set for stun!
+		</sp>
+      <sd> Leia steps from her hiding place and blasts a trooper with
+	her laser pistol. She starts to run but is felled by a
+	paralyzing ray. The troopers inspect her inert body.
+</sd>
+      <sp spk="TROOPER"> She'll be all right. Inform Lord Vader we have a prisoner.
+</sp>
+   </scene>
+   <scene n="10">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- SUBHALLWAY.
+	Artoo stops before the small hatch of an emergency lifepod. He
+	snaps the seal on the main latch and a red warning light
+	begins to flash. The stubby astro-robot works his way into the
+	cramped four-man pod.
+</sd>
+      <sp spk="THREEPIO"> Hey, you're not permitted in there. It's restricted. You'll
+be deactivated for sure..
+		</sp>
+      <sd> Artoo beeps something to him.
+</sd>
+      <sp spk="THREEPIO"> Don't call me a mindless philosopher, you overweight glob of
+grease! Now come out before somebody sees you.
+		</sp>
+      <sd> Artoo whistles something at his reluctant friend regarding
+	the mission he is about to perform.
+</sd>
+      <sp spk="THREEPIO"> Secret mission? What plans? What are you talking about? I'm
+not getting in there!
+		</sp>
+      <sd> Artoo isn't happy with Threepio's stubbornness, and he beeps
+	and twangs angrily.
+	A new explosion, this time very close, sends dust and debris
+	through the narrow subhallway. Flames lick at Threepio and,
+	after a flurry of electronic swearing from Artoo, the lanky
+	robot jumps into the lifepod.
+</sd>
+      <sp spk="THREEPIO"> I'm going to regret this.
+</sp>
+   </scene>
+   <scene n="11">
+      <sd>INTERIOR: IMPERIAL STARDESTROYER.
+	On the main viewscreen, the lifepod carrying the two terrified
+	robots speeds away from the stricken Rebel spacecraft.
+</sd>
+      <sp spk="CHIEF PILOT"> There goes another one.
+</sp>
+      <sp spk="CAPTAIN"> Hold your fire. There are no life forms. It must have been
+short-circuited.
+</sp>
+   </scene>
+   <scene n="12">
+      <sd>INTERIOR: LIFEPOD.
+	Artoo and Threepio look out at the receding Imperial starship.
+	Stars circle as the pod rotates through the galaxy.
+</sd>
+      <sp spk="THREEPIO"> That's funny, the damage doesn't look as bad from out here.</sp>
+      <sd>Artoo beeps an assuring response.
+</sd>
+      <sp spk="THREEPIO"> Are you sure this things safe?
+</sp>
+   </scene>
+   <scene n="13">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD SETTLEMENT -- POWER STATION -- DAY.
+	Heat waves radiate from the dozen or so bleached white
+	buildings. Luke pilots his Landspeeder through the dusty empty
+	street of the tiny settlement. An old woman runs to get out of
+	the way of the speeding vehicle, shaking her fist at Luke as
+	he flies past.
+</sd>
+      <sp spk="WOMAN"> I've told you kids to slow down!
+</sp>
+   </scene>
+   <scene n="14">
+      <sd>INTERIOR: POWER STATION -- DAY.
+	Luke bursts into the power station, waking The Fixer, a rugged
+	mechanic and Camie, a sexy, disheveled girl who has been
+	asleep in his lap. They grumbled as he races through the
+	office, yelling wildly.
+</sd>
+      <sp spk="FIXER"> Did I hear a young noise blast through here?
+</sp>
+      <sp spk="CAMIE"> It was just wormie on another rampage.
+		</sp>
+      <sd> Luke bounces into a small room behind the office where Deak
+	and Windy, two tough boys about the same age as Luke, are
+	playing a computer pool-like game with Biggs, a burly,
+	handsome boy a few years older than the rest. His flashy city
+	attire is a sharp contrast to the loose-fitting tunics of the
+	farm boys. A robot repairs some equipment in the background.
+</sd>
+      <sp spk="LUKE"> Shape it up you guys!.... Biggs?
+		</sp>
+      <sd> Luke's surprise at the appearance of Biggs gives way to
+	great joy and emotion. They give each other a great bear hug.
+</sd>
+      <sp spk="LUKE"> I didn't know you were back! When did you get in?
+</sp>
+      <sp spk="BIGGS"> Just now. I wanted to surprise you, hot shot. I thought you'd be
+here...certainly didn't expect you to be out working. <sd>he laughs.</sd>
+      </sp>
+      <sp spk="LUKE"> The Academy didn't change you much...but you're back so soon?
+Hey, what happened, didn't you get your commission?
+		</sp>
+      <sd> Biggs has an air of cool that seems slightly phony.
+</sd>
+      <sp spk="BIGGS"> Of course I got it. Signed aboard The Rand Ecliptic last week.
+First mate Biggs Darklighter at your service...<sd>he salutes</sd>...I just
+came to say good-bye to all you unfortunate landlocked simpletons.
+		</sp>
+      <sd> Everyone laughs. The dazzling spectacle of his dashing
+	friend is almost too much for Luke, but suddenly he snaps out
+	of it.
+</sd>
+      <sp spk="LUKE"> I almost forgot. There's a battle going on! Right here in our
+system. Come and look!
+</sp>
+      <sp spk="DEAK"> Not again! Forget it.
+</sp>
+   </scene>
+   <scene n="15">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD -- SETTLEMENT -- POWER STATION -- DAY.
+	The group stumbles out into the stifling desert sun. Camie and
+	The Fixer complain and are forced to shade their eyes. Luke
+	has his binoculars out scanning the heavens.
+</sd>
+      <sp spk="LUKE"> There they are!
+		</sp>
+      <sd> Biggs takes the binoculars from Luke as the others strain
+	to see something with the naked eye. Through the binoculars
+	Biggs sees two small silver specks.
+</sd>
+      <sp spk="BIGGS"> That's no battle, hot shot...they're just sitting there!
+Probably a freighter-tanker refueling.
+</sp>
+      <sp spk="LUKE"> But there was a lot of firing earlier...
+		</sp>
+      <sd> Camie grabs the binoculars away banging them against the
+	building in the process. Luke grabs them.
+</sd>
+      <sp spk="LUKE"> Hey, easy with those...
+</sp>
+      <sp spk="CAMIE"> Don't worry about it, Wormie.
+		</sp>
+      <sd> The Fixer gives Luke a hard look and the young farm boy
+	shrugs his shoulders in resignation.
+</sd>
+      <sp spk="FIXER"> I keep telling you, the Rebellion is a long way from here. I
+doubt if the Empire would even fight to keep this system. Believe me
+Luke, this planet is a big hunk of nothing...
+		</sp>
+      <sd> Luke agrees, although it's obvious he isn't sure why. The
+	group stumbles back into the power station, grumbling about
+	Luke's ineptitude.
+</sd>
+   </scene>
+   <scene n="16">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- HALLWAY
+	Princess Leia is led down a low-ceilinged hallway by a squad
+	of armored stormtroopers. Her hands are bound and she is
+	brutally shoved when she is unable to keep up with the briskly
+	marching troops. They stop in a smoky hallway as Darth Vader
+	emerges from the shadows. The sinister Dark Lord stares hard
+	at the frail young senator, but she doesn't move.
+</sd>
+      <sp spk="LEIA"> Lord Vader, I should have known. Only you could be so bold. The
+Imperial Senate will not sit for this, when they hear you've attacked
+a diplomatic...
+</sp>
+      <sp spk="VADER"> Don't play games with me, Your Highness. You weren't on any
+mercy mission this time. You passed directly through a restricted
+system. Several transmissions were beamed to this ship by Rebel spies.
+I want to know what happened to the plans they sent you.
+</sp>
+      <sp spk="LEIA"> I don't know what you're talking about. I'm a member of the
+Imperial Senate on a diplomatic mission to Alderaan...
+</sp>
+      <sp spk="VADER"> You're a part of the Rebel Alliance...and a traitor. Take her
+away!
+		</sp>
+      <sd> Leia is marched away down the hallway and into the
+	smoldering hole blasted in the side of the ship. An Imperial
+	Commander turns to Vader.
+</sd>
+      <sp spk="COMMANDER"> Holding her is dangerous. If word of this gets out, it
+could generate sympathy for the Rebellion in the senate.
+</sp>
+      <sp spk="VADER"> I have traced the Rebel spies to her. Now she is my only link
+to find their secret base!
+</sp>
+      <sp spk="COMMANDER"> She'll die before she tells you anything.
+</sp>
+      <sp spk="VADER"> Leave that to me. Send a distress signal and then inform the
+senate that all aboard were killed!
+		</sp>
+      <sd> Another Imperial Officer approaches Vader and the
+	Commander. They stop and snap to attention.
+</sd>
+      <sp spk="SECOND OFFICER"> Lord Vader, the battle station plans are not aboard
+this ship! And no transmissions were made. An escape pod was
+jettisoned during the fighting, but no life forms were aboard.
+		</sp>
+      <sd> Vader turns to the Commander.
+</sd>
+      <sp spk="VADER"> She must have hidden the plans in the escape pod. Send a
+detachment down to retrieve them. See to it personally, Commander.
+There'll be no one to stop us this time.
+</sp>
+      <sp spk="COMMANDER"> Yes, sir.
+</sp>
+   </scene>
+   <scene n="17">
+      <sd>EXTERIOR: SPACE.
+	The Imperial Stardestroyer comes over the surface of the
+	planet Tatooine.
+</sd>
+   </scene>
+   <scene n="18">
+      <sd>EXTERIOR: TATOOINE -- DESERT.
+	Jundland, or "No Man's Land", where the rugged desert mesas
+	meet the foreboding dune sea. The two helpless astro-droids
+	kick up clouds of sand as they leave the lifepod and clumsily
+	work their way across the desert wasteland. The lifepod in the
+	distance rests half buried in the sand.
+</sd>
+      <sp spk="THREEPIO"> How did I get into this mess? I really don't know how. We
+seem to be made to suffer. It's our lot in life.
+		</sp>
+      <sd> Artoo answers with beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> I've got to rest before I fall apart. My joints are almost
+frozen. 
+		</sp>
+      <sd> Artoo continues to respond with beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> What a desolate place this is.
+		</sp>
+      <sd> Suddenly Artoo whistles, makes a sharp right turn and
+	starts off in the direction of the rocky desert mesas. Threepio
+	stops and yells at him.
+</sd>
+      <sp spk="THREEPIO"> Where are you going?
+		</sp>
+      <sd> A stream of electronic noises pours forth from the small
+	robot.
+</sd>
+      <sp spk="THREEPIO"> Well, I'm not going that way. It's much too rocky. This way
+is much easier.
+		</sp>
+      <sd> Artoo counters with a long whistle.
+</sd>
+      <sp spk="THREEPIO"> What makes you think there are settlements over there?
+		</sp>
+      <sd> Artoo continues to make beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> Don't get technical with me.
+		</sp>
+      <sd> Artoo continues to make beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> What mission? What are you talking about? I've had just
+about enough of you! Go that way! You'll be malfunctioning within a
+day, you nearsighted scrap pile!
+		</sp>
+      <sd> Threepio gives the little robot a kick and starts off in
+	the direction of the vast dune sea.
+</sd>
+      <sp spk="THREEPIO"> And don't let me catch you following me begging for help,
+because you won't get it.
+		</sp>
+      <sd> Artoo's reply is a rather rude sound. He turns and trudges
+	off in the direction of the towering mesas.
+</sd>
+      <sp spk="THREEPIO"> No more adventures. I'm not going that way.
+		</sp>
+      <sd> Artoo beeps to himself as he makes his way toward the
+	distant mountains.
+</sd>
+   </scene>
+   <scene n="19">
+      <sd>EXTERIOR: TATOOINE -- DUNE SEA.
+	Threepio, hot and tired, struggles up over the ridge of a dune;
+	only to find more dunes, which seem to go on for endless
+	miles.  He looks back in the direction of the now distant rock
+	mesas. 
+</sd>
+      <sp spk="THREEPIO"> That malfunctioning little twerp. This is all his fault! He
+tricked me into going this way, but he'll do no better.
+		</sp>
+      <sd> In a huff of anger and frustration, Threepio knocks the
+	sand from his joints. His plight seems hopeless, when a glint
+	of reflected light in the distance reveals an object moving
+	towards him.
+</sd>
+      <sp spk="THREEPIO"> Wait, what's that? A transport! I'm saved!
+		</sp>
+      <sd> The bronze android waves frantically and yells at the
+	approaching transport.
+</sd>
+      <sp spk="THREEPIO"> Over here! Help! Please, help!
+</sp>
+   </scene>
+   <scene n="20">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD SETTLEMENT -- POWER STATION -- DAY.
+	Luke and Biggs are walking and drinking a malt brew. Fixer and
+	the others can be heard working inside.
+</sd>
+      <sp spk="LUKE">
+         <sd>Very animated</sd>...so I cut off my power, shut down the
+afterburners and came in low on Deak's trail. I was so close I thought
+I was going to fry my instruments. As it was I busted up the Skyhopper
+pretty bad. Uncle Owen was pretty upset. He grounded me for the rest
+of the season. You should have been there...it was fantastic.
+</sp>
+      <sp spk="BIGGS"> You ought to take it easy Luke. You may be the hottest
+bushpilot this side of Mos Eisley, but those little Skyhoppers are
+dangerous. Keep it up, and one day, whammo, you're going to be nothing
+more than a dark spot on the down side of a canyon wall.
+</sp>
+      <sp spk="LUKE"> Look who's talking. Now that you've been around those giant
+starships you're beginning to sound like my uncle. You've gotten soft
+in the city...
+</sp>
+      <sp spk="BIGGS"> I've missed you kid.
+</sp>
+      <sp spk="LUKE"> Well, things haven't been the same since you left, Biggs. It's
+been so...quiet.
+		</sp>
+      <sd> Biggs looks around then leans close to Luke.
+</sd>
+      <sp spk="BIGGS"> Luke, I didn't come back just to say good-bye...I shouldn't
+tell you this, but you're the only one I can trust...and if I don't
+come back, I want somebody to know.
+		</sp>
+      <sd> Luke's eyes are wide with Biggs' seriousness and loyalty.
+</sd>
+      <sp spk="LUKE"> What are you talking about?
+</sp>
+      <sp spk="BIGGS"> I made some friends at the Academy. <sd>he whispers</sd>...when our
+frigate goes to one of the central systems, we're going to jump ship
+and join the Alliance...
+		</sp>
+      <sd> Luke, amazed and stunned, is almost speechless.
+</sd>
+      <sp spk="LUKE"> Join the Rebellion?! Are you kidding! How?
+</sp>
+      <sp spk="BIGGS"> Quiet down will ya! You got a mouth bigger than a meteor
+crater!
+</sp>
+      <sp spk="LUKE"> I'm sorry. I'm quiet. <sd>he whispers</sd> Listen how quiet I am. You
+can barely hear me...
+		</sp>
+      <sd> Biggs shakes his head angrily and then continues.
+</sd>
+      <sp spk="BIGGS"> My friend has a friend on Bestine who might help us make
+contact.
+</sp>
+      <sp spk="LUKE"> Your crazy! You could wander around forever trying to find them.
+</sp>
+      <sp spk="BIGGS"> I know it's a long shot, but if I don't find them I'll do what
+I can on my own...It's what we always talked about. Luke, I'm not
+going to wait for the Empire to draft me into service. The Rebellion
+is spreading and I want to be on the right side -- the side I believe
+in. 
+</sp>
+      <sp spk="LUKE"> And I'm stuck here...
+</sp>
+      <sp spk="BIGGS"> I thought you were going to the Academy next term. You'll get
+your chance to get off this rock.
+</sp>
+      <sp spk="LUKE"> Not likely! I had to cancel my application. There has been a lot
+of unrest among the Sandpeople since you left...they've even raided
+the outskirts of Anchorhead.
+</sp>
+      <sp spk="BIGGS"> Your uncle could hold off a whole colony of Sandpeople with one
+blaster.
+</sp>
+      <sp spk="LUKE"> I know, but he's got enough vaporators going to make the place
+pay off. He needs me for just one more season. I can't leave him now.
+</sp>
+      <sp spk="BIGGS"> I feel for you, Luke, you're going to have to learn what seems
+to be important or what really is important. What good is all your
+uncle's work if it's taken over by the Empire?...You know they're
+starting to nationalize commerce in the central systems...it won't be
+long before your uncle is merely a tenant, slaving for the greater
+glory of the Empire.
+</sp>
+      <sp spk="LUKE"> It couldn't happen here. You said it yourself. The Empire won't
+bother with this rock.
+</sp>
+      <sp spk="BIGGS"> Things always change.
+</sp>
+      <sp spk="LUKE"> I wish I was going...Are you going to be around long? 
+</sp>
+      <sp spk="BIGGS"> No, I'm leaving in the morning...
+</sp>
+      <sp spk="LUKE"> Then I guess I won't see you.
+</sp>
+      <sp spk="BIGGS"> Maybe someday...I'll keep a lookout.
+</sp>
+      <sp spk="LUKE"> Well, I'll be at the Academy next season...after that who knows.
+I won't be drafted into the Imperial Starfleet that's for sure...Take
+care of yourself, you'll always be the best friend I've got.
+</sp>
+      <sp spk="BIGGS"> So long, Luke.
+		</sp>
+      <sd> Biggs turns away from his old friend and heads towards the
+	power station.
+</sd>
+   </scene>
+   <scene n="21">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SUNSET.
+	The gargantuan rock formations are shrouded in a strange
+	foreboding mist and the onimous sounds of unearthly creatures
+	fill the air. Artoo moves cautiously through the creepy rock
+	canyon, inadvertently making a loud clicking noise as he goes.
+	He hears a distant, hard, metallic sound and stops for a
+	moment. Convinced he is alone, he continues on his way.
+		 In the distance, a pepple tumbles down the steep canyon
+	wall and a small dark figure darts into the shadows. A little
+	further up the canyon a slight flicker of light reveals a pair
+	of eyes in the dark recesses only a few feet from the narrow
+	path.
+		 The unsuspecting robot waddles along the rugged trail until
+	suddenly, out of nowhere, a powerful magnetic ray shoots out
+	of the rocks and engulfs him in an eerie glow. He manages one
+	short electronic squeak before he topples over onto his back.
+	His bright computer lights flicker off, then on, then off
+	again. Out of the rocks scurry three Jawas, no taller than
+	Artoo. They holster strange and complex weapons as they
+	cautiously approach the robot. They wear grubby cloaks and
+	their faces are shrouded so only their glowing eyes can be
+	seen. They hiss and make odd guttural sounds as they heave the
+	heavy robot onto their shoulders and carry him off down the
+	trail. 
+</sd>
+   </scene>
+   <scene n="22">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SANDCRAWLER -- SUNSET.
+	The eight Jawas carry Artoo out of the canyon to a huge
+	tank-like vehicle the size of a four-story house. They weld a
+	small disk on the side of Artoo and then put him under a large
+	tube on the side of the vehicle and the little robot is sucked
+	into the giant machine.
+		 The filthy little Jawas scurry like rats up small ladders
+	and enter the main cabin of the behemoth transport.
+</sd>
+   </scene>
+   <scene n="23">
+      <sd>INTERIOR: SANDCRAWLER -- HOLD AREA.
+	It is dim inside the hold area of the Sandcrawler. Artoo
+	switches on a small floodlight on his forehead and stumbles
+	around the scrap heap. The narrow beam swings across rusty
+	metal rocket parts and an array of grotesquely twisted and
+	maimed astro-robots. He lets out a pathetic electronic whimper
+	and stumbles off toward what appears to be a door at the end
+	of the chamber.
+</sd>
+   </scene>
+   <scene n="24">
+      <sd>INTERIOR: SANDCRAWLER -- PRISON AREA.
+	Artoo enters a wide room with a four-foot ceiling. In the
+	middle of the scrap heap sit a dozen or so robots of various
+	shapes and sizes. Some are engaged in electronic conversation,
+	while others simply mill about. A voice of recognition calls
+	out from the gloom.
+</sd>
+      <sp spk="THREEPIO"> Artoo-Detoo! It's you! It's you!
+		</sp>
+      <sd> A battered Threepio scrambles up to Artoo and embraces him.
+</sd>
+   </scene>
+   <scene n="25">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SANDCRAWLER -- SUNSET.
+	The enormous Sandcrawler lumbers off toward the magnificent
+	twin suns, which are slowly setting over a distant mountain
+	ridge.
+</sd>
+   </scene>
+   <scene n="26">
+      <sd>EXTERIOR: TATOOINE -- DESERT -- DAY.
+	Four Imperial stormtroopers mill about in front of the half-
+	buried lifepod that brought Artoo and Threepio to Tatooine. A
+	trooper yells to an officer some distance away.
+</sd>
+      <sp spk="FIRST TROOPER"> Someone was in the pod. The tracks go off in this
+direction. 
+		</sp>
+      <sd> A second trooper picks a small bit of metal out of the sand
+	and gives it to the first trooper.
+</sd>
+      <sp spk="SECOND TROOPER"> Look, sir -- droids.
+</sp>
+   </scene>
+   <scene n="27">
+      <sd>EXTERIOR: TATOOINE -- DUNES.
+	The Sandcrawler moves slowly down a great sand dune.
+</sd>
+   </scene>
+   <scene n="28">
+      <sd>INTERIOR: SANDCRAWLER.
+	Threepio and Artoo noisily bounce along inside the cramped
+	prison chamber. Artoo appears to be shut off.
+</sd>
+      <sp spk="THREEPIO"> Wake up! Wake up!
+		</sp>
+      <sd> Suddenly the shaking and bouncing of the Sandcrawler stops,
+	creating quite a commotion among the mechanical men.
+	Threepio's fist bangs the head of Artoo whose computer lights
+	pop on as he begins beeping. At the far end of the long
+	chamber a hatch opens, filling the chamber with blinding white
+	light. a dozen or so Jawas make their way through the odd
+	assortment of robots.
+</sd>
+      <sp spk="THREEPIO"> We're doomed.
+		</sp>
+      <sd> A Jawa starts moving toward them.
+</sd>
+      <sp spk="THREEPIO"> Do you think they'll melt us down?
+		</sp>
+      <sd> Artoo responds, making beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> Don't shoot! Don't shoot! Will this never end?
+</sp>
+   </scene>
+   <scene n="29">
+      <sd>EXTERIOR: TATOOINE -- DESERT -- LARS HOMESTEAD -- AFTERNOON.
+	The Jawas mutter gibberish as they busily line up their
+	battered captives, including Artoo and Threepio, in front of
+	the enormous Sandcrawler, which is parked beside a small
+	homestead consisting of three large holes in the ground
+	surrounded by several tall moisture vaporators and one small
+	adobe block house.
+		 The Jawas scurry around fussing over the robots,
+	straightening them up or brushing some dust from a dented
+	metallic elbow. The shrouded little creatures smell horribly,
+	attracting small insects to the dark areas when their mouths
+	and nostrils should be.
+		 Out of the shadows of a dingy side-building limps Owen
+	Lars, a large burly man in his mid-fifties. His reddish eyes
+	are sunken in a dust-covered face. As the farmer carefully
+	inspects each robot, he is closely followed by his slump-
+	shouldered nephew, Luke Skywalker. One of the vile little
+	Jawas walks ahead of the farmer spouting an animated sales
+	pitch in a queer, unintelligible language.
+		 A voice calls out from one of the huge holes that form the
+	homestead. Luke goes over to the edge and sees his Aunt Beru
+	standing in the main courtyard.
+</sd>
+      <sp spk="BERU"> Luke, tell Owen that if he gets a translator to be sure it
+speaks Bocce.
+</sp>
+      <sp spk="LUKE"> It looks like we don't have much of a choice but I'll remind
+him.
+		</sp>
+      <sd> Luke returns to his uncle as they look over the equipment
+	for sale with the Jawa leader.
+</sd>
+      <sp spk="OWEN"> I have no need for a protocol droid.
+</sp>
+      <sp spk="THREEPIO">
+         <sd>quickly</sd> Sir -- not in an environment such as this --
+that's why I've also been programmed for over thirty secondary
+functions that...
+</sp>
+      <sp spk="OWEN"> What I really need is a droid that understands the binary
+language of moisture vaporators.
+</sp>
+      <sp spk="THREEPIO"> Vaporators! Sir -- My first job was programming binary load
+lifter...very similar to your vaporators. You could say...
+</sp>
+      <sp spk="OWEN"> Do you speak Bocce?
+</sp>
+      <sp spk="THREEPIO"> Of course I can, sir. It's like a second language for
+me...I'm as fluent in Bocce...
+</sp>
+      <sp spk="OWEN"> All right shut up! <sd>turning to Jawa</sd> I'll take this one.
+</sp>
+      <sp spk="THREEPIO"> Shutting up, sir.
+</sp>
+      <sp spk="OWEN"> Luke, take these two over to the garage, will you? I want you to
+have both of them cleaned up before dinner.
+</sp>
+      <sp spk="LUKE"> But I was going into Toshi Station to pick up some power
+converters...
+</sp>
+      <sp spk="OWEN"> You can waste time with your friends when your chores are done.
+Now come on, get to it!
+</sp>
+      <sp spk="LUKE"> All right, come on! And the red one, come on. Well, come on,
+Red, let's go.
+		</sp>
+      <sd> As the Jawas start to lead the three remaining robots
+	back into the Sandcrawler, Artoo lets out a pathetic little
+	beep and starts after his old friend Threepio. He is
+	restrained by a slimy Jawa, who zaps him with a control box.
+</sd>
+      <sd> Owen is negotiating with the head Jawa. Luke and the two
+	robots start off for the garage when a plate pops off the head
+	of the red astro-droid's head plate and it sparks wildly.
+</sd>
+      <sp spk="LUKE"> Uncle Owen...
+</sp>
+      <sp spk="OWEN"> Yeah?
+</sp>
+      <sp spk="LUKE"> This R2 unit has a bad motivator. Look!
+</sp>
+      <sp spk="OWEN">
+         <sd>to the head Jawa</sd> Hey, what're you trying to push on us?
+		</sp>
+      <sd> The Jawa goes into a loud spiel. Meanwhile, Artoo has
+	sneaked out of line and is moving up and down trying to
+	attract attention. He lets out with a low whistle. Threepio
+	taps Luke on the shoulder.
+</sd>
+      <sp spk="THREEPIO">
+         <sd>pointing to Artoo</sd> Excuse me, sir, but that R2 unit is in
+prime condition. A real bargain.
+</sp>
+      <sp spk="LUKE"> Uncle Owen...
+</sp>
+      <sp spk="OWEN"> Yeah?
+</sp>
+      <sp spk="LUKE"> What about that one?
+</sp>
+      <sp spk="OWEN">
+         <sd>to Jawa</sd> What about that blue one? We'll take that one.
+		</sp>
+      <sd> With a little reluctance the scruffy dwarf trades the
+	damaged astro-droid for Artoo.
+</sd>
+      <sp spk="LUKE"> Yeah, take it away.
+</sp>
+      <sp spk="THREEPIO"> Uh, I'm quite sure you'll be very pleased with that one,
+sir. He really is in first-class condition. I've worked with him
+before. Here he comes.
+		</sp>
+      <sd> Owen pays off the whining Jawa as Luke and the two robots
+	trudge off toward a grimy homestead entry.
+</sd>
+      <sp spk="LUKE"> Okay, let's go.
+</sp>
+      <sp spk="THREEPIO">
+         <sd>to Artoo</sd> Now, don't you forget this! Why I should stick my
+neck out for you is quite beyond my capacity!
+</sp>
+   </scene>
+   <scene n="30">
+      <sd>INTERIOR: LARS HOMESTEAD -- GARAGE AREA -- LATE AFTERNOON.
+	The garage is cluttered and worn, but a friendly peaceful
+	atmosphere permeates the low grey chamber. Threepio lowers
+	himself into a large tub filled with warm oil. Near the
+	battered Landspeeder little Artoo rests on a large battery
+	with a cord to his face.
+</sd>
+      <sp spk="THREEPIO"> Thank the maker! This oil bath is going to feel so good.
+I've got such a bad case of dust contamination, I can barely move!
+		</sp>
+      <sd> Artoo beeps a muffled reply. Luke seems to be lost in
+	thought as he runs his hand over the damaged fin of a small
+	two-man Skyhopper spaceship resting in a low hangar off the
+	garage. Finally Luke's frustrations get the better of him and
+	he slams a wrench across the workbench.
+</sd>
+      <sp spk="LUKE"> It just isn't fair. Oh, Biggs is right. I'm never gonna get out
+of here!
+</sp>
+      <sp spk="THREEPIO"> Is there anything I might do to help? 
+		</sp>
+      <sd> Luke glances at the battered robot. A bit of his anger
+	drains and a tiny smile creeps across his face.
+</sd>
+      <sp spk="LUKE"> Well, not unless you can alter time, speed up the harvest, or
+teleport me off this rock!
+</sp>
+      <sp spk="THREEPIO"> I don't think so, sir. I'm only a droid and not very
+knowledgeable about such things. Not on this planet, anyways. As a
+matter of fact, I'm not even sure which planet I'm on.
+</sp>
+      <sp spk="LUKE"> Well, if there's a bright center to the universe, you're on the
+planet that it's farthest from.
+</sp>
+      <sp spk="THREEPIO"> I see, sir.
+</sp>
+      <sp spk="LUKE"> Uh, you can call me Luke.
+</sp>
+      <sp spk="THREEPIO"> I see, sir Luke.
+</sp>
+      <sp spk="LUKE">
+         <sd>laughing</sd> Just Luke.
+</sp>
+      <sp spk="THREEPIO"> And I am See-Threepio, human-cyborg relations, and this is
+my counterpart, Artoo-Detoo.
+</sp>
+      <sp spk="LUKE"> Hello.
+		</sp>
+      <sd> Artoo beeps in response. Luke unplugs Artoo and begins to
+	scrape several connectors on the robot's head with a chrome
+	pick. Threepio climbs out of the oil tub and begins wiping oil
+	from his bronze body.
+</sd>
+      <sp spk="LUKE"> You got a lot of carbon scoring here. It looks like you boys
+have seen a lot of action.
+</sp>
+      <sp spk="THREEPIO"> With all we've been through, sometimes I'm amazed we're in
+as good condition as we are, what with the Rebellion and all.
+</sp>
+      <sp spk="LUKE"> You know of the Rebellion against the Empire?
+</sp>
+      <sp spk="THREEPIO"> That's how we came to be in your service, if you take my
+meaning, sir.
+</sp>
+      <sp spk="LUKE"> Have you been in many battles?
+</sp>
+      <sp spk="THREEPIO"> Several, I think. Actually, there's not much to tell. I'm
+not much more than an interpreter, and not very good at telling
+stories. Well, not at making them interesting, anyways.
+		</sp>
+      <sd> Luke struggles to remove a small metal fragment from Artoo's
+	neck joint. He uses a larger pick.
+</sd>
+      <sp spk="LUKE"> Well, my little friend, you've got something jammed in here real
+good. Were you on a cruiser or...
+		</sp>
+      <sd> The fragment breaks loose with a snap, sending Luke
+	tumbling head over heels. He sits up and sees a twelve-inch
+	three-dimensional hologram of Leia Organa, the Rebel senator,
+	being projected from the face of little Artoo. The image is a
+	rainbow of colors as it flickers and jiggles in the dimly lit
+	garage. Luke's mouth hangs open in awe.
+</sd>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi. You're my only hope.
+</sp>
+      <sp spk="LUKE"> What's this?
+		</sp>
+      <sd> Artoo looks around and sheepishly beeps an answer for
+	Threepio to translate. Leia continues to repeat the sentence
+	fragment over and over.
+</sd>
+      <sp spk="THREEPIO"> What is what?!? He asked you a question...<sd>pointing to Leia</sd>
+What is that?
+		</sp>
+      <sd> Artoo whistles his surprise as he pretends to just notice
+	the hologram. He looks around and sheepishly beeps an answer
+	for Threepio to translate. Leia continues to repeat the
+	sentence fragment over and over.
+</sd>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi. You're my only hope. Help me, Obi-Wan
+Kenobi. You're my only hope.
+</sp>
+      <sp spk="THREEPIO"> Oh, he says it's nothing, sir. Merely a malfunction. Old
+data. Pay it no mind.
+		</sp>
+      <sd> Luke becomes intrigued by the beautiful girl.
+</sd>
+      <sp spk="LUKE"> Who is she? She's beautiful.
+</sp>
+      <sp spk="THREEPIO"> I'm afraid I'm not quite sure, sir.
+</sp>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi...
+</sp>
+      <sp spk="THREEPIO"> I think she was a passenger on our last voyage. A person of
+some importance, sir -- I believe. Our captain was attached to...
+</sp>
+      <sp spk="LUKE"> Is there more to this recording?
+		</sp>
+      <sd> Luke reaches out for Artoo but he lets out several frantic
+	squeaks and a whistle.
+</sd>
+      <sp spk="THREEPIO"> Behave yourself, Artoo. You're going to get us in trouble.
+It's all right, you can trust him. He's our new master.
+		</sp>
+      <sd> Artoo whistles and beeps a long message to Threepio.
+</sd>
+      <sp spk="THREEPIO"> He says he's the property of Obi-Wan Kenobi, a resident of
+these parts. And it's a private message for him. Quite frankly, sir I
+don't know what he's talking about. Our last master was Captain
+Antilles, but with what we've been through, this little R2 unit has
+become a bit eccentric.
+</sp>
+      <sp spk="LUKE"> Obi-Wan Kenobi? I wonder if he means old Ben Kenobi?
+</sp>
+      <sp spk="THREEPIO"> I beg your pardon, sir, but do you know what he's talking
+about?
+</sp>
+      <sp spk="LUKE"> Well, I don't know anyone named Obi-Wan, but old Ben lives out
+beyond the dune sea. He's kind of a strange old hermit.
+		</sp>
+      <sd> Luke's gazes at the beautiful young princess for a few
+	moments. 
+</sd>
+      <sp spk="LUKE"> I wonder who she is. It sounds like she's in trouble. I'd better
+play back the whole thing.
+		</sp>
+      <sd> Artoo beeps something to Threepio.
+</sd>
+      <sp spk="THREEPIO"> He says the restraining bolt has short circuited his
+recording system. He suggests that if you remove the bolt, he might be
+able to play back the entire recording.
+		</sp>
+      <sd> Luke looks longingly at the lovely, little princess and
+	hasn't really heard what Threepio has been saying.
+</sd>
+      <sp spk="LUKE"> H'm? Oh, yeah, well, I guess you're too small to run away on me
+if I take this off! Okay.
+		</sp>
+      <sd> Luke takes a wedged bar and pops the restraining bolt off
+	Artoo's side.
+</sd>
+      <sp spk="LUKE"> There you go.
+		</sp>
+      <sd> The princess immediately disappears...
+</sd>
+      <sp spk="LUKE"> Well, wait a minute. Where'd she go? Bring her back! Play back
+the entire message.
+		</sp>
+      <sd> Artoo beeps an innocent reply as Threepio sits up in
+	embarrassment.
+</sd>
+      <sp spk="THREEPIO"> What message? The one you're carrying inside your rusty
+innards! 
+		</sp>
+      <sd> A women's voice calls out from another room.
+</sd>
+      <sp spk="AUNT BERU"> Luke? Luke! Come to dinner!
+		</sp>
+      <sd> Luke stands up and shakes his head at the malfunctioning
+	robot.
+</sd>
+      <sp spk="LUKE"> All right, I'll be right there, Aunt Beru.
+</sp>
+      <sp spk="THREEPIO"> I'm sorry, sir, but he appears to have picked up a slight
+flutter.
+		</sp>
+      <sd> Luke tosses Artoo's restraining bolt on the workbench and
+	hurries out of the room.
+</sd>
+      <sp spk="LUKE"> Well, see what you can do with him. I'll be right back.
+</sp>
+      <sp spk="THREEPIO">
+         <sd>to Artoo</sd> Just you reconsider playing that message for him.
+		</sp>
+      <sd> Artoo beeps in response.
+</sd>
+      <sp spk="THREEPIO"> No, I don't think he likes you at all.
+		</sp>
+      <sd> Artoo beeps.
+</sd>
+      <sp spk="THREEPIO"> No, I don't like you either.
+</sp>
+   </scene>
+   <scene n="31">
+      <sd>INTERIOR: LARS HOMESTEAD -- DINING AREA.
+	 Luke's Aunt Beru, a warm, motherly woman, fills a pitcher
+	with blue fluid from a refrigerated container in the well-used
+	kitchen. She puts the pitcher on a tray with some bowls of
+	food and starts for the dining area.
+		 Luke sits with his Uncle Owen before a table covered with
+	steaming bowls of food as Aunt Beru carries in a bowl of red
+	grain.
+</sd>
+      <sp spk="LUKE"> You know, I think that R2 unit we bought might have been stolen.
+</sp>
+      <sp spk="OWEN"> What makes you think that?
+</sp>
+      <sp spk="LUKE"> Well, I stumbled across a recording while I was cleaning him. He
+says he belongs to someone called Obi-Wan Kenobi.
+		</sp>
+      <sd> Owen is greatly alarmed at the mention of his name, but
+	manages to control himself.
+</sd>
+      <sp spk="LUKE"> I thought he might have meant old Ben. Do you know what he's
+talking about? Well, I wonder if he's related to Ben.
+		</sp>
+      <sd> Owen breaks loose with a fit of uncontrolled anger.
+</sd>
+      <sp spk="OWEN"> That old man's just a crazy old wizard. Tomorrow I want you to
+take that R2 unit into Anchorhead and have its memory flushed. That'll
+be the end of it. It belongs to us now.
+</sp>
+      <sp spk="LUKE"> But what if this Obi-Wan comes looking for him?
+</sp>
+      <sp spk="OWEN"> He won't, I don't think he exists any more. He died about the
+same time as your father.
+</sp>
+      <sp spk="LUKE"> He knew my father?
+</sp>
+      <sp spk="OWEN"> I told you to forget it. Your only concern is to prepare the new
+droids for tomorrow. In the morning I want them on the south ridge
+working out those condensers.
+</sp>
+      <sp spk="LUKE"> Yes, sir. I think those new droids are going to work out fine.
+In fact, I, uh, was also thinking about our agreement about my staying
+on another season. And if these new droids do work out, I want to
+transmit my application to the Academy this year.
+		</sp>
+      <sd> Owen's face becomes a scowl, although he tries to suppress
+	it.
+</sd>
+      <sp spk="OWEN"> You mean the next semester before harvest?
+</sp>
+      <sp spk="LUKE"> Sure, there're more than enough droids.
+</sp>
+      <sp spk="OWEN"> Harvest is when I need you the most. Only one more season. This
+year we'll make enough on the harvest so I'll be able to hire some
+more hands. And then you can go to the Academy next year.
+		</sp>
+      <sd> Luke continues to toy with his food, not looking at his
+	uncle.
+</sd>
+      <sp spk="OWEN"> You must understand I need you here, Luke.
+</sp>
+      <sp spk="LUKE"> But it's a whole 'nother year.
+</sp>
+      <sp spk="OWEN"> Look, it's only one more season.
+		</sp>
+      <sd> Luke pushes his half-eaten plate of food aside and stands.
+</sd>
+      <sp spk="LUKE"> Yeah, that's what you said last year when Biggs and Tank left.
+</sp>
+      <sp spk="AUNT BERU"> Where are you going?
+</sp>
+      <sp spk="LUKE"> It looks like I'm going nowhere. I have to finish cleaning those
+droids.
+		</sp>
+      <sd> Resigned to his fate, Luke paddles out of the room. Owen
+	mechanically finishes his dinner.
+</sd>
+      <sp spk="AUNT BERU"> Owen, he can't stay here forever. Most of his friends have
+gone. It means so much to him.
+</sp>
+      <sp spk="OWEN"> I'll make it up to him next year. I promise.
+</sp>
+      <sp spk="AUNT BERU"> Luke's just not a farmer, Owen. He has too much of his
+father in him.
+</sp>
+      <sp spk="OWEN"> That's what I'm afraid of.
+</sp>
+   </scene>
+   <scene n="32">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	The giant twin suns of Tatooine slowly disappear behind a
+	distant dune range. Luke stands watching them for a few
+	moments, then reluctantly enters the doomed entrance to the
+	homestead.
+</sd>
+   </scene>
+   <scene n="33">
+      <sd>INTERIOR: LARS HOMESTEAD -- GARAGE.
+		 Luke enters the garage to discover the robots nowhere in
+	sight. He takes a small control box from his utility belt
+	similar to the one the Jawas were carrying. He activates the
+	box, which creates a low hum, and Threepio, letting out a
+	short yell, pops up from behind the Skyhopper spaceship.
+</sd>
+      <sp spk="LUKE"> What are you doing hiding there?
+		</sp>
+      <sd> Threepio stumbles forward, but Artoo is still nowhere in
+	sight. 
+</sd>
+      <sp spk="THREEPIO"> It wasn't my fault, sir. Please don't deactivate me. I told
+him not to go, but he's faulty, malfunctioning; kept babbling on about
+his mission.
+</sp>
+      <sp spk="LUKE"> Oh, no!</sp>
+      <sd>Luke races out of the garage followed by Threepio.
+</sd>
+   </scene>
+   <scene n="34">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	Luke rushes out of the small doomed entry to the homestead and
+	searches the darkening horizon for the small triped astro-
+	robot. Threepio struggles out of the homestead and on the salt
+	flat as Luke scans the landscape with his electrobinoculars.
+</sd>
+      <sp spk="THREEPIO"> That R2 unit has always been a problem. These astro-droids
+are getting quite out of hand. Even I can't understand their logic at
+times. 
+</sp>
+      <sp spk="LUKE"> How could I be so stupid? He's nowhere in sight. Blast it!
+</sp>
+      <sp spk="THREEPIO"> Pardon me, sir, but couldn't we go after him?
+</sp>
+      <sp spk="LUKE"> It's too dangerous with all the Sandpeople around. We'll have to
+wait until morning.
+		</sp>
+      <sd> Owen yells up from the homestead plaza.
+</sd>
+      <sp spk="OWEN"> Luke, I'm shutting the power down for the night.
+</sp>
+      <sp spk="LUKE"> All right, I'll be there in a few minutes. Boy, am I gonna get it.</sp>
+      <sd>He takes one final look across the dim horizon.
+</sd>
+      <sp spk="LUKE"> You know that little droid is going to cause me a lot of
+trouble.
+</sp>
+      <sp spk="THREEPIO"> Oh, he excels at that, sir.
+</sp>
+   </scene>
+   <scene n="35">
+      <sd>INTERIOR: LARS HOMESTEAD -- PLAZA.
+	Morning slowly creeps into the sparse but sparkling oasis of
+	the open courtyard. The idyll is broken be the yelling of
+	Uncle Owen, his voice echoing throughout the homestead.
+</sd>
+      <sp spk="OWEN"> Luke? Luke? Luke? Where could he be loafing now!
+</sp>
+   </scene>
+   <scene n="36">
+      <sd>INTERIOR: LARS HOMESTEAD -- KITCHEN.
+	The interior of the kitchen is a worm glow as Aunt Beru prepares
+	the morning breakfast. Owen enters in a huff.
+</sd>
+      <sp spk="OWEN"> Have you seen Luke this morning?
+</sp>
+      <sp spk="AUNT BERU"> He said he had some things to do before he started today,
+so he left early.
+</sp>
+      <sp spk="OWEN"> Uh? Did he take those two new droids with him?
+</sp>
+      <sp spk="AUNT BERU"> I think so.
+</sp>
+      <sp spk="OWEN"> Well, he'd better have those units in the south range repaired
+be midday or there'll be hell to pay!
+</sp>
+   </scene>
+   <scene n="37">
+      <sd>EXTERIOR: TATOOINE -- DESERT WASTELAND -- LUKE'S SPEEDER -- DAY.
+	The rock and sand of the desert floor are a blur as Threepio
+	pilots the sleek Landspeeder gracefully across the vast
+	wasteland. 
+</sd>
+      <sd>INTERIOR/EXTERIOR: LUKE'S SPEEDER -- DESERT WASTELAND -- TRAVELING -- DAY.
+	Luke leans over the back of the speeder and adjusts something
+	in the motor compartment.
+</sd>
+      <sp spk="LUKE">
+         <sd>yelling</sd> How's that.
+		</sp>
+      <sd> Threepio signals that is fine and Luke turns back into the
+	wind-whipped cockpit and pops the canopy shut.
+</sd>
+      <sp spk="LUKE"> Old Ben Kenobi lives out in this direction somewhere, but I
+don't see how that R2 unit could have come this far. We must have
+missed him. Uncle Owen isn't going to take this very well.
+</sp>
+      <sp spk="THREEPIO"> Sir, would it help if you told him it was my fault.
+</sp>
+      <sp spk="LUKE">
+         <sd>brightening</sd> Sure. He needs you. He'd probably only deactivate
+you for a day or so...
+</sp>
+      <sp spk="THREEPIO"> Deactivate! Well, on the other hand if you hadn't removed
+his restraining bolt...
+</sp>
+      <sp spk="LUKE"> Wait, there's something dead ahead on the scanner. It looks like
+our droid...hit the accelerator.
+</sp>
+   </scene>
+   <scene n="38">
+      <sd>EXTERIOR: TATOOINE -- ROCK MESA -- DUNE SEA -- COASTLINE -- DAY.
+	From high on a rock mesa, the tiny Landspeeder can be seen
+	gliding across the desert floor. Suddenly in the foreground
+	two weather-beaten Sandpeople shrouded in their grimy desert
+	cloaks peer over the edge of the rock mesa. One of the
+	marginally human creatures raises a long ominous laser rifle
+	and points it at the speeder but the second creature grabs the
+	gun before it can be fired.
+		 The Sandpeople, or Tusken Raiders as they're sometimes
+	called, speak in a coarse barbaric language as they get into
+	an animated argument. The second Tusken Raider seems to get in
+	the final word and the nomads scurry over the rocky terrain.
+</sd>
+   </scene>
+   <scene n="39">
+      <sd>EXTERIOR: TATOOINE -- ROCK MESA -- CANYON.
+	The Tusken Raider approaches two large Banthas standing tied
+	to a rock. The monstrous, bear-like creatures are as large as
+	elephants, with huge red eyes, tremendous looped horns, and
+	long, furry, dinosaur-like tails. The Tusken Raiders mount
+	saddles strapped to the huge creatures' shaggy backs and ride
+	off down the rugged bluff.
+</sd>
+   </scene>
+   <scene n="40">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- FLOOR.
+	The speeder is parked on the floor of a massive canyon. Luke,
+	with his long laser rifle slung over his shoulder, stands
+	before little Artoo.
+</sd>
+      <sp spk="LUKE"> Hey, whoa, just where do you think you're going?
+		</sp>
+      <sd> The little droid whistles a feeble reply, as Threepio poses
+	menacingly behind the little runaway.
+</sd>
+      <sp spk="THREEPIO"> Master Luke here is your rightful owner. We'll have no more
+of this Obi-Wan Kenobi jibberish...and don't talk to me about your
+mission, either. You're fortunate he doesn't blast you into a million
+pieces right here.
+</sp>
+      <sp spk="LUKE"> Well, come on. It's getting late. I only hope we can get back
+before Uncle Owen really blows up.
+</sp>
+      <sp spk="THREEPIO"> If you don't mind my saying so, sir, I think you should
+deactivate the little fugitive until you've gotten him back to your
+workshop.
+</sp>
+      <sp spk="LUKE"> No, he's not going to try anything.
+		</sp>
+      <sd> Suddenly the little robot jumps to life with a mass of
+	frantic whistles and screams.
+</sd>
+      <sp spk="LUKE"> What's wrong with him now?
+</sp>
+      <sp spk="THREEPIO"> Oh my...sir, he says there are several creatures approaching
+from the southeast.
+		</sp>
+      <sd> Luke swings his rifle into position and looks to the south.
+</sd>
+      <sp spk="LUKE"> Sandpeople! Or worst! Come on, let's have a look. Come on.
+</sp>
+   </scene>
+   <scene n="41">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- RIDGE -- DAY.
+	Luke carefully makes his way to the top of a rock ridge and
+	scans the canyon with his electrobinoculars. He spots the two
+	riderless Banthas. Threepio struggles up behind the young
+	adventurer.
+</sd>
+      <sp spk="LUKE"> There are two Banthas down there but I don't see any...wait a
+second, they're Sandpeople all right. I can see one of them now.
+		</sp>
+      <sd> Luke watches the distant Tusken Raider through his
+	electrobinoculars. Suddenly something huge moves in front of
+	his field of view. Before Luke or Threepio can react, a large,
+	gruesome Tusken Raider looms over them. Threepio is startled
+	and backs away, right off the side if the cliff. He can be
+	heard for several moments as he clangs, bangs and rattles down
+	the side of the mountain.
+</sd>
+      <sd> The towering creature brings down his curved,
+	double-pointed gaderffii -- the dreaded axe blade that has
+	struck terror in the heart of the local settlers. But Luke
+	manages to block the blow with his laser rifle, which is
+	smashed to pieces. The terrified farm boy scrambles backward
+	until he is forced to the edge of a deep crevice. The sinister
+	Raider stands over him with his weapon raised and lets out a
+	horrible shrieking laugh.
+</sd>
+   </scene>
+   <scene n="42">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- FLOOR -- DAY.
+	Artoo forces himself into the shadows of a small alcove in the
+	rocks as the vicious Sandpeople walk past carrying the inert
+	Luke Skywalker, who is dropped in a heap before the speeder.
+	The Sandpeople ransack the speeder, throwing parts and
+	supplies in all directions. Suddenly they stop. Then
+	everything is quiet for a few moments. A great howling moan is
+	heard echoing throughout the canyon which sends the Sandpeople
+	fleeing in terror.
+		 Artoo moves even tighter into the shadows as the slight
+	swishing sound that frightened off the Sandpeople grows even
+	closer, until a shabby old desert-rat-of-a-man appears and
+	leans over Luke. His ancient leathery face, cracked and
+	weathered by exotic climates is set off by dark, penetrating
+	eyes and a scraggly white beard. Ben Kenobi squints his eyes
+	as he scrutinizes the unconscious farm boy. Artoo makes a
+	slight sound and Ben turns and looks right at him.
+</sd>
+      <sp spk="BEN"> Hello there! Come here my little friend. Don't be afraid.</sp>
+      <sd>Artoo waddles over to were Luke lies crumpled in a 
+	heap and begins to whistle and beep his concern. Ben
+	puts his hand on Luke's forehead and he begins to 
+	come around.
+</sd>
+      <sp spk="BEN"> Don't worry, he'll be all right.
+</sp>
+      <sp spk="LUKE"> What happened?
+</sp>
+      <sp spk="BEN"> Rest easy, son, you've had a busy day. You're fortunate you're
+still in one piece.
+</sp>
+      <sp spk="LUKE"> Ben? Ben Kenobi! Boy, am I glad to see you! 
+</sp>
+      <sp spk="BEN"> The Jundland wastes are not to be traveled lightly. Tell me young
+Luke, what brings you out this far?
+</sp>
+      <sp spk="LUKE"> Oh, this little droid! I think he's searching for his former
+master...I've never seen such devotion in a droid before...there
+seems to be no stopping him. He claims to be the property of an Obi-
+Wan Kenobi. Is he a relative of yours? Do you know who he's talking 
+about?</sp>
+      <sd>Ben ponders this for a moment, scratching his scruffy beard.
+</sd>
+      <sp spk="BEN"> Obi-Wan Kenobi...Obi-Wan? Now thats a name I haven't heard in a 
+long time...a long time.
+</sp>
+      <sp spk="LUKE"> I think my uncle knew him. He said he was dead.
+</sp>
+      <sp spk="BEN"> Oh, he's not dead, not...not yet.
+</sp>
+      <sp spk="LUKE"> You know him!
+</sp>
+      <sp spk="BEN"> Well of course, of course I know him. He's me! I haven't gone by
+the name Obi-Wan since oh, before you were born.
+</sp>
+      <sp spk="LUKE"> Then the droid does belong to you.
+</sp>
+      <sp spk="BEN"> Don't seem to remember ever owning a droid. Very interesting...</sp>
+      <sd>He suddenly looks up at the overhanging cliffs.
+</sd>
+      <sp spk="BEN"> I think we better get indoors. The Sandpeople are easily startled
+but they will soon be back and in greater numbers.</sp>
+      <sd>Luke sits up and rubs his head. Artoo lets out a pathetic
+	beep causing Luke to remember something. He looks around.
+</sd>
+      <sp spk="LUKE"> Threepio!
+</sp>
+   </scene>
+   <scene n="43">
+      <sd>EXTERIOR: TATOOINE -- SAND PIT -- ROCK MESA -- DAY.
+	Little Artoo stands at the edge of a large sand pit and begins
+	to chatter away in electronic whistles and beeps. Luke and Ben
+	stand over a very dented and tangled Threepio lying half
+	buried in the sand. One of his arms has broken off.
+		 Luke tries to revive the inert robot by shaking him and
+	then flips a hidden switch on his back several times until
+	finally the mechanical man's systems turn on.
+</sd>
+      <sp spk="THREEPIO"> Where am I? I must have taken a bad step...
+</sp>
+      <sp spk="LUKE"> Can you stand? We've got to get out of here before the
+Sandpeople return.
+</sp>
+      <sp spk="THREEPIO"> I don't think I can make it. You go on, Master Luke. There's
+no sense in you risking yourself on my account. I'm done for.
+	
+		</sp>
+      <sd> Artoo makes a beeping sound.
+</sd>
+      <sp spk="LUKE"> No, you're not. What kind of talk is that?
+		</sp>
+      <sd> Luke and Ben help the battered robot to his feet. Little
+	Artoo watches from the top of the pit. Ben glances around
+	suspiciously. Sensing something, he stands up and sniffs the
+	air.
+</sd>
+      <sp spk="BEN"> Quickly, son...they're on the move.
+</sp>
+   </scene>
+   <scene n="44">
+      <sd>INTERIOR: KENOBI'S DWELLING.
+	The small, spartan hovel is cluttered with desert junk but
+	still manages to radiate an air of time-worn comfort and
+	security. Luke is in one corner repairing Threepio's arm, as
+	old Ben sits thinking.
+</sd>
+      <sp spk="LUKE"> No, my father didn't fight in the wars. He was a navigator on a
+spice freighter.
+</sp>
+      <sp spk="BEN"> That's what your uncle told you. He didn't hold with your
+father's ideals. Thought he should have stayed here and not gotten
+involved.
+</sp>
+      <sp spk="LUKE"> You fought in the Clone Wars?
+</sp>
+      <sp spk="BEN"> Yes, I was once a Jedi Knight the same as your father.
+</sp>
+      <sp spk="LUKE"> I wish I'd known him.
+</sp>
+      <sp spk="BEN"> He was the best star-pilot in the galaxy, and a cunning warrior.
+I understand you've become quite a good pilot yourself. And he was a
+good friend. Which reminds me...
+		</sp>
+      <sd> Ben gets up and goes to a chest where he rummages around.
+	As Luke finishes repairing Threepio and starts to fit the
+	restraining bolt back on, Threepio looks at him nervously.
+	Luke thinks about the bolt for a moment then puts it on the
+	table. Ben shuffles up and presents Luke with a short handle
+	with several electronic gadgets attached to it.
+</sd>
+      <sp spk="BEN"> I have something here for you. Your father wanted you to have
+this when you were old enough, but your uncle wouldn't allow it. He
+feared you might follow old Obi-Wan on some damned-fool idealistic
+crusade like your father did. 
+</sp>
+      <sp spk="THREEPIO"> Sir, if you'll not be needing me, I'll close down for
+awhile.
+</sp>
+      <sp spk="LUKE"> Sure, go ahead.
+		</sp>
+      <sd> Ben hands Luke the saber.
+</sd>
+      <sp spk="LUKE"> What is it?
+</sp>
+      <sp spk="BEN"> Your fathers lightsaber. This is the weapon of a Jedi Knight. Not
+as clumsy or as random as a blaster.
+		</sp>
+      <sd>	 
+		 Luke pushes a button on the handle. A long beam shoots out
+	about four feet and flickers there. The light plays across the
+	ceiling.</sd>
+      <sp spk="BEN"> An elegant weapon for a more civilized time. For over a thousand
+generations the Jedi Knights were the guardians of peace and justice
+in the Old Republic. Before the dark times, before the Empire.
+		</sp>
+      <sd> Luke hasn't really been listening.
+</sd>
+      <sp spk="LUKE"> How did my father die?
+</sp>
+      <sp spk="BEN"> A young Jedi named Darth Vader, who was a pupil of mine until he
+turned to evil, helped the Empire hunt down and destroy the Jedi
+Knights. He betrayed and murdered your father. Now the Jedi are all
+but extinct. Vader was seduced by the dark side of the Force.
+</sp>
+      <sp spk="LUKE"> The Force?
+</sp>
+      <sp spk="BEN"> Well, the Force is what gives a Jedi his power. It's an energy
+field created by all living things. It surrounds us and penetrates us.
+It binds the galaxy together.
+		</sp>
+      <sd> Artoo makes beeping sounds.
+</sd>
+      <sp spk="BEN"> Now, let's see if we can't figure out what you are, my little
+friend. And where you come from.
+</sp>
+      <sp spk="LUKE"> I saw part of the message he was...
+		</sp>
+      <sd> Luke is cut short as the recorded image of the beautiful
+	young Rebel princess is projected from Artoo's face.
+</sd>
+      <sp spk="BEN"> I seem to have found it.
+		</sp>
+      <sd> Luke stops his work as the lovely girl's image flickers
+	before his eyes.
+</sd>
+      <sp spk="LEIA"> General Kenobi, years ago you served my father in the Clone
+Wars. Now he begs you to help him in his struggle against the Empire.
+I regret that I am unable to present my father's request to you in
+person, but my ship has fallen under attack and I'm afraid my mission
+to bring you to Alderaan has failed. I have placed information vital
+to the survival of the Rebellion into the memory systems of this R2
+unit. My father will know how to retrieve it. You must see this droid
+safely delivered to him on Alderaan. This is our most desperate hour.
+Help me, Obi-Wan Kenobi, you're my only hope.</sp>
+      <sd>There is a little static and the transmission is cut short.
+	Old Ben leans back and scratches his head. He silently puffs
+	on a tarnished chrome water pipe. Luke has stars in his eyes.
+</sd>
+      <sp spk="BEN"> You must learn the ways of the Force if you're to come with me to
+Alderaan.
+</sp>
+      <sp spk="LUKE">
+         <sd>laughing</sd> Alderaan? I'm not going to Alderaan. I've got to go
+home. It's late, I'm in for it as it is.
+</sp>
+      <sp spk="BEN"> I need your help, Luke. She needs your help. I'm getting too old
+for this sort of thing.
+</sp>
+      <sp spk="LUKE"> I can't get involved! I've got work to do! It's not that I like
+the Empire. I hate it! But there's nothing I can do about it right
+now. It's such a long way from here.
+</sp>
+      <sp spk="BEN"> That's your uncle talking.
+</sp>
+      <sp spk="LUKE">
+         <sd>sighing</sd> Oh, God, my uncle. How am I ever going to explain
+this?
+</sp>
+      <sp spk="BEN"> Learn about the Force, Luke.
+</sp>
+      <sp spk="LUKE"> Look, I can take you as far as Anchorhead. You can get a
+transport there to Mos Eisley or wherever you're going.
+</sp>
+      <sp spk="BEN"> You must do what you feel is right, of course.
+</sp>
+   </scene>
+   <scene n="45">
+      <sd>EXTERIOR: SPACE.
+	An Imperial Stardestroyer heads toward the evil planet-like
+	battle station: the Death Star!
+</sd>
+   </scene>
+   <scene n="46">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Eight Imperial senators and generals sit around a black
+	conference table. Imperial stormtroopers stand guard around
+	the room. Commander Tagge, a young, slimy-looking general, is
+	speaking.
+</sd>
+      <sp spk="TAGGE"> Until this battle station is fully operational we are
+vulnerable. The Rebel Alliance is too well equipped. They're more
+dangerous than you realize.
+		</sp>
+      <sd> The bitter Admiral Motti twists nervously in his chair.
+</sd>
+      <sp spk="MOTTI"> Dangerous to your starfleet, Commander, not to this battle
+station!
+</sp>
+      <sp spk="TAGGE"> The Rebellion will continue to gain a support in the Imperial
+Senate as long as....
+		</sp>
+      <sd> Suddenly all heads turn as Commander Tagge's speech is cut
+	short and the Grand Moff Tarkin, governor of the Imperial
+	outland regions, enters. He is followed by his powerful ally,
+	The Sith Lord, Darth Vader. All of the generals stand and bow
+	before the thin, evil-looking governor as he takes his place
+	at the head of the table. The Dark Lord stands behind him.
+</sd>
+      <sp spk="TARKIN"> The Imperial Senate will no longer be of any concern to us.
+I've just received word that the Emperor has dissolved the council
+permanently. The last remnants of the Old Republic have been swept
+away.
+</sp>
+      <sp spk="TAGGE"> That's impossible! How will the Emperor maintain control
+without the bureaucracy?
+</sp>
+      <sp spk="TARKIN"> The regional governors now have direct control over
+territories. Fear will keep the local systems in line. Fear of this
+battle station.
+</sp>
+      <sp spk="TAGGE"> And what of the Rebellion? If the Rebels have obtained a
+complete technical readout of this station, it is possible, however
+unlikely, that they might find a weakness and exploit it.
+</sp>
+      <sp spk="VADER"> The plans you refer to will soon be back in our hands.
+</sp>
+      <sp spk="MOTTI"> Any attack made by the Rebels against this station would be a
+useless gesture, no matter what technical data they've obtained. This
+station is now the ultimate power in the universe. I suggest we use
+it!
+</sp>
+      <sp spk="VADER"> Don't be too proud of this technological terror you've
+constructed. The ability to destroy a planet is insignificant next to
+the power of the Force.
+</sp>
+      <sp spk="MOTTI"> Don't try to frighten us with your sorcerer's ways, Lord Vader.
+Your sad devotion to that ancient religion has not helped you conjure
+up the stolen data tapes, or given you clairvoyance enough to find the
+Rebel's hidden fort...
+		</sp>
+      <sd> Suddenly Motti chokes and starts to turn blue under Vader's
+	spell.
+</sd>
+      <sp spk="VADER"> I find your lack of faith disturbing.
+</sp>
+      <sp spk="TARKIN"> Enough of this! Vader, release him!
+</sp>
+      <sp spk="VADER"> As you wish.
+</sp>
+      <sp spk="TARKIN"> This bickering is pointless. Lord Vader will provide us with
+the location of the Rebel fortress by the time this station is
+operational. We will then crush the Rebellion with one swift stroke.
+</sp>
+   </scene>
+   <scene n="47">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	The speeder stops before what remains of the huge Jawas
+	Sandcrawler. Luke and Ben walk among the smoldering rubble
+	and scattered bodies.
+</sd>
+      <sp spk="LUKE"> It looks like Sandpeople did this, all right. Look, here are
+Gaffi sticks, Bantha tracks. It's just...I never heard of them hitting
+anything this big before.
+		</sp>
+      <sd> Ben is crouching in the sand studying the tracks.
+</sd>
+      <sp spk="BEN"> They didn't. But we are meant to think they did. These tracks are
+side by side. Sandpeople always ride single file to hide there numbers.
+</sp>
+      <sp spk="LUKE"> These are the same Jawas that sold us Artoo and Threepio.
+</sp>
+      <sp spk="BEN"> And these blast points, too accurate for Sandpeople. Only
+Imperial stormtroopers are so precise.
+</sp>
+      <sp spk="LUKE"> Why would Imperial troops want to slaughter Jawas?
+		</sp>
+      <sd> Luke looks back at the speeder where Artoo and Threepio are
+	inspecting the dead Jawas, and put two and two together.
+</sd>
+      <sp spk="LUKE"> If they traced the robots here, they may have learned who they
+sold them to. And that would lead them home!
+		</sp>
+      <sd> Luke reaches a sudden horrible realization, then races for
+	the speeder and jumps it.
+</sd>
+      <sp spk="BEN"> Wait, Luke! It's too dangerous.
+		</sp>
+      <sd> Luke races off leaving Ben and the two robots alone with
+	the burning Sandcrawler.
+</sd>
+   </scene>
+   <scene n="48">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	Luke races across the wasteland in his battered Landspeeder.
+</sd>
+   </scene>
+   <scene n="49">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	The speeder roars up to the burning homestead. Luke jumps out
+	and runs to the smoking holes that were once his home. Debris
+	is scattered everywhere and it looks as if a great battle has
+	taken place.
+</sd>
+      <sp spk="LUKE"> Uncle Owen! Aunt Beru! Uncle Owen!
+		</sp>
+      <sd> Luke stumbles around in a daze looking for his aunt and
+	uncle. Suddenly he comes upon their smoldering remains. He is
+	stunned, and cannot speak. Hate replaces fear and a new
+	resolve comes over him.
+</sd>
+   </scene>
+   <scene n="50">
+      <sd>EXTERIOR: SPACE.
+	Imperial TIE fighter races toward the Death Star.
+</sd>
+   </scene>
+   <scene n="51">
+      <sd>INTERIOR: DEATH STAR -- DETENTION CORRIDOR.
+	Two stormtroopers open an electronic cell door and allow
+	several Imperial guards to enter. Princess Leia's face is
+	filled with defiance, which slowly gives way to fear as a
+	giant black torture robot enters, followed by Darth Vader.
+</sd>
+      <sp spk="VADER"> And, now Your Highness, we will discuss the location of your
+hidden Rebel base.
+		</sp>
+      <sd> The torture robot gives off a steady beeping sound as it
+	approaches Princess Leia and extends one of its mechanical
+	arms bearing a large hypodermic needle. The door slides shut
+	and the long cell block hallway appears peaceful. The muffled
+	screams of the Rebel princess are barely heard.
+</sd>
+   </scene>
+   <scene n="52">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	There is a large bonfire of Jawa bodies blazing in front of
+	the Sandcrawler as Ben and the robots finish burning the dead.
+	Luke drives up in the speeder and Ben walks over to him.
+</sd>
+      <sp spk="BEN"> There's nothing you could have done, Luke, had you been there.
+You'd have been killed, too, and the droids would be in the hands of
+the Empire.
+</sp>
+      <sp spk="LUKE"> I want to come with you to Alderaan. There's nothing here for me
+now. I want to learn the ways of the Force and become a Jedi like my
+father.
+</sp>
+   </scene>
+   <scene n="53">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	The Landspeeder with Luke, Artoo, Threepio, and Ben in it
+	zooms across the desert. The speeder stops on a bluff
+	overlooking the spaceport at Mos Eisley. It is a haphazard
+	array of low, grey, concrete structures and semi-domes. A
+	harsh gale blows across the stark canyon floor. Luke adjusts
+	his goggles and walks to the edge of the craggy bluff where
+	Ben is standing.
+</sd>
+      <sp spk="BEN"> Mos Eisley Spaceport. You will never find a more wretched hive of
+scum and villainy. We must be cautious.
+		</sp>
+      <sd> Ben looks over at Luke, who gives the old Jedi a determined
+	smile.
+</sd>
+   </scene>
+   <scene n="54">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	The speeder is stopped on a crowded street by several
+	combat-hardend stormtroopers who look over the two robots. A
+	Trooper questions Luke.
+</sd>
+      <sp spk="TROOPER"> How long have you had these droids?
+</sp>
+      <sp spk="LUKE"> About three or four seasons.
+</sp>
+      <sp spk="BEN"> They're for sale if you want them.
+</sp>
+      <sp spk="TROOPER"> Let me see your identification.
+		</sp>
+      <sd> Luke becomes very nervous as he fumbles to find his ID
+	while Ben speaks to the Trooper in a very controlled voice.
+</sd>
+      <sp spk="BEN"> You don't need to see his identification.
+</sp>
+      <sp spk="TROOPER"> We don't need to see his identification.
+</sp>
+      <sp spk="BEN"> These are not the droids your looking for.
+</sp>
+      <sp spk="TROOPER"> These are not the droids we're looking for.
+</sp>
+      <sp spk="BEN"> He can go about his business.
+</sp>
+      <sp spk="TROOPER"> You can go about your business.
+</sp>
+      <sp spk="BEN">
+         <sd>to Luke</sd> Move along.
+</sp>
+      <sp spk="TROOPER"> Move along. Move along.
+</sp>
+   </scene>
+   <scene n="55">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	The speeder pulls up in front of a rundown blockhouse cantina
+	on the outskirts of the spaceport. Various strange forms of
+	transport, including several unusual beasts of burden, are
+	parked outside the bar. A Jawa runs up and begins to fondle
+	the speeder.
+</sd>
+      <sp spk="THREEPIO"> I can't abide these Jawas. Disgusting creatures.
+		</sp>
+      <sd> As Luke gets out of the speeder he tries to shoo the Jawa
+	away.
+	 
+</sd>
+      <sp spk="LUKE"> Go on, go on. I can't understand how we got by those troopers. I
+thought we were dead.
+</sp>
+      <sp spk="BEN"> The Force can have a strong influence on the weak-minded. You
+will find it a powerful ally.
+</sp>
+      <sp spk="LUKE"> Do you really think we're going to find a pilot here that'll
+take us to Alderaan?
+</sp>
+      <sp spk="BEN"> Well, most of the best freighter pilots can be found here. Only
+watch your step. This place can be a little rough.
+</sp>
+      <sp spk="LUKE"> I'm ready for anything.
+</sp>
+      <sp spk="THREEPIO"> Come along, Artoo.
+</sp>
+   </scene>
+   <scene n="56">
+      <sd>INTERIOR: TATOOINE -- MOS EISLEY -- CANTINA.
+	The young adventurer and his two mechanical servants follow
+	Ben Kenobi into the smoke-filled cantina. The murky, moldy den
+	is filled with a startling array of weird and exotic alien
+	creatures and monsters at the long metallic bar. At first the
+	sight is horrifying. One-eyed, thousand-eyed, slimy, furry,
+	scaly, tentacled, and clawed creatures huddle over drinks. Ben
+	moves to an empty spot at the bar near a group of repulsive
+	but human scum. A huge, rough-looking Bartender stops Luke and
+	the robots.
+</sd>
+      <sp spk="BARTENDER"> We don't serve their kind here!
+		</sp>
+      <sd> Luke still recovering from the shock of seeing so many
+	outlandish creatures, doesn't quite catch the bartender's
+	drift.
+</sd>
+      <sp spk="LUKE"> What?
+</sp>
+      <sp spk="BARTENDER"> Your droids. They'll have to wait outside. We don't want
+them here.
+		</sp>
+      <sd> Luke looks at old Ben, who is busy talking to one of the
+	Galactic pirates. He notices several of the gruesome creatures
+	along the bar are giving him a very unfriendly glare.
+</sd>
+      <sd> Luke pats Threepio on the shoulder.
+</sd>
+      <sp spk="LUKE"> Listen, why don't you wait out by the speeder. We don't want any
+trouble.
+</sp>
+      <sp spk="THREEPIO"> I heartily agree with you sir.</sp>
+      <sd>Threepio and his stubby partner go outside and most of the
+	creatures at the bar go back to their drinks.
+		</sd>
+      <sd> Ben is standing next to Chewbacca, an eight-foot-tall-
+	savage-looking creature resembling a huge grey bushbaby monkey
+	with fierce baboon-like fangs. His large blue eyes dominate a
+	fur-covered face and soften his otherwise awesome appearance.
+	Over his matted, furry body he wears two chrome bandoliers,
+	and little else. He is a two-hundred-year-old Wookiee and a
+	sight to behold.
+</sd>
+      <sd>Ben speaks to the Wookiee, pointing to Luke several times
+	during his conversation and the huge creature suddenly lets
+	out a horrifying laugh. Luke is more than a little bit
+	disconcerted and pretends not to hear the conversation between
+	Ben and the giant Wookiee.</sd>
+      <sd>&gt;Luke is terrified but tries not to show it. He quietly sips
+	his drink, looking over the crowd for a more sympathetic ear
+	or whatever.</sd>
+      <sd>A large, multiple-eyed Creature gives Luke a rough shove.</sd>
+      <sp spk="CREATURE"> Negola dewaghi wooldugger?!?
+		</sp>
+      <sd> The hideous freak is obviously drunk. Luke tries to ignore
+	the creature and turns back on his drink. A short, grubby
+	Human and an even smaller rodent-like beast join the
+	belligerent monstrosity.
+</sd>
+      <sp spk="HUMAN"> He doesn't like you.
+</sp>
+      <sp spk="LUKE"> I'm sorry.
+</sp>
+      <sp spk="HUMAN"> I don't like you either
+		</sp>
+      <sd> The big creature is getting agitated and yells out some
+	unintelligible gibberish at the now rather nervous, young
+	adventurer.
+</sd>
+      <sp spk="HUMAN">
+         <sd>continued</sd> Don't insult us. You just watch yourself. We're
+wanted men. I have the death sentence in twelve systems.
+</sp>
+      <sp spk="LUKE"> I'll be careful than.
+</sp>
+      <sp spk="HUMAN"> You'll be dead.
+		</sp>
+      <sd> The rodent lets out a loud grunt and everything at the bar
+	moves away. Luke tries to remain cool but it isn't easy. His
+	three adversaries ready their weapons. Old Ben moves in behind
+	Luke.
+</sd>
+      <sp spk="BEN"> This little one isn't worth the effort. Come let me buy you
+something...
+		</sp>
+      <sd> A powerful blow from the unpleasant creature sends the
+	young would-be Jedi sailing across the room, crashing through
+	tables and breaking a large jug filled with a foul-looking
+	liquid. With a blood curdling shriek, the monster draws a
+	wicked chrome laser pistol from his belt and levels it at old
+	Ben. The bartender panics.
+</sd>
+      <sp spk="BARTENDER"> No blasters! No blaster!
+		</sp>
+      <sd> With astounding agility old Ben's laser sword sparks to
+	life and in a flash an arm lies on the floor. The rodent is
+	cut in two and the giant multiple-eyed creature lies doubled,
+	cut from chin to groin. Ben carefully and precisely turns off
+	his laser sword and replaces it on his utility belt. Luke,
+	shaking and totally amazed at the old man's abilities, attempts
+	to stand. The entire fight has lasted only a matter of seconds.
+	The cantina goes back to normal, although Ben is given a
+	respectable amount of room at the bar. Luke, rubbing his
+	bruised head, approaches the old man with new awe. Ben points
+	the the Wookiee.
+</sd>
+      <sp spk="BEN"> This is Chewbacca. He's first-mate on a ship that might suit our
+needs.
+</sp>
+   </scene>
+   <scene n="57">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Threepio paces in front of the cantina as Artoo carries on an
+	electronic conversation with another little red astro-droid. A
+	creature comes out of the cantina and approaches two
+	stormtroopers in the street.
+</sd>
+      <sp spk="THREEPIO"> I don't like the look of this.
+</sp>
+   </scene>
+   <scene n="58">
+      <sd>INTERIOR: TATOOINE -- MOS EISLEY -- CANTINA.
+	Strange creatures play exotic big band music on odd-looking
+	instruments as Luke, still giddy, downs a fresh drink and
+	follows Ben and Chewbacca to a booth where Han Solo is
+	sitting. Han is a tough, roguish starpilot about thirty years
+	old. A mercenary on a starship, he is simple, sentimental, and
+	cocksure.
+</sd>
+      <sp spk="HAN"> Han Solo. I'm captain of the Millennium Falcon. Chewie here tells
+me you're looking for passage to the Alderaan system.
+</sp>
+      <sp spk="BEN"> Yes, indeed. If it's a fast ship.
+</sp>
+      <sp spk="HAN"> Fast ship? You've never heard of the Millennium Falcon?
+</sp>
+      <sp spk="BEN"> Should I have?
+</sp>
+      <sp spk="HAN"> It's the ship that made the Kessel run in less than twelve
+parsecs!
+		</sp>
+      <sd> Ben reacts to Solo's stupid attempt to impress them with
+	obvious misinformation.
+</sd>
+      <sp spk="HAN">
+         <sd>continued</sd> I've outrun Imperial starships, not the local
+bulk-cruisers, mind you. I'm talking about the big Corellian ships
+now. She's fast enough for you, old man. What's the cargo?
+</sp>
+      <sp spk="BEN"> Only passengers. Myself, the boy, two droids, and no questions
+asked.
+</sp>
+      <sp spk="HAN"> What is it? Some kind of local trouble?
+</sp>
+      <sp spk="BEN"> Let's just say we'd like to avoid any Imperial entanglements.
+</sp>
+      <sp spk="HAN"> Well, that's the trick, isn't it? And it's going to cost you
+something extra. Ten thousand in advance.
+</sp>
+      <sp spk="LUKE"> Ten thousand? We could almost buy our own ship for that!
+</sp>
+      <sp spk="HAN"> But who's going to fly it, kid! You?
+</sp>
+      <sp spk="LUKE"> You bet I could. I'm not such a bad pilot myself! We don't have
+to sit here and listen...
+</sp>
+      <sp spk="BEN"> We haven't that much with us. But we could pay you two thousand
+now, plus fifteen when we reach Alderaan.
+</sp>
+      <sp spk="HAN"> Seventeen, huh!
+		</sp>
+      <sd> Han ponders this for a few moments.
+</sd>
+      <sp spk="HAN"> Okay. You guys got yourself a ship. We'll leave as soon as you're
+ready. Docking bay Ninety-four.
+</sp>
+      <sp spk="BEN"> Ninety-four.
+</sp>
+      <sp spk="HAN"> Looks like somebody's beginning to take an interest in your
+handiwork.
+		</sp>
+      <sd> Ben and Luke turn around to see four Imperial stormtroopers
+	looking at the dead bodies and asking the bartenders some
+	questions. The bartender points to the booth.
+</sd>
+      <sp spk="TROOPER"> All right, we'll check it out.
+		</sp>
+      <sd> The stormtroopers look over at the booth but Luke and Ben
+	are gone. The bartender shrugs his shoulders in puzzlement.
+</sd>
+      <sp spk="HAN"> Seventeen thousand! Those guys must really be desperate. This
+could really save my neck. Get back to the ship and get her ready.
+</sp>
+   </scene>
+   <scene n="59">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+</sd>
+      <sp spk="BEN"> You'll have to sell your speeder.
+</sp>
+      <sp spk="LUKE"> That's okay. I'm never coming back to this planet again.
+</sp>
+   </scene>
+   <scene n="60">
+      <sd>INTERIOR: MOS EISLEY -- CANTINA.
+	As Han is about to leave, Greedo, a slimy green-faced alien 
+	with a short trunk-nose, pokes a gun in his side. The creature
+	speaks in a foreign tongue translated into English subtitles.
+</sd>
+      <sp spk="GREEDO"> Going somewhere, Solo?
+</sp>
+      <sp spk="HAN"> Yes, Greedo. As a matter of fact, I was just going to see your
+boss. Tell Jabba that I've got his money.
+		</sp>
+      <sd> Han sits down and the alien sits across from him holding
+	the gun on him.
+</sd>
+      <sp spk="GREEDO"> It's too late. You should have paid him when you had the
+chance. Jabba's put a price on your head, so large that every bounty
+hunter in the galaxy will be looking for you. I'm lucky I found you
+first.
+</sp>
+      <sp spk="HAN"> Yeah, but this time I got the money.
+</sp>
+      <sp spk="GREEDO"> If you give it to me, I might forget I found you.
+</sp>
+      <sp spk="HAN"> I don't have it with me. Tell Jabba...
+</sp>
+      <sp spk="GREEDO"> Jabba's through with you. He has no time for smugglers who
+drop their shipments at the first sign of an Imperial cruiser.
+</sp>
+      <sp spk="HAN"> Even I get boarded sometimes. Do you think I had a choice?
+	
+		</sp>
+      <sd> Han Solo slowly reaches for his gun under the table.
+</sd>
+      <sp spk="GREEDO"> You can tell that to Jabba. He may only take your ship.
+</sp>
+      <sp spk="HAN"> Over my dead body.
+</sp>
+      <sp spk="GREEDO"> That's the idea. I've been looking forward to killing you for
+a long time.
+</sp>
+      <sp spk="HAN"> Yes, I'll bet you have.
+		</sp>
+      <sd> Suddenly the slimy alien disappears in a blinding flash of
+	light. Han pulls his smoking gun from beneath the table as the
+	other patron look on in bemused amazement. Han gets up and
+	starts out of the cantina, flipping the bartender some coins
+	as he leaves.
+</sd>
+      <sp spk="HAN"> Sorry about the mess.
+</sp>
+   </scene>
+   <scene n="61">
+      <sd>EXTERIOR: SPACE.
+	Several TIE fighters approach the Death Star.
+</sd>
+   </scene>
+   <scene n="62">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+</sd>
+      <sp spk="VADER"> Her resistance to the mind probe is considerable. It will be
+some time before we can extract any information from her.
+		</sp>
+      <sd> An Imperial Officer interrupts the meeting.
+</sd>
+      <sp spk="IMPERIAL OFFICER"> The final check-out is complete. All systems are
+operational. What course shall we set?
+</sp>
+      <sp spk="TARKIN"> Perhaps she would respond to an alternative form of
+persuasion.
+</sp>
+      <sp spk="VADER"> What do you mean?
+</sp>
+      <sp spk="TARKIN"> I think it is time we demonstrate the full power of this
+station. <sd>to soldier</sd> Set your course for Princess Leia's home planet
+of Alderaan.
+</sp>
+      <sp spk="TROOPER"> With pleasure.
+</sp>
+   </scene>
+   <scene n="63">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Four heavily-armed stormtroopers move menacingly along a
+	narrow slum alleyway crowed with darkly clad creatures hawking
+	exotic goods in the dingy little stalls. Men, monsters, and
+	robots crouch in the waste-filled doorways, whispering and
+	hiding from the hot winds.
+</sd>
+      <sp spk="THREEPIO"> Lock the door, Artoo.
+		</sp>
+      <sd> One of the troopers checks a tightly locked door and moves
+	on down the alleyway. The door slides open a crack and
+	Threepio peeks out. Artoo is barely visible in the background.
+</sd>
+      <sp spk="TROOPER"> All right, check that side of the street. It's secure. Move
+on to the next door.
+		</sp>
+      <sd> The door opens, Threepio moves into the doorway.
+</sd>
+      <sp spk="THREEPIO"> I would much rather have gone with Master Luke than stay
+here with you. I don't know what all the trouble is about, but I'm
+sure it must be your fault.
+		</sp>
+      <sd> Artoo makes beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> You watch your language!
+</sp>
+   </scene>
+   <scene n="64">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET -- ALLEYWAY -- USED SPEEDER LOT.
+	Ben and Luke are standing in a sleazy used speeder lot,
+	talking with a tall, grotesque, insect-like used speeder
+	dealer. Strange exotic bodies and spindly-legged beasts pass
+	by as the insect concludes the sale by giving Luke some coins.
+</sd>
+      <sp spk="LUKE"> He says it's the best he can do. Since the XP-38 came out,
+they're just not in demand.
+</sp>
+      <sp spk="BEN"> It will be enough.
+		</sp>
+      <sd> Ben and Luke leave the speeder lot and walk down the dusty
+	alleyway past a small robot herding a bunch of anteater-like
+	creatures. Luke turns and gives one last forlorn look at his
+	faithful speeder as he rounds a corner. A darkly clad creature
+	moves out of the shadows as they pass and watches them as they
+	disappear down another alley.
+</sd>
+      <sp spk="BEN"> If the ship's as fast as he's boasting, we ought to do well.
+</sp>
+   </scene>
+   <scene n="65">
+      <sd>INTERIOR: DOCKING BAY 94 -- DAY.
+	Jabba the Hut and a half-dozen grisly alien pirates and purple
+	creatures stand in the middle of the docking bay. Jabba is the
+	grossest of the slavering hulks and his scarred face is a grim
+	testimonial to his prowess as a vicious killer. He is a fat,
+	slug-like creature with eyes on extended feelers and a huge
+	ugly mouth.
+</sd>
+      <sp spk="JABBA"> Come on out, Solo!
+		</sp>
+      <sd> A voice from directly behind the pirates startles them and
+	they turn around to see Han Solo and the giant Wookiee,
+	Chewbacca, standing behind them with no weapons in sight.
+</sd>
+      <sp spk="HAN"> I've been waiting for you, Jabba.
+</sp>
+      <sp spk="JABBA"> I expected you would be.
+</sp>
+      <sp spk="HAN"> I'm not the type to run.
+</sp>
+      <sp spk="JABBA">
+         <sd>fatherly-smooth</sd> Han, my boy, there are times when you
+disappoint me...why haven't you paid me? And why did you have to fry
+poor Greedo like that...after all we've been through together.
+</sp>
+      <sp spk="HAN"> You sent Greedo to blast me.
+</sp>
+      <sp spk="JABBA">
+         <sd>mock surprise</sd> Han, why you're the best smuggler in the
+business. You're too valuable to fry. He was only relaying my concern
+at your delays. He wasn't going to blast you.
+</sp>
+      <sp spk="HAN"> I think he thought he was. Next time don't send one of those
+twerps. If you've got something to say to me, come see me yourself.
+</sp>
+      <sp spk="JABBA"> Han, Han! If only you hadn't had to dump that shipment of
+spice...you understand I just can't make an exception. Where would I
+be if every pilot who smuggled for me dumped their shipment at the
+first sign of an Imperial starship? It's not good business.
+</sp>
+      <sp spk="HAN"> You know, even I get boarded sometimes, Jabba. I had no choice,
+but I've got a charter now and I can pay you back, plus a little
+extra. I just need some more time.
+</sp>
+      <sp spk="JABBA">
+         <sd>to his men</sd> Put your blasters away. Han, my boy, I'm only
+doing this because you're the best and I need you. So, for an extra,
+say twenty percent I'll give you a little more time...but this is it.
+If you disappoint me again, I'll put a price on your head so large you
+won't be able to go near a civilized system for the rest of your short
+life.
+</sp>
+      <sp spk="HAN"> Jabba, I'll pay you because it's my pleasure.
+</sp>
+   </scene>
+   <scene n="66">
+      <sd>EXTERIOR: DOCKING PORT ENTRY -- ALLEYWAY.
+	Chewbacca waits restlessly at the entrance to Docking Bay 94.
+	Ben, Luke, and the robots make their way up the street.
+	Chewbacca jabbers excitedly and signals for them to hurry. The
+	darkly clad creature has followed them from the speeder lot.
+	He stops in a nearby doorway and speaks into a small
+	transmitter.
+</sd>
+   </scene>
+   <scene n="67">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94
+	Chewbacca leads the group into a giant dirt pit that is Docking
+	Bay 94. Resting in the middle of the huge hole is a large,
+	round, beat-up, pieced-together hunk of junk that could only
+	loosely be called a starship.
+</sd>
+      <sp spk="LUKE"> What a piece of junk.
+		</sp>
+      <sd> The tall figure of Han Solo comes down the boarding ramp.
+</sd>
+      <sp spk="HAN"> She'll make point five beyond the speed of light. She may not
+look like much, but she's got it where it counts, kid. I've added some
+special modifications myself.
+		</sp>
+      <sd> Luke scratches his head. It's obvious he isn't sure about
+	all this. Chewbacca rushes up the ramp and urges the others to
+	follow.
+</sd>
+      <sp spk="HAN"> We're a little rushed, so if you'll hurry aboard we'll get out of
+here.
+		</sp>
+      <sd> The group rushes up the gang plank, passing a grinning Han
+	Solo.
+</sd>
+   </scene>
+   <scene n="68">
+      <sd>INTERIOR: MILLENNIUM FALCON.
+	Chewbacca settles into the pilot's chair and starts the mighty
+	engines of the starship.
+</sd>
+   </scene>
+   <scene n="69">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94.
+	Luke, Ben, Threepio, and Artoo move toward the Millennium
+	Falcon passing Solo.
+</sd>
+      <sp spk="THREEPIO"> Hello, sir.
+</sp>
+   </scene>
+   <scene n="70">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Eight Imperial stormtroopers rush up to the darkly clad
+	creature.
+</sd>
+      <sp spk="TROOPER"> Which way?
+		</sp>
+      <sd> The darkly clad creature points to the door of the docking
+	bay.
+</sd>
+      <sp spk="TROOPER"> All right, men. Load your weapons!
+</sp>
+   </scene>
+   <scene n="71">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94.
+	The troops hold their guns at the ready and charge down the
+	docking bay entrance.
+</sd>
+      <sp spk="TROOPER"> Stop that ship!
+		</sp>
+      <sd> Han Solo looks up and sees the Imperial stormtroopers
+	rushing into the docking bay. Several of the troopers fire at
+	Han as he ducks into the spaceship.
+</sd>
+      <sp spk="TROOPER"> Blast 'em!
+		</sp>
+      <sd> Han draws his laser pistol and pops off a couple of shots
+	which force the stormtroopers to dive for safety. The
+	pirateship engines whine as Han hits the release button that
+	slams the overhead entry shut.
+</sd>
+   </scene>
+   <scene n="72">
+      <sd>INTERIOR: MILLENNIUM FALCON.
+</sd>
+      <sp spk="HAN"> Chewie, get us out of here!
+		</sp>
+      <sd> The group straps in for take off.
+</sd>
+      <sp spk="THREEPIO"> Oh, my. I'd forgotten how much I hate space travel.
+</sp>
+   </scene>
+   <scene n="73">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREETS.
+	The half-dozen stormtroopers at a check point hear the general
+	alarm and look to the sky as the huge starship rises above the
+	dingy slum dwellings and quickly disappears into the morning
+	sky.
+</sd>
+   </scene>
+   <scene n="74">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han climbs into the pilot's chair next to Chewbacca, who
+	chatters away as he points to something on the radar scope.
+</sd>
+   </scene>
+   <scene n="75">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	The Corellian pirateship zooms from Tatooine into space.
+</sd>
+   </scene>
+   <scene n="76">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han frantically types information into the ship's computer.
+	Little Artoo appears momentarily at the cockpit doorway, makes
+	a few beeping remarks, then scurries away.
+</sd>
+      <sp spk="HAN"> It looks like an Imperial cruiser. Our passengers must be hotter
+than I thought. Try and hold them off. Angle the deflector shield
+while I make the calculations for the jump to light speed.
+</sp>
+   </scene>
+   <scene n="77">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	The Millennium Falcon pirateship races away from the yellow
+	planet, Tatooine. It is followed by two huge Imperial
+	stardestroyers.
+</sd>
+   </scene>
+   <scene n="78">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Over the shoulders of Chewbacca and Han, we can see the galaxy
+	spread before them. Luke and Ben make their way into the
+	cramped cockpit where Han continues his calculation.
+</sd>
+      <sp spk="HAN"> Stay sharp! There are two more coming in; they're going to try to
+cut us off.
+</sp>
+      <sp spk="LUKE"> Why don't you outrun them? I thought you said this thing was
+fast.
+</sp>
+      <sp spk="HAN"> Watch your mouth, kid, or you're going to find yourself floating
+home. We'll be safe enough once we make the jump to hyperspace.
+Besides, I know a few maneuvers. We'll lose them!
+</sp>
+   </scene>
+   <scene n="79">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	Imperial cruisers fire at the pirateship.
+</sd>
+   </scene>
+   <scene n="80">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The ship shudders as an explosion flashes outside the window.
+</sd>
+      <sp spk="HAN"> Here's where the fun begins!
+</sp>
+      <sp spk="BEN"> How long before you can make the jump to light speed?
+</sp>
+      <sp spk="HAN"> It'll take a few moments to get the coordinates from the
+navi-computer.</sp>
+      <sd>The ship begins to rock violently as lasers hit it.
+</sd>
+      <sp spk="LUKE"> Are you kidding? At the rate they're gaining...
+</sp>
+      <sp spk="HAN"> Traveling through hyperspace isn't like dusting crops, boy!
+Without precise calculations we could fly right through a star or
+bounce too close to a supernova and that'd end your trip real quick,
+wouldn't it?
+		</sp>
+      <sd> The ship is now constantly battered with laserfire as a red
+	warning light begins to flash.
+</sd>
+      <sp spk="LUKE"> What's that flashing?
+</sp>
+      <sp spk="HAN"> We're losing our deflector shield. Go strap yourself in, I'm
+going to make the jump to light speed.
+		</sp>
+      <sd> The galaxy brightens and they move faster, almost as if
+	crashing a barrier. Stars become streaks as the pirateship
+	makes the jump to hyperspace.
+</sd>
+   </scene>
+   <scene n="81">
+      <sd>EXTERIOR: SPACE.
+	The Millennium Falcon zooms into infinity in less than a
+	second.
+</sd>
+   </scene>
+   <scene n="82">
+      <sd>EXTERIOR: DEATH STAR.
+	Alderaan looms behind the Death Star battlestation.
+</sd>
+   </scene>
+   <scene n="83">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Admiral Motti enters the quiet control room and bows before
+	Governor Tarkin, who stands before the huge wall screen
+	displaying a small green planet.
+</sd>
+      <sp spk="MOTTI"> We've entered the Alderaan system.
+		</sp>
+      <sd> Vader and two stormtroopers enter with Princess Leia. Her
+	hands are bound.
+</sd>
+      <sp spk="LEIA"> Governor Tarkin, I should have expected to find you holding
+Vader's leash. I recognized your foul stench when I was brought on
+board.
+</sp>
+      <sp spk="TARKIN"> Charming to the last. You don't know how hard I found it
+signing the order to terminate your life!
+</sp>
+      <sp spk="LEIA"> I surprised you had the courage to take the responsibility
+yourself!
+</sp>
+      <sp spk="TARKIN"> Princess Leia, before your execution I would like you to be my
+guest at a ceremony that will make this battle station operational. No
+star system will dare oppose the Emperor now.
+</sp>
+      <sp spk="LEIA"> The more you tighten your grip, Tarkin, the more star systems
+will slip through your fingers.
+</sp>
+      <sp spk="TARKIN"> Not after we demonstrate the power of this station. In a way,
+you have determined the choice of the planet that'll be destroyed
+first. Since you are reluctant to provide us with the location of the
+Rebel base, I have chosen to test this station's destructive power...
+on your home planet of Alderaan.
+</sp>
+      <sp spk="LEIA"> No! Alderaan is peaceful. We have no weapons. You can't
+possibly...
+</sp>
+      <sp spk="TARKIN"> You would prefer another target? A military target? Then name
+the system!
+		</sp>
+      <sd> Tarkin waves menacingly toward Leia.
+</sd>
+      <sp spk="TARKIN"> I grow tired of asking this. So it'll be the last time. Where
+is the Rebel base?
+		</sp>
+      <sd> Leia overhears an intercom voice announcing the approach to
+	Alderaan.
+</sd>
+      <sp spk="LEIA">
+         <sd>softly</sd> Dantooine.
+		</sp>
+      <sd> Leia lowers her head.
+</sd>
+      <sp spk="LEIA"> They're on Dantooine.
+</sp>
+      <sp spk="TARKIN"> There. You see Lord Vader, she can be reasonable. (addressing
+Motti) Continue with the operation. You may fire when ready.
+</sp>
+      <sp spk="LEIA"> What?
+</sp>
+      <sp spk="TARKIN"> You're far too trusting. Dantooine is too remote to make an
+effective demonstration. But don't worry. We will deal with your Rebel
+friends soon enough. 
+</sp>
+      <sp spk="LEIA"> No!
+</sp>
+   </scene>
+   <scene n="84">
+      <sd>INTERIOR: DEATH STAR -- BLAST CHAMBER.
+</sd>
+      <sp spk="VADER"> Commence primary ignition.
+		</sp>
+      <sd> A button is pressed which switches on a panel of lights. A
+	hooded Imperial soldier reaches overhead and pulls a lever.
+	Another lever is pulled. Vader reaches for still another lever
+	and a bank of lights on a panel and wall light up. A huge beam
+	of light emanates from within a cone-shaped area and converges
+	into a single laser beam out toward Alderaan. The small green
+	planet of Alderaan is blown into space dust.
+</sd>
+   </scene>
+   <scene n="85">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Ben watches Luke practice the lightsaber with a small "seeker"
+	robot. Ben suddenly turns away and sits down. He falters,
+	seems almost faint.
+</sd>
+      <sp spk="LUKE"> Are you all right? What's wrong?
+</sp>
+      <sp spk="BEN"> I felt a great disturbance in the Force...as if millions of
+voices suddenly cried out in terror and were suddenly silenced. I fear
+something terrible has happened.
+		</sp>
+      <sd> Ben rubs his forehead. He seems to drift into a trance. Then
+	he fixes his gaze on Luke.
+</sd>
+      <sp spk="BEN"> You'd better get on with your exercises.
+		</sp>
+      <sd> Han Solo enters the room.
+</sd>
+      <sp spk="HAN"> Well, you can forget your troubles with those Imperial slugs. I
+told you I'd outrun 'em.
+		</sp>
+      <sd> Luke is once again practicing with the lightsaber.
+</sd>
+      <sp spk="HAN"> Don't everyone thank me at once.
+		</sp>
+      <sd> Threepio watches Chewbacca and Artoo who are engrossed in a
+	game in which three-dimensional holographic figures move along
+	a chess-type board.
+</sd>
+      <sp spk="HAN"> Anyway, we should be at Alderaan about oh-two-hundred hours.
+		</sp>
+      <sd> Chewbacca and the two robots sit around the lighted table
+	covered with small holographic monsters. Each side of the
+	table has a small computer monitor embedded in it. Chewbacca
+	seems very pleased with himself as he rests his lanky fur-
+	covered arms over his head.
+</sd>
+      <sp spk="THREEPIO"> Now be careful, Artoo.
+		</sp>
+      <sd> Artoo immediately reaches up and taps the computer with his
+	stubby claw hand, causing one of the holographic creatures to
+	walk to the new square. A sudden frown crosses Chewbacca's
+	face and he begins yelling gibberish at the tiny robot.
+	Threepio intercedes on behalf of his small companion and
+	begins to argue with the huge Wookiee.
+</sd>
+      <sp spk="THREEPIO"> He made a fair move. Screaming about it won't help you.
+</sp>
+      <sp spk="HAN">
+         <sd>interrupting</sd> Let him have it. It's not wise to upset a Wookiee.
+</sp>
+      <sp spk="THREEPIO"> But sir, nobody worries about upsetting a droid.
+</sp>
+      <sp spk="HAN"> That's 'cause droids don't pull people's arms out of their socket
+when they lose. Wookiees are known to do that.
+</sp>
+      <sp spk="THREEPIO"> I see your point, sir. I suggest a new strategy, Artoo. Let
+the Wookiee win.
+		</sp>
+      <sd> Luke stands in the middle of the small hold area; he seems
+	frozen in place. A humming lightsaber is held high over his
+	head. Ben watches him from the corner, studying his movements.
+	Han watches with a bit of smugness.
+</sd>
+      <sp spk="BEN"> Remember, a Jedi can feel the Force flowing through him.
+</sp>
+      <sp spk="LUKE"> You mean it controls your actions?
+</sp>
+      <sp spk="BEN"> Partially. But it also obeys your commands.
+		</sp>
+      <sd> Suspended at eye level, about ten feet in front of Luke, a
+	"seeker", a chrome baseball-like robot covered with antennae,
+	hovers slowly in a wide arc. The ball floats to one side of
+	the youth then the other. Suddenly it makes a lightning-swift
+	lunge and stops within a few feet of Luke's face. Luke doesn't
+	move and the ball backs off. It slowly moves behind the boy,
+	then makes another quick lunge, this time emitting a blood red
+	laser beam as it attacks. It hits Luke in the leg causing him
+	to tumble over. Han lets loose with a burst of laughter.
+</sd>
+      <sp spk="HAN"> Hokey religions and ancient weapons are no match for a good
+blaster at your side, kid.
+</sp>
+      <sp spk="LUKE"> You don't believe in the Force, do you?
+</sp>
+      <sp spk="HAN"> Kid, I've flown from one side of this galaxy to the other. I've
+seen a lot of strange stuff, but I've never seen anything to make me
+believe there's one all-powerful force controlling everything. There's
+no mystical energy field that controls my destiny.
+		</sp>
+      <sd> Ben smiles quietly
+</sd>
+      <sp spk="HAN"> It's all a lot of simple tricks and nonsense.
+</sp>
+      <sp spk="BEN"> I suggest you try it again, Luke.
+		</sp>
+      <sd> Ben places a large helmet on Luke's head which covers his
+	eyes.
+</sd>
+      <sp spk="BEN"> This time, let go your conscious self and act on instinct.
+</sp>
+      <sp spk="LUKE">
+         <sd>laughing</sd> With the blast shield down, I can't even see. How am
+I supposed to fight?
+</sp>
+      <sp spk="BEN"> Your eyes can deceive you. Don't trust them.
+		</sp>
+      <sd> Han skeptically shakes his head as Ben throws the seeker
+	into the air. The ball shoots straight up in the air, then
+	drops like a rock. Luke swings the lightsaber around blindly
+	missing the seeker, which fires off a laserbolt which hits
+	Luke square on the seat of the pants. He lets out a painful
+	yell and attempts to hit the seeker.
+</sd>
+      <sp spk="BEN"> Stretch out with your feelings.
+		</sp>
+      <sd> Luke stands in one place, seemingly frozen. The seeker
+	makes a dive at Luke and, incredibly, he managed to deflect
+	the bolt. The ball ceases fire and moves back to its original
+	position.
+</sd>
+      <sp spk="BEN"> You see, you can do it.
+</sp>
+      <sp spk="HAN"> I call it luck. 
+</sp>
+      <sp spk="BEN"> In my experience, there's no such thing as luck.
+</sp>
+      <sp spk="HAN"> Look, going good against remotes is one thing. Going good against
+the living? That's something else.
+		</sp>
+      <sd> Solo notices a small light flashing on the far side of the
+	control panel.
+</sd>
+      <sp spk="HAN"> Looks like we're coming up on Alderaan.
+		</sp>
+      <sd> Han and Chewbacca head back to the cockpit.
+</sd>
+      <sp spk="LUKE"> You know, I did feel something. I could almost see the remote.
+</sp>
+      <sp spk="BEN"> That's good. You have taken your first step into a larger world.
+</sp>
+   </scene>
+   <scene n="86">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Imperial Officer Cass stands before Governor Tarkin and the
+	evil Dark Lord Darth Vader.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="OFFICER CASS"> Our scout ships have reached Dantooine. They found the
+remains of a Rebel base, but they estimate that it has been deserted
+for some time. They are now conducting an extensive search of the
+surrounding systems.
+</sp>
+      <sp spk="TARKIN"> She lied! She lied to us!
+</sp>
+      <sp spk="VADER"> I told you she would never consciously betray the Rebellion.
+</sp>
+      <sp spk="TARKIN"> Terminate her...immediately!
+</sp>
+   </scene>
+   <scene n="87">
+      <sd>EXTERIOR: HYPERSPACE.
+	The pirateship is just coming out of hyperspace; a strange
+	surreal light show surrounds the ship.
+</sd>
+   </scene>
+   <scene n="88">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="HAN"> Stand by, Chewie, here we go. Cut in the sublight engines.
+		</sp>
+      <sd> Han pulls back on a control lever. Outside the cockpit
+	window stars begin streaking past, seem to decrease in speed,
+	then stop. Suddenly the starship begins to shudder and
+	violently shake about. Asteroids begin to race toward them,
+	battering the sides of the ship.
+</sd>
+      <sp spk="HAN"> What the...? Aw, we've come out of hyperspace into a meteor
+shower. Some kind of asteroid collision. It's not on any of the
+charts.
+		</sp>
+      <sd> The Wookiee flips off several controls and seems very cool
+	in the emergency. Luke makes his way into the bouncing
+	cockpit.
+</sd>
+      <sp spk="LUKE"> What's going on?
+</sp>
+      <sp spk="HAN"> Our position is correct, except...no, Alderaan!
+</sp>
+      <sp spk="LUKE"> What do you mean? Where is it?
+</sp>
+      <sp spk="HAN"> Thats what I'm trying to tell you, kid. It ain't there. It's been
+totally blown away.
+</sp>
+      <sp spk="LUKE"> What? How?
+		</sp>
+      <sd> Ben moves into the cockpit behind Luke as the ship begins
+	to settle down.
+</sd>
+      <sp spk="BEN"> Destroyed...by the Empire!
+</sp>
+      <sp spk="HAN"> The entire starfleet couldn't destroy the whole planet. It'd take
+a thousand ships with more fire power than I've...
+		</sp>
+      <sd> A signal starts flashing on the control panel and a muffled
+	alarm starts humming.
+</sd>
+      <sp spk="HAN"> There's another ship coming in.
+</sp>
+      <sp spk="LUKE"> Maybe they know what happened.
+</sp>
+      <sp spk="BEN"> It's an Imperial fighter.
+		</sp>
+      <sd> Chewbacca barks his concern. A huge explosion bursts
+	outside the cockpit window, shaking the ship violently. A
+	tiny, finned Imperial TIE fighter races past the cockpit
+	window.
+</sd>
+      <sp spk="LUKE"> It followed us!
+</sp>
+      <sp spk="BEN"> No. It's a short range fighter.
+</sp>
+      <sp spk="HAN"> There aren't any bases around here. Where did it come from?
+</sp>
+   </scene>
+   <scene n="89">
+      <sd>EXTERIOR: SPACE.
+	The fighter races past the Corellian pirateship.
+</sd>
+   </scene>
+   <scene n="90">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> It sure is leaving in a big hurry. If they identify us, we're in
+big trouble.
+</sp>
+      <sp spk="HAN"> Not if I can help it. Chewie...jam it's transmissions.
+</sp>
+      <sp spk="BEN"> It'd be as well to let it go. It's too far out of range.
+</sp>
+      <sp spk="HAN"> Not for long...
+</sp>
+   </scene>
+   <scene n="91">
+      <sd>EXTERIOR: SPACE.
+	The pirateship zooms over the camera and away into the
+	vastness of space after the Imperial TIE fighter.
+</sd>
+   </scene>
+   <scene n="92">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The tension mounts as the pirateship gains on the tiny fighter.
+	In the distance, one of the stars becomes brighter until it is
+	obvious that the TIE ship is heading for it. Ben stands behind
+	Chewbacca.
+</sd>
+      <sp spk="BEN"> A fighter that size couldn't get this deep into space on its own.
+</sp>
+      <sp spk="LUKE"> It must have gotten lost, been part of a convoy or something.
+</sp>
+      <sp spk="HAN"> Well, he ain't going to be around long enough to tell anyone
+about us.
+</sp>
+   </scene>
+   <scene n="93">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter is losing ground to the larger pirateship as
+	they race toward camera and disappear over head.
+</sd>
+   </scene>
+   <scene n="94">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The distant star can be distinguished as a small moon or
+	planet.
+</sd>
+      <sp spk="LUKE"> Look at him. He's headed for that small moon.
+</sp>
+      <sp spk="HAN"> I think I can get him before he gets there...he's almost in
+range.
+		</sp>
+      <sd> The small moon begins to take on the appearance of a
+	monstrous spherical battle station.
+</sd>
+      <sp spk="BEN"> That's no moon! It's a space station.
+</sp>
+      <sp spk="HAN"> It's too big to be a space station.
+</sp>
+      <sp spk="LUKE"> I have a very bad feeling about this.
+</sp>
+      <sp spk="HAN"> Yeah, I think your right. Full reverse! Chewie, lock in the
+auxiliary power.
+		</sp>
+      <sd> The pirateship shudders and the TIE fighter accelerates
+	away toward the gargantuan battle station.
+</sd>
+      <sp spk="LUKE"> Why are we still moving towards it?
+</sp>
+      <sp spk="HAN"> We're caught in a tractor beam! It's pulling us in!
+</sp>
+      <sp spk="LUKE"> But there's gotta be something you can do!
+</sp>
+      <sp spk="HAN"> There's nothin' I can do about it, kid. I'm in full power. I'm
+going to have to shut down. But they're not going to get me without a
+fight!
+		</sp>
+      <sd> Ben Kenobi puts a hand on his shoulder.
+</sd>
+      <sp spk="BEN"> You can't win. But there are alternatives to fighting.
+</sp>
+   </scene>
+   <scene n="95">
+      <sd>INTERIOR: MILLENNIUM FALCON -- DEATH STAR.
+	As the battered pirate starship is towed closer to the awesome
+	metal moon, the immense size of the massive battle station
+	becomes staggering. Running along the equator of the gigantic
+	sphere is a mile-high band of huge docking ports into which
+	the helpless pirateship is dragged.
+</sd>
+   </scene>
+   <scene n="96">
+      <sd>EXTERIOR: DEATH STAR -- HUGE PORT DOORS.
+	The helpless Millennium Falcon is pulled past a docking port
+	control room and huge laser turret cannons.
+</sd>
+      <sp spk="VOICE OVER DEATH STAR INTERCOM"> Clear Bay twenty-three-seven. We are
+opening the magnetic field.
+</sp>
+   </scene>
+   <scene n="97">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY 2037.
+	The pirateship is pulled in through port doors of the Death
+	Star, coming to rest in a huge hangar. Thirty stormtroopers
+	stand at attention in a central assembly area.
+</sd>
+      <sp spk="OFFICER"> To you stations!
+</sp>
+      <sp spk="OFFICER">
+         <sd>to another officer</sd> Come with me.
+</sp>
+   </scene>
+   <scene n="98">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Stormtroopers run to their posts.
+</sd>
+   </scene>
+   <scene n="99">
+      <sd>INTERIOR: DEATH STAR -- HANGAR 2037.
+	A line of stormtroopers march toward the pirateship in
+	readiness to board it, while other troopers stand with weapons
+	ready to fire.
+</sd>
+      <sp spk="OFFICER"> Close all outboard shields! Close all outboard shields!
+</sp>
+   </scene>
+   <scene n="100">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+ 
+	Tarkin pushes a button and responds to the intercom buzz.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="VOICE">
+         <sd>over intercom</sd> We've captured a freighter entering the remains
+of the Alderaan system. It's markings match those of a ship that
+blasted its way out of Mos Eisley.
+</sp>
+      <sp spk="VADER"> They must be trying to return the stolen plans to the princess.
+She may yet be of some use to us.
+</sp>
+   </scene>
+   <scene n="101">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY 2037.
+	Vader and a commander approach the troops as an Officer and
+	several heavily armed troops exit the spacecraft.
+</sd>
+      <sp spk="VOICE">
+         <sd>over intercom</sd> Unlock one-five-seven and nine. Release
+charges.
+</sp>
+      <sp spk="OFFICER">
+         <sd>to Vader</sd> There's no one on board, sir. According to the
+log, the crew abandoned ship right after takeoff. It must be a decoy,
+sir. Several of the escape pods have been jettisoned.
+</sp>
+      <sp spk="VADER"> Did you find any droids?
+</sp>
+      <sp spk="OFFICER"> No, sir. If there were any on board, they must also have
+jettisoned.
+</sp>
+      <sp spk="VADER"> Send a scanning crew on board. I want every part of this ship
+checked.
+</sp>
+      <sp spk="OFFICER"> Yes, sir.
+</sp>
+      <sp spk="VADER"> I sense something...a presence I haven't felt since...
+		</sp>
+      <sd> Vader turns quickly and exits the hangar.
+</sd>
+      <sp spk="OFFICER"> Get me a scanning crew in here on the double. I want every
+part of this ship checked!
+</sp>
+   </scene>
+   <scene n="102">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HALLWAY.
+	A trooper runs through the hallway heading for the exit. In a
+	few moments all is quiet. The muffled sounds of a distant
+	officer giving orders finally fade. Two floor panels suddenly
+	pop up revealing Han Solo and Luke. Ben Kenobi sticks his head
+	out of a third locker.
+</sd>
+      <sp spk="LUKE"> Boy, it's lucky you had these compartments.
+</sp>
+      <sp spk="HAN"> I use them for smuggling. I never thought I'd be smuggling myself
+in them. This is ridiculous. Even if I could take off, I'd never get
+past the tractor beam.
+</sp>
+      <sp spk="BEN"> Leave that to me!
+</sp>
+      <sp spk="HAN"> Damn fool. I knew that you were going to say that!
+</sp>
+      <sp spk="BEN"> Who's the more foolish...the fool or the fool who follows him?
+		</sp>
+      <sd> Han shakes his head, muttering to himself. Chewbacca
+	agrees.
+</sd>
+   </scene>
+   <scene n="103">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	The crewmen carry a heavy box on board the ship, past the two
+	stormtroopers guarding either side of the ramp.
+</sd>
+      <sp spk="TROOPER"> The ship's all yours. If the scanners pick up anything,
+report it immediately. All right, let's go.
+		</sp>
+      <sd> The crewmen enter the pirateship and a loud crashing sound
+	is followed by a voice calling to the guard below.
+</sd>
+      <sp spk="HAN'S VOICE"> Hey down there, could you give us a hand with this?
+		</sp>
+      <sd> The stormtroopers enter the ship and a quick round of
+	gunfire is heard.
+</sd>
+   </scene>
+   <scene n="104">
+      <sd>INTERIOR: DEATH STAR -- FORWARD BAY -- COMMAND OFFICE.
+	In a very small command office near the entrance to the
+	pirateship, a Gantry Officer looks out his window and notices
+	the guards are missing. He speaks into the comlink.
+</sd>
+      <sp spk="GANTRY OFFICER"> TX-four-one-two. Why aren't you at your post?
+</sp>
+      <sp spk="TX"> four-one-two, do you copy? 
+		</sp>
+      <sd> A stormtrooper comes down the ramp of the pirateship and
+	waves to the gantry officer, pointing to his ear indicating
+	his comlink is not working. The gantry officer shakes his head
+	in disgust and heads for the door, giving his aide an annoyed
+	look.
+</sd>
+      <sp spk="GANTRY OFFICER"> Take over. We've got a bad transmitter. I'll see what
+I can do.
+		</sp>
+      <sd> As the officer approaches the door, it slides open
+	revealing the towering Chewbacca. The gantry officer, in a
+	momentary state of shock, stumbles backward. With a bone-
+	chilling howl, the giant Wookiee flattens the officer with one
+	blow. The aide immediately reaches for his pistol, but is
+	blasted by Han, dressed as an Imperial stormtrooper. Ben and
+	the robots enter the room quickly followed by Luke, also
+	dressed as a stormtrooper. Luke quickly removes his helmet.
+</sd>
+      <sp spk="LUKE"> You know, between his howling and your blasting everything in
+sight, it's a wonder the whole station doesn't know we're here.
+</sp>
+      <sp spk="HAN"> Bring them on! I prefer a straight fight to all this sneaking
+around.
+</sp>
+      <sp spk="THREEPIO"> We found the computer outlet, sir.
+		</sp>
+      <sd> Ben feeds some information into the computer and a map of
+	the city appears on the monitor. He begins to inspect it
+	carefully. Threepio and Artoo look over the control panel.
+	Artoo finds something that makes him whistle wildly.
+</sd>
+      <sp spk="BEN"> Plug in. He should be able to interpret the entire Imperial
+computer network.
+		</sp>
+      <sd> Artoo punches his claw arm into the computer socket and the
+	vast Imperial brain network comes to life, feeding information
+	to the little robot. After a few moments, he beeps something.
+</sd>
+      <sp spk="THREEPIO"> He says he's found the main computer to power the tractor
+beam that's holding the ship here. He'll try to make the precise
+location appear on the monitor.
+		</sp>
+      <sd> The computer monitor flashes readouts.
+</sd>
+      <sp spk="THREEPIO"> The tractor beam is coupled to the main reactor in seven
+locations. A power loss at one of the terminals will allow the ship to
+leave.
+		</sp>
+      <sd> Ben studies the data on the monitor readout.
+</sd>
+      <sp spk="BEN"> I don't think you boys can help. I must go alone.
+</sp>
+      <sp spk="HAN"> Whatever you say. I've done more that I bargained for on this
+trip already.
+</sp>
+      <sp spk="LUKE"> I want to go with you.
+</sp>
+      <sp spk="BEN"> Be patient, Luke. Stay and watch over the droids.
+</sp>
+      <sp spk="LUKE"> But he can...
+</sp>
+      <sp spk="BEN"> They must be delivered safely or other star systems will suffer
+the same fate as Alderaan. Your destiny lies along a different path
+than mine. The Force will be with you...always!
+		</sp>
+      <sd> Ben adjusts the lightsaber on his belt and silently steps
+	out of the command office, then disappears down a long grey
+	hallway. Chewbacca barks a comment and Han shakes his head in
+	agreement.
+</sd>
+      <sp spk="HAN"> Boy you said it, Chewie.
+		</sp>
+      <sd> Han looks at Luke.
+</sd>
+      <sp spk="HAN"> Where did you dig up that old fossil?
+</sp>
+      <sp spk="LUKE"> Ben is a great man.
+</sp>
+      <sp spk="HAN"> Yeah, great at getting us into trouble.
+</sp>
+      <sp spk="LUKE"> I didn't hear you give any ideas...
+</sp>
+      <sp spk="HAN"> Well, anything would be better than just hanging around waiting
+for him to pick us up...
+</sp>
+      <sp spk="LUKE"> Who do you think...
+		</sp>
+      <sd> Suddenly Artoo begins to whistle and beep a blue streak.
+	Luke goes over to him.
+</sd>
+      <sp spk="LUKE"> What is it?
+</sp>
+      <sp spk="THREEPIO"> I'm afraid I'm not quite sure, sir. He says "I found her",
+and keeps repeating, "She's here."
+</sp>
+      <sp spk="LUKE"> Well, who...who has he found?
+		</sp>
+      <sd> Artoo whistles a frantic reply.
+</sd>
+      <sp spk="THREEPIO"> Princess Leia.
+</sp>
+      <sp spk="LUKE"> The princess? She's here?
+</sp>
+      <sp spk="HAN"> Princess? What's going on?
+</sp>
+      <sp spk="THREEPIO"> Level five. Detention block A A-twenty-three. I'm afraid
+she's scheduled to be terminated.
+</sp>
+      <sp spk="LUKE"> Oh, no! We've got to do something.
+</sp>
+      <sp spk="HAN"> What are you talking about?
+</sp>
+      <sp spk="LUKE"> The droid belongs to her. She's the one in the message.. We've
+got to help her.
+</sp>
+      <sp spk="HAN"> Now, look, don't get any funny ideas. The old man wants us to
+wait right here.
+</sp>
+      <sp spk="LUKE"> But he didn't know she was here. Look, will you just find a way
+back into the detention block?
+</sp>
+      <sp spk="HAN"> I'm not going anywhere.
+</sp>
+      <sp spk="LUKE"> They're going to execute her. Look, a few minutes ago you said
+you didn't want to just wait here to be captured. Now all you want to
+do is stay. 
+</sp>
+      <sp spk="HAN"> Marching into the detention area is not what I had in mind.
+</sp>
+      <sp spk="LUKE"> But they're going to kill her!
+</sp>
+      <sp spk="HAN"> Better her than me...
+</sp>
+      <sp spk="LUKE"> She's rich.
+		</sp>
+      <sd> Chewbacca growls.
+</sd>
+      <sp spk="HAN"> Rich?
+</sp>
+      <sp spk="LUKE"> Yes. Rich, powerful! Listen, if you were to rescue her, the
+reward would be...
+</sp>
+      <sp spk="HAN"> What?
+</sp>
+      <sp spk="LUKE"> Well more wealth that you can imagine.
+</sp>
+      <sp spk="HAN"> I don't know, I can imagine quite a bit!
+</sp>
+      <sp spk="LUKE"> You'll get it!
+</sp>
+      <sp spk="HAN"> I better!
+</sp>
+      <sp spk="LUKE"> You will...
+</sp>
+      <sp spk="HAN"> All right, kid. But you'd better be right about this.
+		</sp>
+      <sd> Han looks at Chewie, who grunts a short grunt.
+</sd>
+      <sp spk="LUKE"> All right.
+</sp>
+      <sp spk="HAN"> What's your plan?
+</sp>
+      <sp spk="LUKE"> Uh...Threepio, hand me those binders there will you?
+		</sp>
+      <sd> Luke moves toward Chewbacca with electronic cuffs.
+</sd>
+      <sp spk="LUKE"> Okay. Now, I'm going to put these on you.
+		</sp>
+      <sd> Chewie lets out a hideous growl.
+</sd>
+      <sp spk="LUKE"> Okay. Han, you put these on.
+		</sp>
+      <sd> Luke sheepishly hands the binders to Han.
+</sd>
+      <sp spk="HAN"> Don't worry, Chewie. I think I know what he has in mind.
+		</sp>
+      <sd> The Wookiee has a worried and frightened look on his face
+	as Han binds him with the electronic cuffs.
+</sd>
+      <sp spk="THREEPIO"> Master Luke, sir! Pardon me for asking...but, ah...what
+should Artoo and I do if we're discovered here?
+</sp>
+      <sp spk="LUKE"> Lock the door!
+</sp>
+      <sp spk="HAN"> And hope they don't have blasters.
+</sp>
+      <sp spk="THREEPIO"> That isn't very reassuring.
+		</sp>
+      <sd> Luke and Han put on their armored stormtrooper helmets and
+	start off into the giant Imperial Death Star.
+</sd>
+   </scene>
+   <scene n="105">
+      <sd>INTERIOR: DEATH STAR -- DETENTION AREA -- ELEVATOR TUBE.
+	Han and Luke try to look inconspicuous in their armored suits
+	as they wait for a vacuum elevator to arrive. Troops,
+	bureaucrats, and robots bustle about, ignoring the trio
+	completely. Only a few give the giant Wookiee a curious
+	glance.
+		 Finally a small elevator arrives and the trio enters.
+</sd>
+      <sp spk="LUKE"> I can't see a thing in this helmet.</sp>
+      <sd>A bureaucrat races to get aboard also, but is signaled away by
+	Han. The door to the pod-like vehicle slides closed and the
+	elevator car takes off through a vacuum tube.
+</sd>
+   </scene>
+   <scene n="106">
+      <sd>INTERIOR: DEATH STAR -- MAIN HALLWAY.
+	Several Imperial officers walk through the wide main
+	passageway. They pass several stormtroopers and a robot
+	similar to Threepio but with an insect face. At the far end of
+	the hallway, a passing flash of Ben Kenobi appears, then
+	disappears down a small hallway. His appearance is so fleeting
+	that it is hard to tell if he is real or just an illusion. No
+	one in the hallway seems to notice him.
+</sd>
+   </scene>
+   <scene n="107">
+      <sd>INTERIOR: DEATH STAR -- INTERIOR ELEVATOR -- DETENTION SECURITY AREA.
+	Luke and Han step forward to exit the elevator, but the door
+	slides open behind them. The giant Wookiee and his two guards
+	enter the old grey security station. Guards and laser gates
+	are everywhere. Han whispers to Luke under his breath.
+</sd>
+      <sp spk="HAN"> This is not going to work.
+</sp>
+      <sp spk="LUKE"> Why didn't you say so before?
+</sp>
+      <sp spk="HAN"> I did say so before!
+</sp>
+   </scene>
+   <scene n="108">
+      <sd>INTERIOR: DETENTION AREA.
+	Elevator doors open. A tall, grim looking Officer approaches
+	the trio.
+</sd>
+      <sp spk="OFFICER"> Where are you taking this...thing?
+		</sp>
+      <sd> Chewie growls a bit at the remark but Han nudges him to
+	shut up.
+</sd>
+      <sp spk="LUKE"> Prisoner transfer from Block one-one-three-eight.
+</sp>
+      <sp spk="OFFICER"> I wasn't notified. I'll have to clear it.
+		</sp>
+      <sd> The officer goes back to his console and begins to punch in
+	the information. There are only three other troopers in the
+	area. Luke and Han survey the situation, checking all of the
+	alarms, laser gates, and camera eyes. Han unfastens one of
+	Chewbacca's electronic cuffs and shrugs to Luke.
+</sd>
+      <sd> Suddenly Chewbacca throws up his hands and lets out with
+	one of his ear-piercing howls. He grabs Han's laser rifle.
+</sd>
+      <sp spk="HAN"> Look out! He's loose!
+</sp>
+      <sp spk="LUKE"> He's going to pull us all apart.
+</sp>
+      <sp spk="HAN"> Go get him!
+		</sp>
+      <sd> The startled guards are momentarily dumbfounded. Luke and
+	Han have already pulled out their laser pistols and are
+	blasting away at the terrifying Wookiee. Their barrage of
+	laserfire misses Chewbacca, but hits the camera eyes, laser
+	gate controls, and the Imperial guards. The officer is the
+	last of the guards to fall under the laserfire just as he is
+	about to push the alarm system. Han rushes to the comlink
+	system, which is screeching questions about what is going on.
+	He quickly checks the computer readout.
+</sd>
+      <sp spk="HAN"> We've got to find out which cell this princess of yours is in.
+Here it is...cell twenty-one-eight-seven. You go get her. I'll hold
+them here.</sp>
+      <sd>Luke races down one of the cell corridors. Han speaks into the
+	buzzing comlink.
+</sd>
+      <sp spk="HAN">
+         <sd>sounding official</sd> Everything is under control. Situation
+normal.
+</sp>
+      <sp spk="INTERCOM VOICE"> What happened?
+</sp>
+      <sp spk="HAN">
+         <sd>getting nervous</sd> Uh...had a slight weapons malfunction. But, uh,
+everything's perfectly all right now. We're fine. We're all fine here,
+now, thank you. How are you?
+</sp>
+      <sp spk="INTERCOM VOICE"> We're sending a squad up.
+</sp>
+      <sp spk="HAN"> Uh, uh, negative. We had a reactor leak here now. Give us a few
+minutes to lock it down. Large leak...very dangerous.
+</sp>
+      <sp spk="INTERCOM VOICE"> Who is this? What's your operating number?
+		</sp>
+      <sd> Han blasts the comlink and it explodes.
+</sd>
+      <sp spk="HAN"> Boring conversation anyway. <sd>yelling down the hall</sd> Luke! We're
+going to have company!
+</sp>
+   </scene>
+   <scene n="109">
+      <sd>INTERIOR: DEATH STAR -- CELL ROW.
+	Luke stops in front of one of the cells and blasts the door
+	away with a laser pistol. When the smoke clears, Luke sees the
+	dazzling young princess-senator. She had been sleeping and is
+	now looking at him with an uncomprehending look on her face.
+	Luke is stunned by her incredible beauty and stands staring at
+	her with his mouth hanging open.
+</sd>
+      <sp spk="LEIA">
+         <sd>finally</sd> Aren't you a little short to be a stormtrooper?
+		</sp>
+      <sd> Luke takes off his helmet, coming out of it.
+</sd>
+      <sp spk="LUKE"> What? Oh...the uniform. I'm Luke Skywalker. I'm here to rescue
+you. 
+</sp>
+      <sp spk="LEIA"> You're who?
+</sp>
+      <sp spk="LUKE"> I'm here to rescue you. I've got your R2 unit. I'm here with Ben
+Kenobi.
+</sp>
+      <sp spk="LEIA"> Ben Kenobi is here! Where is he?
+</sp>
+      <sp spk="LUKE"> Come on!
+</sp>
+   </scene>
+   <scene n="110">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Darth Vader paces the room as Governor Tarkin sits at the far
+	end of the conference table.
+</sd>
+      <sp spk="VADER"> He is here...
+</sp>
+      <sp spk="TARKIN"> Obi-Wan Kenobi! What makes you think so?
+</sp>
+      <sp spk="VADER"> A tremor in the Force. The last time I felt it was in the
+presence of my old master.
+</sp>
+      <sp spk="TARKIN"> Surely he must be dead by now.
+</sp>
+      <sp spk="VADER"> Don't underestimate the power of the Force.
+</sp>
+      <sp spk="TARKIN"> The Jedi are extinct, their fire has gone out of the universe.
+You, my friend, are all that's left of their religion.
+		</sp>
+      <sd> There is a quiet buzz on the comlink.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="INTERCOM VOICE"> Governor Tarkin, we have an emergency alert in
+detention block A A-twenty-three.
+</sp>
+      <sp spk="TARKIN"> The princess! Put all sections on alert!
+</sp>
+      <sp spk="VADER"> Obi-Wan is here. The Force is with him.
+</sp>
+      <sp spk="TARKIN"> If you're right, he must not be allowed to escape.
+</sp>
+      <sp spk="VADER"> Escape is not his plan. I must face him alone.
+</sp>
+   </scene>
+   <scene n="111">
+      <sd>INTERIOR: DEATH STAR -- DETENTION AREA -- HALLWAY.
+	An ominous buzzing sound is heard on the other side of the
+	elevator door.
+</sd>
+      <sp spk="HAN"> Chewie!</sp>
+      <sd>Chewbacca responds with a growling noise.
+</sd>
+      <sp spk="HAN"> Get behind me! Get behind me!
+		</sp>
+      <sd> A series of explosions knock a hole in the elevator door
+	through which several Imperial troops begin to emerge.
+</sd>
+      <sd> Han and Chewie fire laser pistols at them through the smoke
+	and flame. They turn and run down the cell hallway, meeting up
+	with Luke and Leia rushing toward them.
+</sd>
+      <sp spk="HAN"> Can't get out that way.
+</sp>
+      <sp spk="LEIA"> Looks like you managed to cut off our only escape route.
+</sp>
+      <sp spk="HAN">
+         <sd>sarcastically</sd> Maybe you'd like it back in your cell, Your
+Highness.
+		</sp>
+      <sd> Luke takes a small comlink transmitter from his belt as
+	they continue to exchange fire with stormtroopers making their
+	way down the corridor.
+</sd>
+      <sp spk="LUKE"> See-Threepio! See-Threepio!
+</sp>
+      <sp spk="THREEPIO">
+         <sd>over comlink</sd> Yes sir?
+</sp>
+      <sp spk="LUKE"> We've been cut off! Are there any other ways out of the cell
+bay?...What was that? I didn't copy!
+</sp>
+   </scene>
+   <scene n="112">
+      <sd>INTERIOR: DEATH STAR -- MAIN BAY GANTRY -- CONTROL TOWER.
+	Threepio paces the control center as little Artoo beeps and
+	whistles a blue streak. Threepio yells into the small comlink
+	transmitter.
+</sd>
+      <sp spk="THREEPIO"> I said, all systems have been alerted to your presence, sir.
+The main entrance seems to be the only way in or out; all other
+information on your level is restricted.
+		</sp>
+      <sd> Someone begins banging on the door.
+</sd>
+      <sp spk="TROOPER VOICE"> Open up in there!
+</sp>
+      <sp spk="THREEPIO"> Oh, no!
+</sp>
+   </scene>
+   <scene n="113">
+      <sd>INTERIOR: DEATH STAR -- DETENTION CORRIDOR.
+	Luke and Leia crouch together in an alcove for protection as
+	they continue to exchange fire with troops. Han and Chewbacca
+	are barely able to keep the stormtroopers at bay at the far
+	and of the hallway. The laserfire is very intense, and smoke
+	fills the narrow cell corridor.
+</sd>
+      <sp spk="LUKE"> There isn't any other way out.
+</sp>
+      <sp spk="HAN"> I can't hold them off forever! Now what?
+</sp>
+      <sp spk="LEIA"> This is some rescue. When you came in here, didn't you have a
+plan for getting out?
+</sp>
+      <sp spk="HAN">
+         <sd>pointing to Luke</sd> He's the brains, sweetheart.
+		</sp>
+      <sd> Luke manages a sheepish grin and shrugs his shoulders.
+</sd>
+      <sp spk="LUKE"> Well, I didn't...
+		</sp>
+      <sd> The princess grabs Luke's gun and fires at a small grate in
+	the wall next to Han, almost frying him.
+</sd>
+      <sp spk="HAN"> What the hell are you doing?
+</sp>
+      <sp spk="LEIA"> Somebody has to save our skins. Into the garbage chute, wise
+guy.
+		</sp>
+      <sd> She jumps through the narrow opening as Han and Chewbacca
+	look on in amazement. Chewbacca sniffs the garbage chute and
+	says something.
+</sd>
+      <sp spk="HAN"> Get in there you big furry oaf! I don't care what you smell! Get
+in there and don't worry about it.
+		</sp>
+      <sd> Han gives him a kick and the Wookiee disappears into the
+	tiny opening. Luke and Han continue firing as they work their
+	way toward the opening.
+</sd>
+      <sp spk="HAN"> Wonderful girl! Either I'm going to kill her or I'm beginning to
+like her. Get in there!
+		</sp>
+      <sd> Luke ducks laserfire as he jumps into the darkness. Han
+	fires off a couple of quick blasts creating a smokey cover,
+	then slides into the chute himself and is gone.
+</sd>
+   </scene>
+   <scene n="114">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	Han tumbles into the large room filled with garbage and muck.
+	Luke is already stumbling around looking for an exit. He finds
+	a small hatchway and struggles to get it open. It won't budge.
+</sd>
+      <sp spk="HAN">
+         <sd>sarcastically</sd> Oh! The garbage chute was a really wonderful
+idea. What an incredible smell you've discovered! Let's get out of
+here! Get away from there...
+</sp>
+      <sp spk="LUKE"> No! wait!
+		</sp>
+      <sd> Han draws his laser pistol and fires at the hatch. The
+	laserbolt ricochets wildly around the small metal room.
+	Everyone dives for cover in the garbage as the bolt explodes
+	almost on top of them. Leia climbs out of the garbage with a
+	rather grim look on her face.
+</sd>
+      <sp spk="LUKE"> Will you forget it? I already tried it. It's magnetically
+sealed!
+</sp>
+      <sp spk="LEIA"> Put that thing away! You're going to get us all killed.
+</sp>
+      <sp spk="HAN"> Absolutely, Your Worship. Look, I had everything under control
+until you led us down here. You know, it's not going to take them long
+to figure out what happened to us.
+</sp>
+      <sp spk="LEIA"> It could be worst...
+		</sp>
+      <sd> A loud, horrible, inhuman moan works its way up from the
+	murky depths. Chewbacca lets out a terrified howl and begins
+	to back away. Han and Luke stand fast with their laser pistols
+	drawn. The Wookiee is cowering near one of the walls.
+</sd>
+      <sp spk="HAN"> It's worst.
+</sp>
+      <sp spk="LUKE"> There's something alive in here!
+</sp>
+      <sp spk="HAN"> That's your imagination.
+</sp>
+      <sp spk="LUKE"> Something just moves past my leg! Look! Did you see that?
+</sp>
+      <sp spk="HAN"> What?
+</sp>
+      <sp spk="LUKE"> Help!
+		</sp>
+      <sd> Suddenly Luke is yanked under the garbage.
+</sd>
+      <sp spk="HAN"> Luke! Luke! Luke!
+		</sp>
+      <sd> Solo tries to get to Luke. Luke surfaces with a gasp of air
+	and thrashing of limbs. A membrane tentacle is wrapped around
+	his throat.
+</sd>
+      <sp spk="LEIA"> Luke!
+		</sp>
+      <sd> Leia extends a long pipe toward him.
+</sd>
+      <sp spk="LEIA"> Luke, Luke, grab a hold of this.
+</sp>
+      <sp spk="LUKE"> Blast it, will you! My gun's jammed.
+</sp>
+      <sp spk="HAN"> Where?
+</sp>
+      <sp spk="LUKE"> Anywhere! Oh!!
+		</sp>
+      <sd> Solo fires his gun downward. Luke is pulled back into the
+	muck by the slimy tentacle.
+</sd>
+      <sp spk="HAN"> Luke! Luke!
+		</sp>
+      <sd> Suddenly the walls of the garbage receptacle shudder and
+	move in a couple of inches. Then everything is deathly quiet.
+	Han and Leia give each other a worried look as Chewbacca howls
+	in the corner. With a rush of bubbles and muck Luke suddenly
+	bobs to the surface.
+</sd>
+      <sp spk="LEIA"> Grab him!
+		</sp>
+      <sd> Luke seems to be released by the thing.
+</sd>
+      <sp spk="LEIA"> What happened?
+</sp>
+      <sp spk="LUKE"> I don't know, it just let go of me and disappeared...
+</sp>
+      <sp spk="HAN"> I've got a very bad feeling about this.
+		</sp>
+      <sd> Before anyone can say anything the walls begin to rumble
+	and edge toward the Rebels.
+</sd>
+      <sp spk="LUKE"> The walls are moving!
+</sp>
+      <sp spk="LEIA"> Don't just stand there. Try to brace it with something.
+		</sp>
+      <sd> They place poles and long metal beams between the closing
+	walls, but they are simply snapped and bent as the giant
+	trashmasher rumbles on. The situation doesn't look too good.
+</sd>
+      <sp spk="LUKE"> Wait a minute!
+		</sp>
+      <sd> Luke pulls out his comlink.
+</sd>
+      <sp spk="LUKE"> Threepio! Come in Threepio! Threepio! Where could he be?
+</sp>
+   </scene>
+   <scene n="115">
+      <sd>INTERIOR: DEATH STAR -- MAIN GANTRY -- COMMAND OFFICE.
+	A soft buzzer and the muted voice of Luke calling out for
+	See-Threepio can be heard on Threepio's hand comlink, which is
+	sitting on the deserted computer console. Artoo and Threepio
+	are nowhere in sight. Suddenly there is a great explosion and
+	the door of the control tower flies across the floor. Four
+	armed stormtroopers enter the chamber.
+</sd>
+      <sp spk="FIRST TROOPER"> Take over! <sd>pointing to the dead officer</sd> See to him!
+Look there!
+		</sp>
+      <sd> A trooper pushes a button and the supply cabinet door
+	slides open. See-Threepio and Artoo-Detoo are inside. Artoo
+	follows his bronze companion out into the office.
+</sd>
+      <sp spk="THREEPIO"> They're madmen! They're heading for the prison level. If you
+hurry, you might catch them.
+</sp>
+      <sp spk="FIRST OFFICER">
+         <sd>to his troops</sd> Follow me! You stand guard.
+		</sp>
+      <sd> The troops hustle off down the hallway, leaving a guard to
+	watch over the command office.
+</sd>
+      <sp spk="THREEPIO">
+         <sd>to Artoo</sd> Come on!
+		</sp>
+      <sd> The guard aims a blaster at them.
+</sd>
+      <sp spk="THREEPIO"> Oh! All this excitement has overrun the circuits of my
+counterpart here. If you don't mind, I'd like to take him down to
+maintenance.
+</sp>
+      <sp spk="TROOPER"> All right.
+		</sp>
+      <sd> The guard nods and Threepio, with little Artoo in tow,
+	hurries out the door.
+</sd>
+   </scene>
+   <scene n="116">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	As the walls rumble closed, the room gets smaller and smaller.
+Chewie is whining and trying to hold a wall back with his giant paws.
+Han is leaning back against the other wall. Garbage is snapping and
+popping. Luke is trying to reach Threepio.
+</sd>
+      <sp spk="LUKE"> Threepio! Come in, Threepio! Threepio!
+		</sp>
+      <sd> Han and Leia try to brace the contracting walls with a
+	pole. Leia begins to sink into the trash.
+</sd>
+      <sp spk="HAN"> Get to the top!
+</sp>
+      <sp spk="LEIA"> I can't 
+</sp>
+      <sp spk="LUKE"> Where could he be? Threepio! Threepio, will you come in?
+</sp>
+   </scene>
+   <scene n="117">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO"> They aren't here! Something must have happened to them. See
+if they've been captured.
+		</sp>
+      <sd> Little Artoo carefully plugs his claw arm into a new wall
+	socket and a complex array of electronic sounds spew from the
+	tiny robot.
+</sd>
+      <sp spk="THREEPIO"> Hurry!
+</sp>
+   </scene>
+   <scene n="118">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	The walls are only feet apart. Leia and Han are braced against
+	the walls. The princess is frightened. They look at each
+	other. Leia reaches out and takes Han's hand and she holds it
+	tightly. She's terrified and suddenly groans as she feels the
+	first crushing pressure against her body.
+</sd>
+      <sp spk="HAN"> One thing's for sure. We're all going to be a lot thinner! (to
+Leia) Get on top of it!
+</sp>
+      <sp spk="LEIA"> I'm trying!
+</sp>
+   </scene>
+   <scene n="119">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO">
+         <sd>to Artoo</sd> Thank goodness, they haven't found them! Where
+could they be?
+	
+		</sp>
+      <sd> Artoo frantically beeps something to See-Threepio.
+</sd>
+      <sp spk="THREEPIO"> Use the comlink? Oh, my! I forgot I turned it off!
+</sp>
+   </scene>
+   <scene n="120">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	Meanwhile, Luke is lying on his side, trying to keep his head
+	above the rising ooze. Luke's comlink begins to buzz and he
+	rips it off his belt.
+</sd>
+   </scene>
+   <scene n="121">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+	Muffled sounds of Luke's voice over the comlink can be heard,
+	but not distinctly.
+</sd>
+      <sp spk="THREEPIO"> Are you there, sir?
+</sp>
+   </scene>
+   <scene n="122">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+</sd>
+      <sp spk="LUKE"> Threepio!
+</sp>
+   </scene>
+   <scene n="123">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO"> We've had some problems...
+</sp>
+      <sp spk="LUKE">
+         <sd>over comlink</sd> Will you shut up and listen to me? Shut down all
+garbage mashers on the detention level, will you? Do you copy?
+</sp>
+   </scene>
+   <scene n="124">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+</sd>
+      <sp spk="LUKE"> Shut down all the garbage mashers on the detention level.
+</sp>
+   </scene>
+   <scene n="125">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="LUKE">
+         <sd>over comlink</sd> Shut down all the garbage mashers on the
+detention level.
+</sp>
+      <sp spk="THREEPIO">
+         <sd>to Artoo</sd> No. Shut them all down! Hurry!
+		</sp>
+      <sd> Threepio holds his head in agony as he hears the incredible
+	screaming and hollering from Luke's comlink.
+</sd>
+      <sp spk="THREEPIO"> Listen to them! They're dying, Artoo! Curse my metal body! I
+wasn't fast enough. It's all my fault! My poor master!
+</sp>
+      <sp spk="LUKE">
+         <sd>over comlink</sd> Threepio, we're all right!
+</sp>
+   </scene>
+   <scene n="126">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	The screaming and hollering is the sound of joyous relief. The
+	walls have stopped moving. Han, Chewie and Leia embrace in the
+	background.
+</sd>
+      <sp spk="LUKE"> We're all right. You did great.
+		</sp>
+      <sd> Luke moves to the pressure sensitive hatch, looking for a
+	number.
+</sd>
+      <sp spk="LUKE"> Hey...hey, open the pressure maintenance hatch on unit number...
+where are we?
+</sp>
+   </scene>
+   <scene n="127">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="HAN">
+         <sd>over comlink</sd> Three-two-six-eight-two-seven.
+</sp>
+   </scene>
+   <scene n="128">
+      <sd>INTERIOR: DEATH STAR -- TRACTOR BEAM -- POWER GENERATOR TRENCH.
+	Ben enters a humming service trench that powers the huge
+	tractor beam. The trench seems to be a hundred miles deep. The
+	clacking sound of huge switching devices can be heard. The old
+	Jedi edges his his way along a narrow ledge leading to a
+	control panel that connects two large cables. He carefully
+	makes several adjustments in the computer terminal, and
+	several lights on the board go from red to blue.
+</sd>
+   </scene>
+   <scene n="129">
+      <sd>INTERIOR: DEATH STAR -- UNUSED HALLWAY.
+	The group exits the garbage room into a dusty, unused hallway.
+	Han and Luke remove the trooper suits and strap on the blaster
+	belts.
+</sd>
+      <sp spk="HAN"> If we can just avoid any more female advice, we ought to be able
+to get out of here.
+		</sp>
+      <sd> Luke smiles and scratches his head as he takes a blaster
+	from Solo.
+</sd>
+      <sp spk="LUKE"> Well, let's get moving!
+		</sp>
+      <sd> Chewie begins growling and points to the hatch to the
+	garbage room, as he runs away and then stops howling.
+</sd>
+      <sp spk="HAN">
+         <sd>to Chewie</sd> Where are you going?
+		</sp>
+      <sd> The Dia Nogu bangs against the hatch and a long, slimy
+	tentacle works its way out of the doorway searching for a
+	victim. Han aims his pistol.
+</sd>
+      <sp spk="LEIA"> No, wait. They'll hear!
+		</sp>
+      <sd> Han fires at the doorway. The noise of the blast echoes
+	relentlessly throughout the empty passageway. Luke simply
+	shakes his head in disgust.
+</sd>
+      <sp spk="HAN">
+         <sd>to Chewie</sd> Come here, you big coward!
+		</sp>
+      <sd> Chewie shakes his head "no."
+</sd>
+      <sp spk="HAN"> Chewie! Come here!
+</sp>
+      <sp spk="LEIA"> Listen. I don't know who you are, or where you came from, but
+from now on, you do as I tell you. Okay?
+		</sp>
+      <sd> Han is stunned at the command of the petite young girl.
+</sd>
+      <sp spk="HAN"> Look, Your Worshipfulness, let's get one thing straight! I take
+orders from one person! Me!
+</sp>
+      <sp spk="LEIA"> It's a wonder you're still alive. <sd>looking at Chewie</sd> Will
+somebody get this big walking carpet out of my way?
+		</sp>
+      <sd> Han watches her start away. He looks at Luke.
+</sd>
+      <sp spk="HAN"> No reward is worth this.
+		</sp>
+      <sd> They follow her, moving swiftly down the deserted corridor.
+</sd>
+   </scene>
+   <scene n="130">
+      <sd>INTERIOR: DEATH STAR -- POWER TRENCH.
+	Suddenly a door behind Ben slides open and a detachment of
+	stormtroopers marches to the power trench. Ben instantly slips
+	into the shadows as an Officer moves to within a few feet of
+	him.
+</sd>
+      <sp spk="OFFICER"> Secure this area until the alert is canceled.
+</sp>
+      <sp spk="FIRST TROOPER"> Give me regular reports.
+		</sp>
+      <sd> All but two of the stormtroopers leave.
+</sd>
+      <sp spk="FIRST TROOPER"> Do you know what's going on?
+</sp>
+      <sp spk="SECOND TROOPER"> Maybe it's another drill.
+		</sp>
+      <sd> Ben moves around the tractor beam, watching the
+	stormtroopers as they turn their backs to him. Ben gestures
+	with his hand toward them, as the troops think they hear
+	something in the other hallway. With the help of the Force,
+	Ben deftly slips past the troopers and into the main hallway.
+</sd>
+      <sp spk="SECOND TROOPER"> What was that?
+</sp>
+      <sp spk="FIRST TROOPER"> Oh, it's nothing. Don't worry about it.
+</sp>
+   </scene>
+   <scene n="131">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Luke, Han, Chewbacca, and Leia run down an empty hallway and
+	stop before a bay window overlooking the pirateship. Troopers
+	are milling about the ship. Luke takes out his pocket comlink.
+</sd>
+      <sp spk="HAN">
+         <sd>looking at his ship</sd> There she is.
+</sp>
+      <sp spk="LUKE"> See-Threepio, do you copy?
+</sp>
+      <sp spk="THREEPIO">
+         <sd>voice</sd> For the moment. Uh, we're in the main hangar across
+from the ship.
+</sp>
+      <sp spk="LUKE"> We're right above you. Stand by.
+		</sp>
+      <sd> Han is watching the dozen or so troops moving in and out of
+	the pirateship. Leia moves towards Han, touches his arm and
+	points out the window to the ship.
+</sd>
+      <sp spk="LEIA"> You came in that thing? You're braver that I thought.
+</sp>
+      <sp spk="HAN"> Nice! Come on!
+		</sp>
+      <sd> Han gives her a dirty look, and they start off down the
+	hallway. They round a corner and run right into twenty
+	Imperial stormtroopers heading toward them. Both groups are
+	taken by surprise and stop in their tracks.
+</sd>
+      <sp spk="FIRST TROOPER"> It's them! Blast them!
+		</sp>
+      <sd> Before even thinking, Han draws his laser pistol and
+	charges the troops, firing. His blaster knocks one of the
+	stormtroopers into the air. Chewie follows his captain down
+	the corridor, stepping over the fallen trooper on the floor.
+</sd>
+      <sp spk="HAN">
+         <sd>to Luke and Leia</sd> Get back to the ship!
+</sp>
+      <sp spk="LUKE"> Where are you going? Come back!
+		</sp>
+      <sd> Han has already rounded a corner and does not hear.
+</sd>
+      <sp spk="LEIA"> He certainly has courage.
+</sp>
+      <sp spk="LUKE"> What good will it do us if he gets himself killed? Come on!
+		</sp>
+      <sd> Luke is furious but doesn't have time to think about it for
+	muted alarms begin to go off down on the hangar deck. Luke and
+	Leia start off toward the starship hangar.
+</sd>
+   </scene>
+   <scene n="132">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Han chases the stormtroopers down a long subhallway. He is
+	yelling and brandishing his laser pistol. The troops reach a
+	dead end and are forced to turn and fight. Han stops a few
+	feet from them and assumes a defensive position. The troops
+	begin to raise their laser guns. Soon all ten troopers are
+	moving into an attack position in front of the lone
+	starpirate. Han's determined look begins to fade as the troops
+	begin to advance. Solo jumps backward as they fire at him.
+</sd>
+   </scene>
+   <scene n="133">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Chewbacca runs down the subhallway in a last-ditch attempt to
+	save his bold captain. Suddenly he hears the firing of laser
+	guns and yelling. Around the corner shoots Han, pirate
+	extraordinaire, running for his life, followed by a host of
+	furious stormtroopers. Chewbacca turns and starts running the
+	other way also.
+</sd>
+   </scene>
+   <scene n="134">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Luke fires his laser pistol wildly as he and Leia rush down a
+	narrow subhallway, chased by several stormtroopers. They
+	quickly reach the end of the subhallway and race through an
+	open hatchway.
+</sd>
+   </scene>
+   <scene n="135">
+      <sd>INTERIOR: DEATH STAR -- CENTRAL CORE SHAFT.
+	Luke and Leia race through the hatch onto a narrow bridge that
+	spans a huge, deep shaft that seems to go into infinity. The
+	bridge has been retracted into the wall of the shaft, and Luke
+	almost rushes into the abyss. He loses his balance off the end
+	of the bridge as Leia, behind him, takes hold of his arm and
+	pulls him back.
+</sd>
+      <sp spk="LUKE">
+         <sd>gasping</sd> I think we took a wrong turn.
+		</sp>
+      <sd> Blasts from the stormtroopers' laser guns explode nearby
+	reminding them of the oncoming danger. Luke fires back at the
+	advancing troops. Leia reaches over and hits a switch that
+	pops the hatch door shut with a resounding boom, leaving them
+	precariously perched on a short piece of bridge overhang.
+	Laserfire from the troopers continues to hit the steel door.
+</sd>
+      <sp spk="LEIA"> There's no lock!
+		</sp>
+      <sd> Luke blasts the controls with his laser pistol.
+</sd>
+      <sp spk="LUKE"> That oughta hold it for a while.
+</sp>
+      <sp spk="LEIA"> Quick, we've got to get across. Find the control that extends
+the bridge.
+</sp>
+      <sp spk="LUKE"> Oh, I think I just blasted it.
+		</sp>
+      <sd> Luke looks at the blasted bridge control while the
+	stormtroopers on the opposite side of the door begin making
+	ominous drilling and pounding sounds.
+</sd>
+      <sp spk="LEIA"> They're coming through!
+		</sp>
+      <sd> Luke notices something on his stormtrooper belt, when
+	laserfire hits the wall behind him. Luke aims his laser pistol
+	at a stormtrooper perched on a higher bridge overhang across
+	the abyss from them. They exchange fire. Two more troops
+	appear on another overhang, also firing. A trooper is hit, and
+	grabs at his chest.
+</sd>
+      <sd> Another trooper standing on the bridge overhang is hit by
+	Luke's laserfire, and plummets down the shaft. Troopers move
+	back off the bridge; Luke hands the gun to Leia.
+</sd>
+      <sp spk="LUKE"> Here, hold this.
+		</sp>
+      <sd> Luke pulls a thin nylon cable from his trooper utility
+	belt. It has a grappler hook on it. A trooper appears on a
+	bridge overhang and fires at Luke and Leia. As Luke works with
+	the rope, Leia returns the laser volley. Another trooper
+	appears and fires at them, as Leia returns his fire as well.
+	Suddenly, the hatch door begins to open, revealing the feet of
+	more troops.
+</sd>
+      <sp spk="LEIA"> Here they come!
+		</sp>
+      <sd> Leia hits one of the stormtroopers on the bridge above, and
+	he falls into the abyss. Luke tosses the rope across the gorge
+	and it wraps itself around an outcropping of pipes. He tugs on
+	the rope to make sure it is secure, then grabs the princess in
+	his arms. Leia looks at Luke, then kisses him quickly on the
+	lips. Luke is very surprised.
+</sd>
+      <sp spk="LEIA"> For luck!
+		</sp>
+      <sd> Luke pushes off and they swing across the treacherous abyss
+	to the corresponding hatchway on the opposite side. Just as
+	Luke and Leia reach the far side of the canyon, the
+	stormtroopers break through the hatch and begin to fire at
+	the escaping duo. Luke returns the fire before ducking into
+	the tiny subhallway.
+</sd>
+   </scene>
+   <scene n="136">
+      <sd>INTERIOR: DEATH STAR -- NARROW PASSAGEWAY.
+	Ben hides in the shadows of the narrow passageway as several
+	stormtroopers rush past him in the main hallway. He checks to
+	make sure they're gone, then runs down the hallway in the
+	opposite direction. Darth Vader appears at the far end of the
+	hallway and starts after the old Jedi.
+</sd>
+   </scene>
+   <scene n="137">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	Threepio looks around at the troops milling about the
+	pirateship entry ramp.
+</sd>
+      <sp spk="THREEPIO"> Where could they be?
+		</sp>
+      <sd> Artoo, plugged into the computer socket, turns his dome
+	left and right, beeping a response.
+</sd>
+   </scene>
+   <scene n="138">
+      <sd>INTERIOR: DEATH STAR -- CORRIDOR -- BLAST SHIELDS DOOR.
+	Han and Chewbacca run down a long corridor with several
+	troopers hot on their trail.
+</sd>
+      <sp spk="TROOPER"> Close the blast doors!
+		</sp>
+      <sd> At the end of the hallway, blast doors begin to close in
+	front of them. The young starpilot and his furry companion
+	race past the huge doors just as they are closing, and manage
+	to get off a couple off laserblasts at the pursuing troops
+	before the doors slam shut.
+</sd>
+      <sp spk="TROOPER"> Open the blast doors! Open the blast doors!
+</sp>
+   </scene>
+   <scene n="139">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY LEADING TO MAIN FORWARD BAY.
+	Ben hurries along one of the tunnels leading to the hangar
+	where the pirateship waits. Just before he reaches the hangar,
+	Darth Vader steps into view at the end of the tunnel, not ten
+	feet away. Vader lights his saber. Ben also ignites his and
+	steps slowly forward.
+</sd>
+      <sp spk="VADER"> I've been waiting for you, Obi-Wan. We meet again, at last. The
+circle is now complete.
+		</sp>
+      <sd> Ben Kenobi moves with elegant ease into a classical
+	offensive position. The fearsome Dark Knight takes a defensive
+	stance.
+</sd>
+      <sp spk="VADER"> When I left you, I was but the learner; now I am the master.
+</sp>
+      <sp spk="BEN"> Only a master of evil, Darth.
+		</sp>
+      <sd> The two Galactic warriors stand perfectly still for a few
+	moments, sizing each other up and waiting for the right
+	moment. Ben seems to be under increasing pressure and strain,
+	as if an invisible weight were being placed upon him. He
+	shakes his head and, blinking, tries to clear his eyes. 
+</sd>
+      <sd> Ben makes a sudden lunge at the huge warrior but is checked
+	by a lightning movement of The Sith. A masterful slash stroke
+	by Vader is blocked by the old Jedi. Another of the Jedi's
+	blows is blocked, then countered. Ben moves around the Dark
+	Lord and starts backing into the massive starship hangar. The
+	two powerful warriors stand motionless for a few moments with
+	laser swords locked in mid-air, creating a low buzzing sound.
+</sd>
+      <sp spk="VADER"> Your powers are weak, old man.
+</sp>
+      <sp spk="BEN"> You can't win, Darth. If you strike me down, I shall become more
+powerful than you can possibly imagine.
+		</sp>
+      <sd> Their lightsabers continue to meet in combat.
+</sd>
+   </scene>
+   <scene n="140">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	Han Solo and Chewbacca, their weapons in hand, lean back
+	against the wall surveying the forward bay, watching the
+	Imperial stormtroopers make their rounds of the hangar.
+</sd>
+      <sp spk="HAN"> Didn't we just leave this party?
+		</sp>
+      <sd> Chewbacca growls a reply, as Luke and the princess join
+	them.
+</sd>
+      <sp spk="HAN"> What kept you?
+</sp>
+      <sp spk="LEIA"> We ran into some old friends.
+</sp>
+      <sp spk="LUKE"> Is the ship all right?
+</sp>
+      <sp spk="HAN"> Seems okay, if we can get to it. Just hope the old man got the
+tractor beam out of commission.
+</sp>
+   </scene>
+   <scene n="141">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Vader and Ben Kenobi continue their powerful duel. As they hit
+	their lightsabers together, lightning flashes on impact.
+	Troopers look on in interest as the old Jedi and Dark Lord of
+	The Sith fight. Suddenly Luke spots the battle from his
+	group's vantage point.
+</sd>
+      <sp spk="LUKE"> Look!
+		</sp>
+      <sd> Luke, Leia, Han, and Chewie look up and see Ben and Vader
+	emerging from the hallways on the far side of the docking bay.
+</sd>
+   </scene>
+   <scene n="142">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY.
+	Threepio and Artoo-Detoo are in the center of the Death Star's
+	Imperial docking bay.
+</sd>
+      <sp spk="THREEPIO"> Come on, Artoo, we're going!
+		</sp>
+      <sd> Threepio ducks out of sight as the seven stormtroopers who
+	were guarding the starship rush past them heading towards Ben
+	and The Sith Knight. He pulls on Artoo.
+</sd>
+   </scene>
+   <scene n="143">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Solo, Chewie, Luke, and Leia tensely watch the duel. The
+	troops rush toward the battling knights.
+</sd>
+      <sp spk="HAN"> Now's our chance! Go!</sp>
+      <sd>They start for the Millennium Falcon. Ben sees the troops
+	charging toward him and realizes that he is trapped. Vader
+	takes advantage of Ben's momentary distraction and brings his
+	mighty lightsaber down on the old man. Ben manages to deflect
+	the blow and swiftly turns around.
+		</sd>
+      <sd> The old Jedi Knight looks over his shoulder at Luke, lifts
+	his sword from Vader's then watches his opponent with a serene
+	look on his face.
+</sd>
+      <sd> Vader brings his sword down, cutting old Ben in half. Ben's
+	cloak falls to the floor in two parts, but Ben is not in it.
+	Vader is puzzled at Ben's disappearance and pokes at the empty
+	cloak. As the guards are distracted, the adventurers and the
+	robots reach the starship. Luke sees Ben cut in two and starts
+	for him. Aghast, he yells out.
+</sd>
+      <sp spk="LUKE"> No!
+		</sp>
+      <sd> The stormtroopers turn toward Luke and begin firing at him.
+	The robots are already moving up the ramp into the Millennium
+	Falcon, while Luke, transfixed by anger and awe, returns their
+	fire. Solo joins in the laserfire. Vader looks up and advances
+	toward them, as one of his troopers is struck down.
+</sd>
+      <sp spk="HAN">
+         <sd>to Luke</sd> Come on!
+</sp>
+      <sp spk="LEIA"> Come on! Luke, its too late!
+</sp>
+      <sp spk="HAN"> Blast the door! Kid!
+		</sp>
+      <sd> Luke fires his pistol at the door control panel, and it
+	explodes. The door begins to slide shut. Three troopers charge
+	forward firing laser bolts, as the door slides to a close
+	behind them, shutting Vader and the other troops out of the
+	docking bay. A stormtrooper lies dead at the feet of his
+	onrushing compatriots. Luke starts for the advancing troops,
+	as Solo and Leia move up the ramp into the pirateship. He
+	fires, hitting a stormtrooper, who crumbles to the floor.
+</sd>
+      <sp spk="BEN'S VOICE"> Run, Luke! Run!
+		</sp>
+      <sd> Luke looks around to see where the voice came from. He
+	turns toward the pirateship, ducking Imperial gunfire from the
+	troopers and races into the ship.
+</sd>
+   </scene>
+   <scene n="144">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han pulls back on the controls and the ship begins to move. The
+	dull thud of laser bolts bouncing off the outside of the ship
+	as Chewie adjusts his controls.
+</sd>
+      <sp spk="HAN"> I hope the old man got that tractor beam out if commission, or
+this is going to be a real short trip. Okay, hit it!
+		</sp>
+      <sd> Chewbacca growls in agreement.
+</sd>
+   </scene>
+   <scene n="145">
+      <sd>EXTERIOR: MILLENNIUM FALCON.
+	The Millennium Falcon powers away from the Death Star docking
+	bay, makes a spectacular turn and disappears into the vastness
+	of space.
+</sd>
+   </scene>
+   <scene n="146">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Luke, saddened by the loss of Obi-Wan Kenobi, stares off
+	blankly as the robots look on. Leia puts a blanket around him
+	protectively, and Luke turns and looks up at her. She sits
+	down beside him.
+</sd>
+   </scene>
+   <scene n="147">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Solo spots approaching enemy ships.
+</sd>
+      <sp spk="HAN">
+         <sd>to Chewie</sd> We're coming up on the sentry ships. Hold 'em off!
+Angle the deflector shields while I charge up the main guns!
+</sp>
+   </scene>
+   <scene n="148">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Luke looks downward sadly, shaking his head back and forth, as
+	the princess smiles comfortingly at him.
+</sd>
+      <sp spk="LUKE"> I can't believe he's gone.
+		</sp>
+      <sd> Artoo-Detoo beeps a reply.
+</sd>
+      <sp spk="LEIA"> There wasn't anything you could have done.
+		</sp>
+      <sd> Han rushes into the hold area where Luke is sitting with
+	the princess.
+</sd>
+      <sp spk="HAN">
+         <sd>to Luke</sd> Come on, buddy, we're not out of this yet!
+</sp>
+   </scene>
+   <scene n="149">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Solo climbs into his attack position in the topside gunport.
+</sd>
+   </scene>
+   <scene n="150">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HOLD AREA.
+	Luke gets up and moves out toward the gunports as Leia heads
+	for the cockpit.
+</sd>
+   </scene>
+   <scene n="151">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Luke climbs down the ladder into the gunport cockpit, settling
+	into one of the two main laser cannons mounted in large
+	rotating turrets on either side of the ship.
+</sd>
+   </scene>
+   <scene n="152">
+      <sd>INTERIOR: MILLENNIUM FALCON -- SOLO'S GUNPORT.
+	Han adjusts his headset as he sits before the controls of his
+	laser cannon, then speaks into the attached microphone.
+</sd>
+      <sp spk="HAN">
+         <sd>to Luke</sd> You in, kid? Okay, stay sharp!
+</sp>
+   </scene>
+   <scene n="153">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Chewbacca and Princess Leia search the heavens for attacking
+	TIE fighters. The Wookiee pulls back on the speed controls as
+	the ship bounces slightly.
+</sd>
+   </scene>
+   <scene n="154">
+      <sd>INTERIOR: MILLENNIUM FALCON -- SOLO'S GUNPORT -- COCKPIT.
+	Computer graphic readouts form on Solo's target screen, as Han
+	reaches for controls.
+</sd>
+   </scene>
+   <scene n="155">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT -- COCKPIT.
+	Luke sits in readiness for the attack, his hand on the laser
+	cannon's control button.
+</sd>
+   </scene>
+   <scene n="156">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Chewbacca spots the enemy ships and barks.
+</sd>
+      <sp spk="LEIA">
+         <sd>into intercom</sd> Here they come!
+</sp>
+   </scene>
+   <scene n="157">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- POV (POINT OF VIEW) -- SPACE.
+	The Imperial TIE fighters move towards the Millennium Falcon,
+	one each veering off to the left and right of the pirateship.
+</sd>
+   </scene>
+   <scene n="158">
+      <sd>INTERIOR: TIE FIGHTER -- COCKPIT.
+	The stars whip past behind the Imperial pilot as he adjusts
+	his maneuvering joy stick.
+</sd>
+   </scene>
+   <scene n="159">
+      <sd>EXTERIOR: MILLENNIUM FALCON -- IN SPACE.
+	The TIE fighter races past the Falcon, firing laser beams as
+	it passes.
+</sd>
+   </scene>
+   <scene n="160">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HOLD AREA.
+	Threepio is seated in the hold area, next to Artoo-Detoo. The
+	pirateship bounces and vibrates as the power goes out in the
+	room and then comes back on.
+</sd>
+   </scene>
+   <scene n="161">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- GUNPORTS.
+	A TIE fighter maneuvers in front of Han, who follows it and
+	fires at it with the laser cannon. Luke does likewise, as the
+	fighter streaks into view. The ship has suffered a minor hit,
+	and bounces slightly. 
+</sd>
+   </scene>
+   <scene n="162">
+      <sd>EXTERIOR: SPACE.
+	Two TIE fighters dive down toward the pirateship.
+</sd>
+   </scene>
+   <scene n="163">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires at an unseen fighter.
+</sd>
+      <sp spk="LUKE"> They're coming in too fast!
+</sp>
+   </scene>
+   <scene n="164">
+      <sd>EXTERIOR: SPACE -- MILLENNIUM FALCON/TIE FIGHTERS.
+	Pan with pirateship as two TIE fighters charge through the
+	background. Laserbolts streak from all the craft.
+</sd>
+   </scene>
+   <scene n="165">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CHEWBACCA.
+	The ship shudders as a laserbolt hits very close to the
+	cockpit. The Wookiee chatters something to Leia.
+</sd>
+   </scene>
+   <scene n="166">
+      <sd>EXTERIOR: TIE FIGHTER -- SPACE.
+	Full shot of a TIE fighter as it moves fast through the frame,
+	firing on the pirate starship.
+</sd>
+   </scene>
+   <scene n="167">
+      <sd>EXTERIOR: SPACE -- TIE FIGHTERS.
+	The two TIE fighters fire a barrage of laserbeams at the
+	pirateship.
+</sd>
+   </scene>
+   <scene n="168">
+      <sd>INTERIOR: MILLENNIUM FALCON -- MAIN PASSAGEWAY.
+	A laserbolt streaks into the side of the pirateship. The ship
+	lurches violently, throwing poor Threepio into a cabinet fill
+	of small computer chips.
+</sd>
+      <sp spk="THREEPIO"> Oooh!
+</sp>
+   </scene>
+   <scene n="169">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- GUNPORTS.
+	Leia watches the computer readout as Chewbacca manipulates the
+	ship's controls.
+</sd>
+      <sp spk="LEIA"> We've lost lateral controls.
+</sp>
+      <sp spk="HAN"> Don't worry, she'll hold together.
+		</sp>
+      <sd> An enemy laserbolt hits the pirateship's control panel,
+	causing it to blow out in a shower of sparks.
+</sd>
+      <sp spk="HAN">
+         <sd>to ship</sd> You hear me, baby? Hold together!
+		</sp>
+      <sd> Artoo-Detoo advances toward the smoking sparking control
+	panel, dousing the inferno by spraying it with fire retardant
+	beeping all the while.
+</sd>
+   </scene>
+   <scene n="170">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Luke swivels in his gun mount, following the TIE fighter with
+	his laser cannon.
+</sd>
+   </scene>
+   <scene n="171">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Solo aims his laser cannon at the enemy fighter.
+</sd>
+   </scene>
+   <scene n="172">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter streaks in front of the starship.
+</sd>
+   </scene>
+   <scene n="173">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Leia watches the TIE fighter ship fly over.
+</sd>
+   </scene>
+   <scene n="174">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter heads right for the pirateship, then zooms
+	overhead.
+</sd>
+   </scene>
+   <scene n="175">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke follows the TIE fighter across his field of view, firing
+	laserbeams from his cannon.
+</sd>
+   </scene>
+   <scene n="176">
+      <sd>EXTERIOR: TIE FIGHTER.
+	A TIE fighter dives past the pirateship.
+</sd>
+   </scene>
+   <scene n="177">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires at a TIE fighter. At his port, Han follows a
+	fighter in his sights, releasing a blast of laserfire. He
+	connects, and the fighter explodes into fiery dust. Han laughs
+	victoriously.
+</sd>
+   </scene>
+   <scene n="178">
+      <sd>EXTERIOR: SPACE.
+	Two TIE fighters move toward and over the Millennium Falcon,
+	unleashing a barrage of laserbolts at the ship.
+</sd>
+   </scene>
+   <scene n="179">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Another TIE fighter moves in on the pirateship and Luke,
+	smiling, fires the laser cannon at it, scoring a spectacular
+	direct hit.
+</sd>
+      <sp spk="LUKE"> Got him! I got him!
+		</sp>
+      <sd> Han turns and gives Luke a victory wave which Luke
+	gleefully returns.
+</sd>
+      <sp spk="HAN"> Great kid! Don't get cocky.
+		</sp>
+      <sd> Han turns back to his laser cannon.
+</sd>
+   </scene>
+   <scene n="180">
+      <sd>EXTERIOR: SPACE.
+	Two more TIE fighters cross in front of the pirateship.
+</sd>
+   </scene>
+   <scene n="181">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT
+	While Chewbacca manipulates the controls, Leia turns, looking
+	over her shoulder out the ports.
+</sd>
+      <sp spk="LEIA"> There are still two more of them out there!
+</sp>
+   </scene>
+   <scene n="182">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter moves up over the pirateship, firing laserblasts
+	at it.
+</sd>
+   </scene>
+   <scene n="183">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke and Han look into their respective projected target
+	screens. An Imperial fighter crosses Solo's port, and Han
+	swivels in his chair, following it with blasts from his laser
+	cannon. Another fighter crosses Luke's port, and he reacts in
+	a like manner, the glow of his target screen lighting his
+	face.
+</sd>
+   </scene>
+   <scene n="184">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter zooms toward the pirateship, firing
+	destructive blasts at it.
+</sd>
+   </scene>
+   <scene n="185">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires a laserblast at the approaching enemy fighter, and
+	it bursts into a spectacular explosion. Luke's projected
+	screen gives a readout of the hit. The pirateship bounces
+	slightly as it is struck by the enemy fire.
+</sd>
+   </scene>
+   <scene n="186">
+      <sd>EXTERIOR: SPACE -- TIE FIGHTER.
+	The last of the attacking Imperial TIE fighters looms in,
+	firing upon the Falcon.
+</sd>
+   </scene>
+   <scene n="187">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Solo swivels behind his cannon, his aim describing the arc of
+	the TIE fighter. The fighter comes closer, firing at the
+	pirateship, but a well-aimed blast from Solo's laser cannon
+	hits the attacker, which blows up in a small atomic shower of
+	burning fragments.
+</sd>
+      <sp spk="LUKE">
+         <sd>laughing</sd> That's it! We did it!
+		</sp>
+      <sd> The princess jumps up and gives Chewie a congratulatory
+	hug.
+</sd>
+      <sp spk="LEIA"> We did it!
+</sp>
+   </scene>
+   <scene n="188">
+      <sd>INTERIOR: MILLENNIUM FALCON -- PASSAGEWAY.
+	Threepio lies on the floor of the ship, completely tangled in
+	the smoking, sparking wires.
+</sd>
+      <sp spk="THREEPIO"> Help! I think I'm melting! <sd>to Artoo</sd> This is all your
+fault.
+		</sp>
+      <sd> Artoo turns his dome from side to side, beeping in
+	response.
+</sd>
+   </scene>
+   <scene n="189">
+      <sd>EXTERIOR: SPACE -- MILLENNIUM FALCON.
+	The victorious Millennium Falcon moves off majestically
+	through space.
+</sd>
+   </scene>
+   <scene n="190">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Darth Vader strides into the control room, where Tarkin is
+	watching the huge view screen. A sea of stars is before him.
+</sd>
+      <sp spk="TARKIN"> Are they away?
+</sp>
+      <sp spk="VADER"> They have just made the jump into hyperspace.
+</sp>
+      <sp spk="TARKIN"> You're sure the homing beacon is secure aboard their ship? I'm
+taking an awful risk, Vader. This had better work.
+</sp>
+   </scene>
+   <scene n="191">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han, removes his gloves and smiling, is at the controls of the
+	ship. Chewie moves into the aft section to check the damage.
+	Leia is seated near Han.
+</sd>
+      <sp spk="HAN"> Not a bad bit of rescuing, huh? You know, sometimes I even amaze
+myself.
+</sp>
+      <sp spk="LEIA"> That doesn't sound too hard. Besides, they let us go. It's the
+only explanation for the ease of our escape.
+</sp>
+      <sp spk="HAN"> Easy...you call that easy?
+</sp>
+      <sp spk="LEIA"> Their tracking us!
+</sp>
+      <sp spk="HAN"> Not this ship, sister.
+		</sp>
+      <sd> Frustrated, Leia shakes her head.
+</sd>
+      <sp spk="LEIA"> At least the information in Artoo is still intact.
+</sp>
+      <sp spk="HAN"> What's so important? What's he carrying?
+</sp>
+      <sp spk="LEIA"> The technical readouts of that battle station. I only hope that
+when the data is analyzed, a weakness can be found. It's not over yet!
+</sp>
+      <sp spk="HAN"> It is for me, sister! Look, I ain't in this for your revolution,
+and I'm not in it for you, Princess. I expect to be well paid. I'm in
+it for the money!
+</sp>
+      <sp spk="LEIA"> You needn't worry about your reward. If money is all that you
+love, then that's what you'll receive!
+		</sp>
+      <sd> She angrily turns, and as she starts out of the cockpit,
+	passes Luke coming in.
+</sd>
+      <sp spk="LEIA"> Your friend is quite a mercenary. I wonder if he really cares
+about anything...or anyone.
+</sp>
+      <sp spk="LUKE"> I care!
+		</sp>
+      <sd> Luke, shaking his head, sits in the copilot seat. He and
+	Han stare out at the vast blackness of space.
+</sd>
+      <sp spk="LUKE"> So...what do you think of her, Han?
+</sp>
+      <sp spk="HAN"> I'm trying not to, kid!
+</sp>
+      <sp spk="LUKE">
+         <sd>under his breath</sd> Good...
+</sp>
+      <sp spk="HAN"> Still, she's got a lot of spirit. I don't know, what do you
+think? Do you think a princess and a guy like me...
+</sp>
+      <sp spk="LUKE"> No!
+		</sp>
+      <sd> Luke says it with finality and looks away. Han smiles at
+	young Luke's jealousy.
+</sd>
+   </scene>
+   <scene n="192">
+      <sd>EXTERIOR: SPACE AROUND FOURTH MOON OF YAVIN.
+	The battered pirateship drifts into orbit around the planet
+	Yavin and proceeds to one of its tiny green moons.
+</sd>
+   </scene>
+   <scene n="193">
+      <sd>EXTERIOR: FOURTH MOON OF YAVIN.
+	The pirateship soars over the dense jungle.
+</sd>
+   </scene>
+   <scene n="194">
+      <sd>EXTERIOR: MASSASSI OUTPOST.
+	An alert guard, his laser gun in hand, scans the countryside.
+	He sets the gun down and looks toward the temple, barely
+	visible in the foliage.
+</sd>
+   </scene>
+   <scene n="195">
+      <sd>EXTERIOR: MASSASSI OUTPOST -- JUNGLE TEMPLE.
+	Rotting in a forest of gargantuan trees, an ancient temple
+	lies shrouded in an eerie mist. The air is heavy with the
+	fantastic cries of unimaginable creatures. Han, Luke and the
+	others are greeted by the Rebel troops.
+		 Luke and the group ride into the massive temple on an
+	armored military speeder.
+</sd>
+   </scene>
+   <scene n="196">
+      <sd>INTERIOR: MASSASSI -- MAIN HANGAR DECK.
+	The military speeder stops in a huge spaceship hangar, set up
+	in the interior of the crumbling temple. Willard, the
+	commander of the Rebel forces, rushes up to the group and
+	gives Leia a big hug. Every one is pleased to see her.
+</sd>
+      <sp spk="WILLARD">
+         <sd>holding Leia</sd> You're safe! We had feared the worst.
+		</sp>
+      <sd> Willard composes himself, steps back and bows formally.
+</sd>
+      <sp spk="WILLARD"> When we heard about Alderaan, we were afraid that you were...
+lost along with your father.
+</sp>
+      <sp spk="LEIA"> We don't have time for our sorrows, Commander. The battle
+station has surely tracked us here <sd>looking pointedly to Han</sd>. It's
+the only explanation for the ease of our escape. You must use the
+information in this R2 unit to plan the attack. It is our only hope.
+</sp>
+   </scene>
+   <scene n="197">
+      <sd>EXTERIOR: SPACE.
+	The surface of the Death Star ominously approaches the red
+	planet Yavin.
+</sd>
+   </scene>
+   <scene n="198">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grand Moff Tarkin and Lord Vader are interrupted in their
+	discussion by the buzz of the comlink. Tarkin moves to answer
+	the call.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="DEATH STAR INTERCOM VOICE"> We are approaching the planet Yavin. The
+Rebel base is on a moon on the far side. We are preparing to orbit the
+planet.
+</sp>
+   </scene>
+   <scene n="199">
+      <sd>EXTERIOR: YAVIN -- JUNGLE.
+	A lone guard stands in a tower high above the Yavin landscape,
+	surveying the countryside. A mist hangs over the jungle of
+	twisted green.
+</sd>
+   </scene>
+   <scene n="200">
+      <sd>INTERIOR: MASSASSI -- WAR ROOM BRIEFING AREA.
+	Dodonna stands before a large electronic wall display. Leia
+	and several other senators are to one side of the giant
+	readout. The low-ceilinged room is filled with starpilots,
+	navigators, and a sprinkling of R2-type robots. Everyone is
+	listening intently to what Dodonna is saying. Han and
+	Chewbacca are standing near the back.
+</sd>
+      <sp spk="DODONNA"> The battle station is heavily shielded and carries a
+firepower greater than half the star fleet. It's defenses are designed
+around a direct large-scale assault. A small one-man fighter should be
+able to penetrate the outer defense.
+		</sp>
+      <sd> Gold Leader, a rough looking man in his early thirties,
+	stands and addresses Dodonna.
+</sd>
+      <sp spk="GOLD LEADER"> Pardon me for asking, sir, but what good are snub
+fighters going to be against that?
+</sp>
+      <sp spk="DODONNA"> Well, the Empire doesn't consider a small one-man fighter to
+be any threat, or they'd have a tighter defense. An analysis of the
+plans provided by Princess Leia has demonstrated a weakness in the
+battle station.
+		</sp>
+      <sd> Artoo-Detoo stands next to a similar robot, makes beeping
+	sounds, and turns his head from right to left.
+</sd>
+      <sp spk="DODONNA"> The approach will not be easy. You are required to maneuver
+straight down this trench and skim the surface to this point. The
+target area is only two meters wide. It's a small thermal exhaust
+port, right below the main port. The shaft leads directly to the
+reactor system. A precise hit will start a chain reaction which should
+destroy the station.
+		</sp>
+      <sd> A murmer of disbelief runs through the room.
+</sd>
+      <sp spk="DODONNA"> Only a precise hit will set up a chain reaction. The shaft is
+ray-shielded, so you'll have to use proton torpedoes.
+		</sp>
+      <sd> Luke is sitting next to Wedge Antilles, a hotshot pilot
+	about sixteen years old.
+</sd>
+      <sp spk="WEDGE"> That's impossible, even for a computer.
+</sp>
+      <sp spk="LUKE"> It's not impossible. I used to bull's-eye womp rats in my
+T-sixteen back home. They're not much bigger than two meters.
+</sp>
+      <sp spk="DODONNA"> Man your ships! And may the Force be with you!
+		</sp>
+      <sd> The group rises and begins to leave.
+</sd>
+   </scene>
+   <scene n="201">
+      <sd>EXTERIOR: SPACE.
+	The Death Star begins to move around the planet toward the
+	tiny green moon.
+</sd>
+   </scene>
+   <scene n="202">
+      <sd>INTERIOR: DEATH STAR.
+	Tarkin and Vader watch the computer projected screen with
+	interest, as a circle of lights intertwines around one another
+	on the screen showing it's position in relation to Yavin and
+	the forth moon.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Orbiting the planet at maximum velocity.
+The moon with the Rebel base will be in range in thirty minutes.
+</sp>
+      <sp spk="VADER"> This will be a day long remembered. It has seen the end of
+Kenobi and it will soon see the end of the Rebellion.
+</sp>
+   </scene>
+   <scene n="203">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN HANGAR DECK.
+	Luke, Threepio and little Artoo enter the huge spaceship
+	hangar and hurry along a long line of gleaming spacefighters.
+	Flight crews rush around loading last-minute armaments and
+	unlocking power couplings. In an area isolated from this
+	activity Luke finds Han and Chewbacca loading small boxes onto
+	an armored speeder.
+</sd>
+      <sp spk="MAN'S VOICE">
+         <sd>over loudspeaker</sd> All flight trooper, man your stations.
+All flight troops, man your stations.
+		</sp>
+      <sd> Han is deliberately ignoring the activity of the fighter
+	pilots' preparation. Luke is quite saddened at the sight of
+	his friend's departure.
+</sd>
+      <sp spk="LUKE"> So...you got your reward and you're just leaving then?
+</sp>
+      <sp spk="HAN"> That's right, yeah! I got some old debts I've got to pay off with
+this stuff. Even if I didn't, you don't think I'd be fool enough to
+stick around here, do you? Why don't you come with us? You're pretty
+good in a fight. I could use you.
+</sp>
+      <sp spk="LUKE">
+         <sd>getting angry</sd> Come on! Why don't you take a look around? You
+know what's about to happen, what they're up against. They could use a
+good pilot like you. You're turning your back on them.
+</sp>
+      <sp spk="HAN"> What good's a reward if you ain't around to use it? Besides,
+attacking that battle station ain't my idea of courage. It's more like
+suicide.
+</sp>
+      <sp spk="LUKE"> All right. Well, take care of yourself, Han. I guess that's
+what you're best at, isn't it?
+		</sp>
+      <sd> Luke goes off and Han hesitates, then calls to him.
+</sd>
+      <sp spk="HAN"> Hey, Luke...may the Force be with you!
+		</sp>
+      <sd> Luke turns and sees Han wink at him. Luke lifts his hand in
+	a small wave and then goes off. 
+</sd>
+      <sd> Han turns to Chewie who growls at his captain,
+</sd>
+      <sp spk="HAN"> What're you lookin' at? I know what I'm doing.
+</sp>
+   </scene>
+   <scene n="204">
+      <sd>INTERIOR: MAIN HANGAR DECK -- LUKE'S SHIP.
+	Luke, Leia, and Dodonna meet under a huge space fighter.
+</sd>
+      <sp spk="LEIA"> What's wrong?
+</sp>
+      <sp spk="LUKE"> Oh, it's Han! I don't know, I really thought he'd change his
+mind. 
+</sp>
+      <sp spk="LEIA"> He's got to follow his own path. No one can choose it for him.
+</sp>
+      <sp spk="LUKE"> I only wish Ben were here.
+		</sp>
+      <sd> Leia gives Luke a little kiss, turns, and goes off. As Luke
+	heads for his ship, another pilot rushes up to him and grabs
+	his arm.
+</sd>
+      <sp spk="BIGGS"> Luke! I don't believe it! How'd you get here...are you going
+out with us?!
+</sp>
+      <sp spk="LUKE"> Biggs! Of course, I'll be up there with you! Listen, have I got
+some stories to tell...
+		</sp>
+      <sd> Red Leader, a rugged handsome man in his forties, comes up
+	behind Luke and Biggs. He has the confident smile of a born
+	leader.
+</sd>
+      <sp spk="RED LEADER"> Are you...Luke Skywalker? Have you been checked out on the
+Incom T-sixty-five?
+</sp>
+      <sp spk="BIGGS"> Sir, Luke is the best bushpilot in the outer rim territories.
+		</sp>
+      <sd> Red Leader pats Luke on the back as they stop in front of
+	his fighter.
+</sd>
+      <sp spk="RED LEADER"> I met your father once when I was just a boy, he was a
+great pilot. You'll do all right. If you've got half of your father's
+skill, you'll do better than all right.
+</sp>
+      <sp spk="LUKE"> Thank you, sir. I'll try.
+		</sp>
+      <sd> Red Leader hurries to his own ship.
+</sd>
+      <sp spk="BIGGS"> I've got to get aboard. Listen, you'll tell me your stories
+when we come back. All right?
+</sp>
+      <sp spk="LUKE"> I told you I'd make it someday, Biggs.
+</sp>
+      <sp spk="BIGGS">
+         <sd>going off</sd> You did, all right. It's going to be like old
+times, Luke. We're a couple of shooting stars that'll never be
+stopped!
+		</sp>
+      <sd> Luke laughs and shakes his head in agreement. He heads for
+	his ship.
+</sd>
+      <sd> As Luke begins to climb up the ladder into his sleek,
+	deadly spaceship, the crew chief, who is working on the craft,
+	points to little Artoo, who is being hoisted into a socket on
+	the back of the fighter.
+</sd>
+      <sp spk="CHIEF"> This R2 unit of your seems a bit beat up. Do you want a new
+one?
+</sp>
+      <sp spk="LUKE"> Not on your life! That little droid and I have been through a
+lot together. <sd>to Artoo</sd> You okay, Artoo?
+		</sp>
+      <sd> The crewmen lower Artoo-Detoo into the craft. Now a part of
+	the exterior shell of the starship, the little droid beeps
+	that he is fine.
+</sd>
+      <sd> Luke climbs up into the cockpit of his fighter and puts an
+	his helmet. Threepio looks on from the floor of the massive
+	hangar as the crewmen secure his little electronic partner
+	into Luke's X-wing. It's an emotional-filled moment as Artoo
+	beeps good-bye.
+</sd>
+      <sp spk="CHIEF"> Okay, easy she goes!
+</sp>
+      <sp spk="THREEPIO"> Hang on tight,Artoo, you've got to come back.
+		</sp>
+      <sd> Artoo beeps in agreement.
+</sd>
+      <sp spk="THREEPIO"> You wouldn't want my life to get boring, would you?
+		</sp>
+      <sd> Artoo whistles his reply.
+</sd>
+      <sd> All final preparations are made for the approaching battle.
+	The hangar is buzzing with the last minute activity as the
+	pilots and crewmen alike make their final adjustments. The hum
+	of activity is occasionally trespassed by the distorted voice
+	of the loudspeaker issuing commands. Coupling hoses are
+	disconnected from the ships as they are fueled. Cockpit
+	shields roll smoothly into place over each pilot. A signalman,
+	holding red guiding lights, directs the ships. Luke, a trace
+	of a smile gracing his lips, peers about through his goggles.
+</sd>
+      <sp spk="BEN'S VOICE"> Luke, the Force will be with you.
+		</sp>
+      <sd> Luke is confused at the voice and taps his headphones.
+</sd>
+   </scene>
+   <scene n="205">
+      <sd>EXTERIOR: MASSASSI OUTPOST -- JUNGLE.
+	All that can be seen of the fortress is a lone guard standing
+	on a small pedestal jutting out above the dense jungle. The
+	muted gruesome crying sounds that naturally permeate this
+	eerie purgatory are overwhelmed by the thundering din of ion
+	rockets as four silver starships catapult from the foliage in
+	a tight formation and disappears into the morning cloud cover.
+</sd>
+   </scene>
+   <scene n="206">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	The princess, Threepio, and a field commander sit quietly
+	before the giant display showing the planet Yavin and its four
+	moons. The red dot that represents the Death Star moves ever
+	closer to the system. A series of green dots appear around the
+	fourth moon. A din of indistinct chatter fills the war room.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE"> Stand-by alert. Death Star approaching.
+Estimated time to firing range, fifteen minutes.
+</sp>
+   </scene>
+   <scene n="207">
+      <sd>EXTERIOR: SPACE.
+	The Death Star slowly moves behind the massive yellow surface
+	of Yavin in the foreground, as many X-wing fighters flying in
+	formation zoom toward us and out of the frame.
+</sd>
+   </scene>
+   <scene n="208">
+      <sd>EXTERIOR: SPACE -- ANOTHER ANGLE.
+	Light from a distant sun creates an eerie atmospheric glow
+	around a huge planet, Yavin. Rebel fighters flying in
+	formation settle ominously in the foreground and very slowly
+	pull away.
+</sd>
+   </scene>
+   <scene n="209">
+      <sd>INTERIOR: RED LEADER STARSHIP -- COCKPIT.
+	Red Leader lowers his visor and adjusts his gun sights,
+	looking to each side at his wing men.
+</sd>
+      <sp spk="RED LEADER"> All wings report in.
+</sp>
+   </scene>
+   <scene n="210">
+      <sd>INTERIOR: ANOTHER COCKPIT.
+	One of the Rebel fighters checks in through his mike.
+</sd>
+      <sp spk="RED TEN"> Red Ten standing by.
+</sp>
+   </scene>
+   <scene n="211">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs checks his fighter's controls, alert and ready for
+	combat.
+</sd>
+      <sp spk="RED SEVEN">
+         <sd>over Biggs' headset</sd> Red Seven standing by.
+</sp>
+      <sp spk="BIGGS"> Red Three standing by.
+</sp>
+   </scene>
+   <scene n="212">
+      <sd>INTERIOR: PORKINS' COCKPIT.
+</sd>
+      <sp spk="PORKINS"> Red Six standing by.
+</sp>
+      <sp spk="RED NINE">
+         <sd>over headset</sd> Red Nine standing by.
+</sp>
+   </scene>
+   <scene n="213">
+      <sd>INTERIOR: WEDGE'S FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="WEDGE"> Red Two standing by.
+</sp>
+   </scene>
+   <scene n="214">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED ELEVEN">
+         <sd>over headset</sd> Red Eleven standing by.
+</sp>
+      <sp spk="LUKE"> Red Five standing by.
+</sp>
+   </scene>
+   <scene n="215">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER
+	Artoo-Detoo, in position outside of the fighter, turns his
+	head from side to side and makes beeping sounds.
+</sd>
+   </scene>
+   <scene n="216">
+      <sd>INTERIOR: RED LEADER'S FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Lock S-foils in attack position.
+</sp>
+   </scene>
+   <scene n="217">
+      <sd>EXTERIOR: SPACE.
+	The group of X-wing fighters move in formation toward the
+	Death Star, unfolding the wings and locking them in the "X"
+	position.
+</sd>
+   </scene>
+   <scene n="218">
+      <sd>INTERIOR: BIGGS' COCKPIT
+</sd>
+      <sp spk="READ LEADER">
+         <sd>over headset</sd> We're passing through their magnetic
+field.
+</sp>
+   </scene>
+   <scene n="219">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Hold tight!
+</sp>
+   </scene>
+   <scene n="220">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke adjusts his controls as he concentrates on the
+	approaching Death Star. The ship begins to be buffeted
+	slightly.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Switch your deflectors on.
+</sp>
+   </scene>
+   <scene n="221">
+      <sd>INTERIOR: ANOTHER COCKPIT.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Double front!
+</sp>
+   </scene>
+   <scene n="222">
+      <sd>EXTERIOR: SPACE.
+	The fighters, now X-shaped darts, move in formation. The Death
+	Star now appears to be a small moon growing rapidly in size as
+	the Rebel fighters approach. Complex patterns on the metallic
+	surface begin to become visible. A large dish antenna is built
+	into the surface on one side.
+</sd>
+   </scene>
+   <scene n="223">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge is amazed and slightly frightened at the awesome
+	spectacle.
+</sd>
+      <sp spk="WEDGE"> Look at the size of that thing!
+</sp>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Cut the chatter, Red Two.
+</sp>
+   </scene>
+   <scene n="224">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Accelerate to attack speed. This is it, boys!
+</sp>
+   </scene>
+   <scene n="225">
+      <sd>EXTERIOR: SPACE.
+	As the fighters move closer to the Death Star, the awesome
+	size of the gargantuan Imperial fortress is revealed. Half of
+	the deadly space station is in shadow and this area sparkles
+	with thousands of small lights running in thin lines and
+	occasionally grouped in large clusters; somewhat like a city
+	at night as seen from a weather satellite.
+</sd>
+   </scene>
+   <scene n="226">
+      <sd>INTERIOR: GOLD LEADER'S COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> Red Leader, this is Gold Leader.
+</sp>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> I copy, Gold Leader.
+</sp>
+      <sp spk="GOLD LEADER"> We're starting for the target shaft now.
+</sp>
+   </scene>
+   <scene n="227">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks around at his wingmen; the Death Star looming
+	in from behind. Two Y-wing fighters bob back and forth in the
+	background. He moves his computer targeting device into
+	position.
+</sd>
+      <sp spk="RED LEADER"> We're in position. I'm going to cut across the axis and
+try and draw their fire.
+</sp>
+   </scene>
+   <scene n="228">
+      <sd>EXTERIOR: SPACE.
+	Two squads of Rebel fighters peel off. The X-wings dive
+	towards the Death Star surface. A thousand lights glow across
+	the dark grey expanse of the huge station.
+</sd>
+   </scene>
+   <scene n="229">
+      <sd>INTERIOR: DEATH STAR.
+	Alarm sirens scream as soldiers scramble to large turbo-
+	powered laser gun emplacements. Electronic drivers rotate the
+	huge guns into position as crew adjust their targeting
+	devices.
+</sd>
+   </scene>
+   <scene n="230">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Laserbolts streak through the star-filled night. The Rebel
+	X-wing fighters move in toward the Imperial base, as the Death
+	Star aims its massive laser guns at the Rebel forces and
+	fires.
+</sd>
+   </scene>
+   <scene n="231">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia listens to the battle over the intercom.
+	Threepio is at her side.
+</sd>
+      <sp spk="WEDGE">
+         <sd>over war room speaker system</sd> Heavy fire, boss! Twenty-degrees.
+</sp>
+      <sp spk="RED LEADER">
+         <sd>over speaker</sd> I see it. Stay low.
+</sp>
+   </scene>
+   <scene n="232">
+      <sd>EXTERIOR: SPACE.
+	An X-wing zooms across the surface of the Death Star.
+</sd>
+   </scene>
+   <scene n="233">
+      <sd>INTERIOR: DEATH STAR.
+	Technical crews scurry here and there loading last-minute
+	armaments and unlocking power cables.
+</sd>
+   </scene>
+   <scene n="234">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge maneuvers his fighter toward the menacing Death Star.
+</sd>
+   </scene>
+   <scene n="235">
+      <sd>EXTERIOR: SPACE.
+	X-wings continue in their attack course on the Death Star.
+</sd>
+   </scene>
+   <scene n="236">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke nosedives radically, starting his attack on the monstrous
+	fortress. The Death Star surface streaks past the cockpit
+	window.
+</sd>
+      <sp spk="LUKE"> This is Red Five; I'm going in!
+</sp>
+   </scene>
+   <scene n="237">
+      <sd>EXTERIOR: SPACE.
+	Luke's X-wing races toward the Death Star. Laserbolts streak
+	from Luke's weapons, creating a huge fireball explosion on the
+	dim surface.
+</sd>
+   </scene>
+   <scene n="238">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Terror crosses Luke's face as he realizes he won't be able to
+	pull out in time to avoid the fireball.
+</sd>
+      <sp spk="BIGGS">
+         <sd>over headset</sd> Luke, pull up!
+</sp>
+   </scene>
+   <scene n="239">
+      <sd>EXTERIOR: SURFACE OF DEATH STAR.
+	Luke's ship emerges from the fireball, with the leading edges
+	of his wings slightly scorched.
+</sd>
+   </scene>
+   <scene n="240">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+</sd>
+      <sp spk="BIGGS"> Are you all right?
+</sp>
+   </scene>
+   <scene n="241">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke adjusts his controls and breathes a sigh of relief. Flak
+	bursts outside the cockpit window.
+</sd>
+      <sp spk="LUKE"> I got a little cooked, but I'm okay.
+</sp>
+   </scene>
+   <scene n="242">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Rebel fighters continue to strafe the Death Star's surface
+	with laserbolts.
+</sd>
+   </scene>
+   <scene n="243">
+      <sd>INTERIOR: DEATH STAR.
+	Walls buckle and cave in. Troops and equipment are blown in
+	all directions. Stormtroopers stagger out of the rubble.
+	Standing in the middle of the chaos, a vision of calm and
+	foreboding, is Darth Vader. One of his Astro-Officers rushes
+	up to him.
+</sd>
+      <sp spk="ASTRO-OFFICER"> We count thirty Rebel ships, Lord Vader. But they're so
+small they're evading our turbo-lasers!
+</sp>
+      <sp spk="VADER"> We'll have to destroy them ship to ship. Get the crews to their
+fighters.
+</sp>
+   </scene>
+   <scene n="244">
+      <sd>INTERIOR: DEATH STAR.
+	Smoke belches from the giant laser guns as they wind up their
+	turbine generators to create sufficient power. The crew rushes
+	about preparing for another blast. Even the troopers head gear
+	is not adequate to protect them from the overwhelming noise of
+	the monstrous weapon. One troopers bangs his helmet with his
+	hand in an attempt to stop the ringing.
+</sd>
+   </scene>
+   <scene n="245">
+      <sd>INTERIOR: READ LEADER'S X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	Red Leader flies through a heavy hail of flak.
+</sd>
+      <sp spk="RED LEADER"> Luke, let me know when you're going in.
+</sp>
+   </scene>
+   <scene n="246">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	The Red Leader's X-wing flies past Luke as he puts his nose
+	down and starts his attack dive.
+</sd>
+      <sp spk="LUKE"> I'm on my way in now...
+</sp>
+      <sp spk="RED LEADER"> Watch yourself! There's a lot of fire coming from the
+right side of that deflection tower.
+</sp>
+      <sp spk="LUKE"> I'm on it.
+</sp>
+   </scene>
+   <scene n="247">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke flings his X-wing into a twisting dive across the horizon
+	and down onto the dim grey surface.
+</sd>
+   </scene>
+   <scene n="248">
+      <sd>EXTERIOR: LUKE'S X-WING TRAVELING.
+	A shot hurls from Luke's guns. Laserbolts streak toward the
+	onrushing Death Star surface. Several small radar emplacements
+	erupt in flame. Laserfire erupts from a protruding tower on
+	the surface.
+</sd>
+   </scene>
+   <scene n="249">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	The blurry Death Star surface races past the cockpit window as
+	a big smile sweeps across Luke's face at the success of his
+	run. Flak thunders on all sides of him.
+</sd>
+   </scene>
+   <scene n="250">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The Death Star superstructure races past Luke as he maneuvers
+	his craft through a wall of laserfire and peels away from the
+	surface towards the heavens.
+</sd>
+   </scene>
+   <scene n="251">
+      <sd>INTERIOR: DEATH STAR.
+	The thunder and smoke of the big guns reverberate throughout
+	the massive structure. Many soldiers rush about in the smoke
+	and chaos, silhouetted by the almost continual flash of
+	explosions.
+</sd>
+   </scene>
+   <scene n="252">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs dives through a forest of radar domes, antennae, and gun
+	towers as he shoots low across the Death Star surface. A dense
+	barrage of laserfire streaks by on all sides.
+</sd>
+   </scene>
+   <scene n="253">
+      <sd>INTERIOR: DEATH STAR.
+	Imperial star pilots dash in unison to a line of small
+	auxiliary hatches that lead to Imperial TIE fighters.
+</sd>
+   </scene>
+   <scene n="254">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia, surrounded by her generals and aides, paces
+	nervously before a lighted computer table. On all sides
+	technicians work in front of many lighted glass walls. Dodonna
+	watches quietly from one corner. One of the officers working
+	over a screen speaks into his headset.
+</sd>
+      <sp spk="CONTROL OFFICER"> Squad leaders, we've picked up a new group of
+signals. Enemy fighters coming your way.
+</sp>
+   </scene>
+   <scene n="255">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	Luke looks around to see if he can spot the approaching
+	Imperial fighters.
+</sd>
+      <sp spk="LUKE"> My scope's negative. I don't see anything.
+</sp>
+   </scene>
+   <scene n="256">
+      <sd>INTERIOR: RED LEADER'S X-WING -- COCKPIT -- TRAVELING.
+	The Death Star's surface sweeps past as Red Leader searches
+	the sky for the Imperial fighters. Flak pounds at his ship.
+</sd>
+      <sp spk="RED LEADER"> Keep up your visual scanning. With all this jamming,
+they'll be on top of you before your scope can pick them up.
+</sp>
+   </scene>
+   <scene n="257">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Silhouetted against the rim lights of the Death Star horizon,
+	four ferocious Imperial TIE ships dive on the Rebel fighters.
+	Two of the TIE fighters peel off and drop out of frame. Pan
+	with the remaining two TIE ships.
+</sd>
+   </scene>
+   <scene n="258">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs panics when he discovers a TIE ship on his tail. The
+	horizon in the background twists around as he peels off,
+	hoping to lose the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="259">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Biggs! You've picked one up...watch it!
+</sp>
+      <sp spk="BIGGS"> I can't see it! Where is he?!
+</sp>
+   </scene>
+   <scene n="260">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs zooms off the surface and into space, closely followed
+	by an Imperial TIE fighter. The TIE ship fires several
+	laserbolts at Biggs, but misses.
+</sd>
+   </scene>
+   <scene n="261">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs see the TIE ship behind him and swings around, trying to
+	avoid him.
+</sd>
+      <sp spk="BIGGS"> He's on me tight, I can't shake him...I can't shake him.
+</sp>
+   </scene>
+   <scene n="262">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs, flying at high altitude, peels off and dives toward the
+	Death Star surface, but he is unable to lose the TIE fighter,
+	who sticks close to his tail.
+</sd>
+   </scene>
+   <scene n="263">
+      <sd>INTERIOR: X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	Luke is flying upside down. He rotates his ship around to
+	normal attitude as he comes out of his dive.
+</sd>
+      <sp spk="LUKE"> Hang on, Biggs, I'm coming in.
+</sp>
+   </scene>
+   <scene n="264">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs and the tailing TIE ship dive for the surface, now
+	followed by a fast-gaining Luke. After Biggs dives out of
+	sight, Luke chases the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="265">
+      <sd>EXTERIOR: SURFACE AROUND THE DEATH STAR.
+	In the foreground, the Imperial fighter races across the Death
+	Star's surface, closely followed by Luke in the background.
+</sd>
+   </scene>
+   <scene n="266">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	There is a shot from Luke's X-wing of the TIE ship exploding
+	in a mass of flames.
+</sd>
+      <sp spk="LUKE"> Got him!
+</sp>
+   </scene>
+   <scene n="267">
+      <sd>INTERIOR: DEATH STAR.
+	Darth Vader strides purposefully down a Death Star corridor,
+	flanked by Imperial stormtroopers.
+</sd>
+      <sp spk="VADER"> Several fighters have broken off from the main group. Come with
+me!
+</sp>
+   </scene>
+   <scene n="268">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	A concerned Princess Leia, Threepio, Dodonna, and other
+	officers of the Rebellion stand around the huge round readout
+	screen, listening to the ship-to-ship communication on the
+	room's loudspeaker.
+</sd>
+      <sp spk="BIGGS">
+         <sd>over speaker</sd> Pull in! Luke...pull in!
+</sp>
+      <sp spk="WEDGE">
+         <sd>over speaker</sd> Watch your back, Luke!
+</sp>
+      <sd>INTERIOR LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="WEDGE">
+         <sd>over headset</sd> Watch your back! Fighter's above you, coming in!
+</sp>
+   </scene>
+   <scene n="269">
+      <sd>EXTERIOR: SPACE.
+	Luke's ship soars away from the Death Star's surface as he
+	spots the tailing TIE fighter.
+</sd>
+   </scene>
+   <scene n="270">
+      <sd>INTERIOR: TIE FIGHTER'S COCKPIT.
+	The TIE pilot takes aim at Luke's X-wing.
+</sd>
+   </scene>
+   <scene n="271">
+      <sd>EXTERIOR: SPACE.
+	The Imperial TIE fighter pilot scores a hit on Luke's ship.
+	Fire breaks out on the right side of the X-wing.
+</sd>
+   </scene>
+   <scene n="272">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks out of his cockpit at the flames on his ship.
+</sd>
+      <sp spk="LUKE"> I'm hit, but not bad.
+</sp>
+   </scene>
+   <scene n="273">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Smoke pours out from behind Artoo-Detoo.
+</sd>
+      <sp spk="LUKE'S VOICE"> Artoo, see what you can do with it. Hang on back there.</sp>
+      <sd>Green laserfire moves past the beeping little robot as his
+	head turns.
+</sd>
+   </scene>
+   <scene n="274">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke nervously works his controls.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Red Six...
+</sp>
+   </scene>
+   <scene n="275">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	In the war room, Leia stands frozen as she listens and worries
+	about Luke.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over speaker</sd> Can you see Red Five?
+</sp>
+      <sp spk="RED TEN">
+         <sd>over speaker</sd> There's a heavy fire zone on this side. Red
+Five, where are you?
+</sp>
+   </scene>
+   <scene n="276">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke spots the TIE fighter behind him and soars away from the
+	Death Star surface.
+</sd>
+      <sp spk="LUKE"> I can't shake him!
+</sp>
+   </scene>
+   <scene n="277">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship soars closer to the surface of the Death Star, an
+	Imperial TIE fighter closing in on him in hot pursuit.
+</sd>
+   </scene>
+   <scene n="278">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	The Death Star whips below Wedge.
+</sd>
+      <sp spk="WEDGE"> I'm on him, Luke!
+</sp>
+   </scene>
+   <scene n="279">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+</sd>
+      <sp spk="WEDGE">
+         <sd>over headset</sd> Hold on!
+</sp>
+   </scene>
+   <scene n="280">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Wedge dives across the horizon toward Luke and the TIE
+	fighter.
+</sd>
+   </scene>
+   <scene n="281">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge moves his X-wing in rapidly.
+</sd>
+   </scene>
+   <scene n="282">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke reacts frantically.
+</sd>
+      <sp spk="LUKE"> Blast it! Wedge where are you?
+</sp>
+   </scene>
+   <scene n="283">
+      <sd>INTERIOR: TIE FIGHTER -- COCKPIT.
+	The fighter pilot watches Wedge's X-wing approach. Another
+	X-wing joins him, and both unleash a volley of laserfire on
+	the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="284">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter explodes, filling the screen with white light.
+	Luke's ship can be seen far in the distance.
+</sd>
+   </scene>
+   <scene n="285">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks about in relief.
+</sd>
+      <sp spk="LUKE"> Thanks, Wedge.
+</sp>
+   </scene>
+   <scene n="286">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia, Threepio, Dodonna and other Rebel officers are listening
+	to the Rebel Fighter's radio transmissions over the war room
+	intercom.
+</sd>
+      <sp spk="BIGGS">
+         <sd>over speaker</sd> Good shooting, Wedge!
+</sp>
+      <sp spk="GOLD LEADER">
+         <sd>over speaker</sd> Red Leader...
+</sp>
+   </scene>
+   <scene n="287">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader peels off and starts toward the long trenches at
+	the Death Star surface pole.
+</sd>
+      <sp spk="GOLD LEADER"> This is Gold Leader. We're starting out attack run.
+</sp>
+   </scene>
+   <scene n="288">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Y-wing fighters of the Gold group dive out of the stars
+	toward the Death Star surface.
+</sd>
+   </scene>
+   <scene n="289">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others are grouped around the screen, as
+	technicians move about attending to their duties.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over speaker</sd> I copy, Gold Leader. Move into position.
+</sp>
+   </scene>
+   <scene n="290">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Imperial TIE ships in precise formation dive toward the
+	Death Star surface.
+</sd>
+   </scene>
+   <scene n="291">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Darth Vader calmly adjusts his control stick as the stars whip
+	past in the window above his head.
+</sd>
+      <sp spk="VADER"> Stay in attack formation!
+</sp>
+   </scene>
+   <scene n="292">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Technicians are seated at the computer readout table.
+</sd>
+      <sp spk="GOLD LEADER">
+         <sd>over speaker</sd> The exhaust post is...
+</sp>
+   </scene>
+   <scene n="293">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> ...marked and locked in!
+</sp>
+   </scene>
+   <scene n="294">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Gold Leader approaches the surface and pulls out to skim the
+	surface of the huge station. The ship moves into a deep
+	trench, firing laserbolts. The surface streaks past as
+	laserfire is returned by the Death Star.
+</sd>
+   </scene>
+   <scene n="295">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT -- TRAVELING.
+	Gold Five is a pilot in his early fifties with a very battered
+	helmet that looks like it's been through many battles. He
+	looks around to see if enemy ships are near. His fighter is
+	buffeted by Imperial flak.
+</sd>
+   </scene>
+   <scene n="296">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader races down the enormous trench that leads to the
+	exhaust port. Laserbolts blast toward him in increasing
+	numbers, occasionally exploding near the ship causing it to
+	bounce about.
+</sd>
+      <sp spk="GOLD LEADER"> Switch power to front deflector screens.
+</sp>
+   </scene>
+   <scene n="297">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three Y-wing skim the Death Star surface deep in the trench,
+	as laserbolts streak past on all sides.
+</sd>
+   </scene>
+   <scene n="298">
+      <sd>EXTERIOR: DEATH STAR SURFACE -- GUN EMPLACEMENTS.
+	An exterior surface gun blazes away at the oncoming Rebel
+	fighters.
+</sd>
+   </scene>
+   <scene n="299">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> How many guns do you think, Gold Five.
+</sp>
+   </scene>
+   <scene n="300">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+</sd>
+      <sp spk="GOLD FIVE">
+         <sd>over speaker</sd> I'd say about twenty guns. Some on the
+surface, some on the towers.
+		</sp>
+      <sd> Leia, Threepio, and the technicians view the projected
+	target screen, as red and blue target lights glow. The red
+	target near the center blinks on and off.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE">
+         <sd>over speaker</sd> Death Star will be in range in
+five minutes. 
+</sp>
+   </scene>
+   <scene n="301">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+		 The three Y-wing fighters race toward camera and zoom
+	overhead through a hail of laserfire.
+</sd>
+   </scene>
+   <scene n="302">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+		 Gold Leader pulls his computer targeting device down in
+	front of his eye. Laserbolts continue to batter the Rebel
+	craft.
+</sd>
+      <sp spk="GOLD LEADER"> Switching to targeting computer.
+</sp>
+   </scene>
+   <scene n="303">
+      <sd>INTERIOR: GOLD TWO'S Y-WING -- COCKPIT.
+		 Gold Two, a younger pilot about Luke's age, pulls down his
+	targeting eye viewer and adjusts it. His ship shudders under
+	intense laser barrage.
+</sd>
+      <sp spk="GOLD TWO"> Computer's locked. Getting a signal.
+		</sp>
+      <sd> As the fighters begin to approach the target area, suddenly
+	all the laserfire stops. An eerie clam clings over the trench
+	as the surface whips past in a blur.
+</sd>
+      <sp spk="GOLD TWO"> The guns...they've stopped!
+</sp>
+   </scene>
+   <scene n="304">
+      <sd>EXTERIOR: GOLD FIVE'S COCKPIT.
+	Gold Five looks behind him.
+</sd>
+      <sp spk="GOLD FIVE"> Stabilize your read deflectors. Watch for enemy fighters.
+</sp>
+   </scene>
+   <scene n="305">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> They've coming in! Three marks at two ten.
+</sp>
+   </scene>
+   <scene n="306">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Imperial TIE ships, Darth Vader in the center flanked by
+	two wingmen, dive in precise formation almost vertically
+	toward the Death Star surface.
+</sd>
+   </scene>
+   <scene n="307">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Darth Vader calmly adjusts his control stick as the stars zoom
+	by.
+</sd>
+      <sp spk="VADER"> I'll take them myself! Cover me!
+</sp>
+      <sp spk="WINGMAN'S VOICE">
+         <sd>over speaker</sd> Yes, sir.
+</sp>
+   </scene>
+   <scene n="308">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three TIE fighters zoom across the surface of the Death Star.
+</sd>
+   </scene>
+   <scene n="309">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader lines up Gold Two in his targeting computer. Vader's
+	hands grip the control stick as he presses the button.
+</sd>
+   </scene>
+   <scene n="310">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT
+	The cockpit explodes around Gold Two. His head falls forward.
+</sd>
+   </scene>
+   <scene n="311">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	As Gold Two's ship explodes, debris is flung out into space.
+</sd>
+   </scene>
+   <scene n="312">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader looks over his shoulder at the scene.
+</sd>
+   </scene>
+   <scene n="313">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The three TIE fighters race along in the trench in a tight
+	formation.
+</sd>
+   </scene>
+   <scene n="314">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader panics.
+</sd>
+      <sp spk="GOLD LEADER">
+         <sd>into mike</sd> I can't maneuver!
+</sp>
+   </scene>
+   <scene n="315">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	Gold Five, the old veteran, trys to calm Gold Leader.
+</sd>
+      <sp spk="GOLD FIVE"> Stay on target.
+</sp>
+   </scene>
+   <scene n="316">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	The Death Star races by outside the cockpit window as he
+	adjusts his targeting device.
+</sd>
+      <sp spk="GOLD LEADER"> We're too close.
+</sp>
+   </scene>
+   <scene n="317">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	The older pilot remains calm.
+</sd>
+      <sp spk="GOLD FIVE"> Stay on target!
+</sp>
+   </scene>
+   <scene n="318">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Now he's really panicked.
+</sd>
+      <sp spk="GOLD LEADER"> Loosen up!
+</sp>
+   </scene>
+   <scene n="319">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader calmly adjusts his targeting computer and pushes the
+	fire button.
+</sd>
+   </scene>
+   <scene n="320">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader's ship is hit by Vader's laser.
+</sd>
+   </scene>
+   <scene n="321">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Gold Leader explodes in a ball of flames, throwing debris in
+	all directions.
+</sd>
+   </scene>
+   <scene n="322">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	Gold Five moves in on the exhaust port.
+</sd>
+      <sp spk="GOLD FIVE"> Gold Five to Red Leader...
+</sp>
+   </scene>
+   <scene n="323">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks over his shoulder at the action outside of his
+	cockpit.
+</sd>
+      <sp spk="GOLD FIVE">
+         <sd>over headset</sd> Lost Tiree, lost Dutch.
+</sp>
+   </scene>
+   <scene n="324">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> I copy, Gold Five.
+</sp>
+   </scene>
+   <scene n="325">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD FIVE"> They came from behind....
+</sp>
+   </scene>
+   <scene n="326">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	One of the engines explodes on Gold Five's Y-wing fighter,
+	blazing out of control. He dives past the horizon toward the
+	Death Star's surface, passing a TIE fighter during his
+	descent. Gold Five, a veteran of countless campaigns, spins
+	toward his death.
+</sd>
+   </scene>
+   <scene n="327">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks nervously about him at the explosive battle.
+</sd>
+   </scene>
+   <scene n="328">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grant Moff Tarkin and a Chief Officer stand in the Death
+	Star's control room.
+</sd>
+      <sp spk="OFFICER"> We've analyzed their attack, sir, and there is a danger.
+Should I have your ship standing by?
+</sp>
+      <sp spk="TARKIN"> Evacuate? In out moment of triumph? I think you overestimate
+their chances!
+		</sp>
+      <sd> Tarkin turns to the computer readout screen. Flames move
+	around the green disk at the center of the screen, as numbers
+	read across the bottom.
+</sd>
+      <sp spk="VOICE">
+         <sd>over speaker</sd> Rebel base, three minutes and closing.
+</sp>
+   </scene>
+   <scene n="329">
+      <sd>INTERIOR: READ LEADER'S COCKPIT.
+	Red Leader looks over at his wingmen.
+</sd>
+      <sp spk="RED LEADER"> Red Group, this is Red Leader.
+</sp>
+   </scene>
+   <scene n="330">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Dodonna moves to the intercom as he fiddles with the computer
+	keys.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over speaker</sd> Rendezvous at mark six point one.
+</sp>
+      <sp spk="WEDGE">
+         <sd>over speaker</sd> This is Red Two. Flying toward you.
+</sp>
+      <sp spk="BIGGS">
+         <sd>over speaker</sd> Red Three, standing by.
+</sp>
+   </scene>
+   <scene n="331">
+      <sd>INTERIOR: RED LEADER'S COCKPIT:
+</sd>
+      <sp spk="DODONNA">
+         <sd>over headset</sd> Red Leader, this is Base One. Keep half your
+group out of range for the next run.
+</sp>
+   </scene>
+   <scene n="332">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED LEADER'S VOICE">
+         <sd>over headset</sd> Copy, Base One. Luke, take Red Two
+and Three. Hold up here and wait for my signal...to start your run.
+		</sp>
+      <sd> Luke nods his head.
+</sd>
+   </scene>
+   <scene n="333">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The X-wing fighters of Luke, Biggs, and Wedge fly in formation
+	high above the Death Star's surface.
+</sd>
+   </scene>
+   <scene n="334">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke peers out from his cockpit.
+</sd>
+   </scene>
+   <scene n="335">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Two X-wings move across the surface of the Death Star. Red
+	Leader's X-wing drops down to the surface leading to the
+	exhaust port.
+</sd>
+   </scene>
+   <scene n="336">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks around to watch for the TIE fighters. He
+	begins to perspire.
+</sd>
+      <sp spk="RED LEADER"> This is it!
+</sp>
+   </scene>
+   <scene n="337">
+      <sd>EXTERIOR: SPACE.
+	Red Leader roams down the trench of the Death Star as lasers
+	streak across the black heavens.
+</sd>
+   </scene>
+   <scene n="338">
+      <sd>EXTERIOR: DEATH STAR SURFACE -- GUN EMPLACEMENTS.
+	A huge remote-control laser cannon fires at the approaching
+	Rebel fighters.
+</sd>
+   </scene>
+   <scene n="339">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The Rebel fighters evade the Imperial laser blasts.
+</sd>
+   </scene>
+   <scene n="340">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten looks around for the Imperial fighters.
+</sd>
+      <sp spk="RED TEN"> We should be able to see it by now.
+</sp>
+   </scene>
+   <scene n="341">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	From the cockpits of the Rebel pilots, the surface of the
+	Death Star streaks by, with Imperial laserfire shooting toward
+	them.
+</sd>
+   </scene>
+   <scene n="342">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Keep your eyes open for those fighters!
+</sp>
+   </scene>
+   <scene n="343">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+</sd>
+      <sp spk="RED TEN"> There's too much interference!
+</sp>
+   </scene>
+   <scene n="344">
+      <sd>EXTERIOR: SPACE -- DEATH STAR TRENCH.
+	Three X-wing fighters move in formation down the Death Star
+	trench.
+</sd>
+      <sp spk="RED TEN'S VOICE"> Red Five, can you see them from where you are?
+</sp>
+   </scene>
+   <scene n="345">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks down at the Death Star surface below.
+</sd>
+      <sp spk="LUKE"> No sign of any...wait!
+</sp>
+   </scene>
+   <scene n="346">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten looks up and sees the Imperial fighters.
+</sd>
+      <sp spk="LUKE">
+         <sd>over headset</sd> Coming in point three five.
+</sp>
+      <sp spk="RED TEN"> I see them.
+</sp>
+   </scene>
+   <scene n="347">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three TIE fighters, Vader flanked by two wingmen, dive in a
+	tight formation. The sun reflects off their dominate solar
+	fins as they loop toward the Death Star's surface.
+</sd>
+   </scene>
+   <scene n="348">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader pulls his targeting device in front of his eyes and
+	makes several adjustments.
+</sd>
+      <sp spk="RED LEADER"> I'm in range.
+</sp>
+   </scene>
+   <scene n="349">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Red Leader's X-wing moves up the Death Star trench.
+</sd>
+   </scene>
+   <scene n="350">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Target's coming up!
+		</sp>
+      <sd> Red Leader looks at his computer target readout screen. He
+	then looks into his targeting device.
+</sd>
+      <sp spk="RED LEADER"> Just hold them off for a few seconds.
+</sp>
+   </scene>
+   <scene n="351">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control lever and dives on the X-wing
+	fighters.
+</sd>
+      <sp spk="VADER"> Close up formation.
+</sp>
+   </scene>
+   <scene n="352">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The three TIE fighters move in formation across the Death Star
+	surface.
+</sd>
+   </scene>
+   <scene n="353">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+		 Red Leader lines up his target on the targeting device
+	cross hairs.
+</sd>
+   </scene>
+   <scene n="354">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader and his wingmen zoom down the trench.
+</sd>
+   </scene>
+   <scene n="355">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader rapidly approaches the two X-wings of Red Ten and Red
+	Twelve. Vader's laser cannon flashes below the view of the
+	front porthole. the X-wings show in the center of Vader's
+	computer screen.
+</sd>
+   </scene>
+   <scene n="356">
+      <sd>EXTERIOR: SPACE.
+	Red Twelve's X-wing fighter is hit by Vader's laserfire, and
+	it explodes into flames against the trench.
+</sd>
+   </scene>
+   <scene n="357">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten works at his controls furiously, trying to avoid
+	Vader's fighter behind him.
+</sd>
+      <sp spk="RED TEN"> You'd better let her loose.
+</sp>
+   </scene>
+   <scene n="358">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader is concentrating on his targeting device.
+</sd>
+      <sp spk="RED LEADER"> Almost there!
+</sp>
+   </scene>
+   <scene n="359">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten panics.
+</sd>
+      <sp spk="RED TEN"> I can't hold them!
+</sp>
+   </scene>
+   <scene n="360">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader and his wingmen whip through the trench in pursuit of
+	the Rebel fighters.
+</sd>
+   </scene>
+   <scene n="361">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader cooly pushes the fire button on his control stick.
+</sd>
+   </scene>
+   <scene n="362">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Darth Vader's well-aimed laserfire proves to be unavoidable,
+	and strikes Red Ten's ship. Red Ten screams in anguish and
+	pain.
+</sd>
+   </scene>
+   <scene n="363">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.  
+	Red Ten's ship explodes and bursts into flames.
+</sd>
+   </scene>
+   <scene n="364">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Grimly, Red Leader takes careful aim and watches his computer
+	targeting device, which shows the target lined up in the cross
+	hairs, and fires.
+</sd>
+   </scene>
+   <scene n="365">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> It's away!
+</sp>
+   </scene>
+   <scene n="366">
+      <sd>INTERIOR: DEATH STAR.   
+	An armed Imperial stormtrooper is knocked to the floor from
+	the attack explosion. Other troopers scurrying about the
+	corridors are knocked against the wall and lose their balance.
+</sd>
+   </scene>
+   <scene n="367">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare at the computer screen.
+</sd>
+      <sp spk="RED NINE'S VOICE">
+         <sd>over speaker</sd> It's a hit!
+</sp>
+      <sp spk="RED LEADER">
+         <sd>over speaker</sd> Negative.
+</sp>
+   </scene>
+   <scene n="368">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks back at the receding Death Star. Tiny
+	explosions are visible in the distance.
+</sd>
+      <sp spk="RED LEADER"> Negative! It didn't go in. It just impacted on the
+surface.
+</sp>
+   </scene>
+   <scene n="369">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR -- TIE FIGHTER.
+	Darth Vader peels off in pursuit as Red Leader's X-wing passes
+	the Death Star horizon.
+</sd>
+   </scene>
+   <scene n="370">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader swings his ship around for the next kill.
+</sd>
+   </scene>
+   <scene n="371">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="LUKE">
+         <sd>over headset</sd> Red Leader, we're right above you. Turn to
+point...
+</sp>
+   </scene>
+   <scene n="372">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke tries to spot Red Leader. He looks down at the Death Star
+	surface.
+</sd>
+      <sp spk="LUKE"> ...oh-five; we'll cover for you.
+</sp>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Stay there...
+</sp>
+   </scene>
+   <scene n="373">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	A wary Red Leader looks about nervously.
+</sd>
+      <sp spk="RED LEADER"> ...I just lost my starboard engine.
+</sp>
+   </scene>
+   <scene n="374">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks excitedly toward Red Leader's X-wing.
+</sd>
+      <sp spk="RED LEADER">
+         <sd>over headset</sd> Get set to make your attack run.
+</sp>
+   </scene>
+   <scene n="375">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's gloved hands make contact with the control sticks, and
+	he presses their firing buttons.
+</sd>
+   </scene>
+   <scene n="376">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader fights to gain control of his ship.
+</sd>
+   </scene>
+   <scene n="377">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Laserbolts are flung from Vader's TIE fighter, connecting with
+	Red Leader's Rebel X-wing fighter. Red Leader buys it,
+	creating a tremendous explosion far below. He screams and is
+	destroyed.
+</sd>
+   </scene>
+   <scene n="378">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks out the window of his X-wing at the explosion far
+	below. For the first time, he feels the helplessness of his
+	situation.
+</sd>
+   </scene>
+   <scene n="379">
+      <sd>INTERIOR: DEATH STAR.
+	Grand Moff Tarkin casts a sinister eye at the computer screen.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, one minute and closing.
+</sp>
+   </scene>
+   <scene n="380">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Dodonna and Princess Leia, with Threepio beside them, listen
+	intently to the talk between the pilots. The room is grim
+	after Red Leader's death. Princess Leia nervously paces the
+	room.
+</sd>
+      <sp spk="LUKE">
+         <sd>over speaker</sd> Biggs, Wedge, let's close it up. We're going in.
+We're going in full throttle.
+</sp>
+   </scene>
+   <scene n="381">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	The horizon twists as Wedge begins to pull out.
+</sd>
+      <sp spk="WEDGE"> Right with you, boss.
+</sp>
+   </scene>
+   <scene n="382">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.  
+	The two X-wings peel off against a background of stars and
+	dive toward the Death Star.
+</sd>
+   </scene>
+   <scene n="383">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+</sd>
+      <sp spk="BIGGS"> Luke, at that speed will you be able to pull out in time?
+</sp>
+   </scene>
+   <scene n="384">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> It'll be just like Beggar's Canyon back home.
+</sp>
+   </scene>
+   <scene n="385">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The three X-wings move in, unleashing a barrage of laserfire.
+	Laserbolts are returned from the Death Star.
+</sd>
+   </scene>
+   <scene n="386">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Luke's lifelong friend struggles with his controls.
+</sd>
+      <sp spk="BIGGS"> We'll stay back far enough to cover you.
+</sp>
+   </scene>
+   <scene n="387">
+      <sd>INTERIOR: LUKE'S COCKPIT.
+	Flak and laserbolts flash outside Luke's cockpit window.
+</sd>
+      <sp spk="WEDGE">
+         <sd>over headset</sd> My scope shows the tower, but I can't see the
+exhaust port! Are you sure the computer can hit it?
+</sp>
+   </scene>
+   <scene n="388">
+      <sd>EXTERIOR: DEATH STAR -- GUN EMPLACEMENTS.
+	The Death Star laser cannon slowly rotates as it shoots
+	laserbolts.
+</sd>
+   </scene>
+   <scene n="389">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks around for the Imperial TIE fighters. He thinks for
+	a moment and then moves his targeting device into position.
+</sd>
+      <sp spk="LUKE"> Watch yourself! Increase speed full throttle!
+</sp>
+   </scene>
+   <scene n="390">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge looks excitedly about for any sign of the TIE fighters.
+</sd>
+      <sp spk="WEDGE"> What about the tower?
+</sp>
+   </scene>
+   <scene n="391">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> You worry about those fighters! I'll worry about the tower!
+</sp>
+   </scene>
+   <scene n="392">
+      <sd>EXTERIOR: DEATH STAR SURFACE.
+	Luke's X-wing streaks through the trench, firing lasers.
+</sd>
+   </scene>
+   <scene n="393">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke breaks into a nervous sweat as the laserfire is returned,
+	knicking one of his wings close to the engine.
+</sd>
+      <sp spk="LUKE">
+         <sd>to Artoo</sd> Artoo...that, that stabilizer's broken loose again!
+See if you can't lock it down!
+</sp>
+   </scene>
+   <scene n="394">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Artoo works to repair the damages. The canyon wall rushes by
+	in the background, making his delicate task seem even more
+	precarious.
+</sd>
+   </scene>
+   <scene n="395">
+      <sd>EXTERIOR: DEATH STAR.
+	Two laser cannons are firing on the Rebel fighters.
+</sd>
+   </scene>
+   <scene n="396">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge looks up and sees the TIE ships.
+</sd>
+   </scene>
+   <scene n="397">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke's targeting device marks off the distance to the target.
+</sd>
+   </scene>
+   <scene n="398">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader and his wingmen zoom closer.
+</sd>
+   </scene>
+   <scene n="399">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his controls and fires laserbolts at two X-wings
+	flying down the trench. He scores a direct hit on Wedge.
+</sd>
+   </scene>
+   <scene n="400">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others are grouped around the computer board.
+</sd>
+      <sp spk="WEDGE">
+         <sd>over speaker</sd> I'm hit! I can't stay with you.
+</sp>
+      <sp spk="LUKE">
+         <sd>over speaker</sd> Get clear, Wedge.
+</sp>
+   </scene>
+   <scene n="401">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> You can't do any more good back there!
+</sp>
+   </scene>
+   <scene n="402">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+</sd>
+      <sp spk="WEDGE"> Sorry!
+</sp>
+   </scene>
+   <scene n="403">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Wedge pulls his crippled X-wing back away from the battle.
+</sd>
+   </scene>
+   <scene n="404">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader watches the escape but issues a command to his wingmen.
+</sd>
+      <sp spk="VADER"> Let him go! Stay on the leader!
+</sp>
+   </scene>
+   <scene n="405">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Luke's X-wing speeds down the trench; the three TIE fighters,
+	still in perfect unbroken formation, tail close behind.
+</sd>
+   </scene>
+   <scene n="406">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs looks around at the TIE fighters. He is worried.
+</sd>
+      <sp spk="BIGGS"> Hurry, Luke, they're coming in much faster this time. I can't
+hold them!
+</sp>
+   </scene>
+   <scene n="407">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The three TIE fighters move ever closer, closing in on Luke
+	and Biggs.
+</sd>
+   </scene>
+   <scene n="408">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks back anxiously at little Artoo.
+</sd>
+      <sp spk="LUKE"> Artoo, try and increase the power!
+</sp>
+   </scene>
+   <scene n="409">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Ignoring the bumpy ride, flak, and lasers, a beeping
+	Artoo-Detoo struggles to increase the power, his dome turning
+	from side to side.
+</sd>
+   </scene>
+   <scene n="410">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Stealthily, the TIE formation creeps closer.
+</sd>
+   </scene>
+   <scene n="411">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control stick.
+</sd>
+   </scene>
+   <scene n="412">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs looks around at the TIE fighters.
+</sd>
+   </scene>
+   <scene n="413">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER.
+	Luke looks into his targeting device. He moves it away for a
+	moment and ponders its use. He looks back into the computer
+	targeter.
+</sd>
+      <sp spk="BIGGS">
+         <sd>over headset</sd> Hurry up, Luke!
+</sp>
+   </scene>
+   <scene n="414">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader and his wingmen race through the Death Star trench.
+	Biggs moves in to cover for Luke, but Vader gains on him.
+</sd>
+   </scene>
+   <scene n="415">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs sees the TIE fighter aiming at him.
+</sd>
+      <sp spk="BIGGS"> Wait!
+</sp>
+   </scene>
+   <scene n="416">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader squeezes the fire button on his controls.
+</sd>
+   </scene>
+   <scene n="417">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs' cockpit explodes around him, lighting him in red.
+</sd>
+   </scene>
+   <scene n="418">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Biggs' ship bursts into a million flaming bits and scatters
+	across the surface.
+</sd>
+   </scene>
+   <scene n="419">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare at the computer board.
+</sd>
+   </scene>
+   <scene n="420">
+      <sd>INTERIOR: LUKE'S X-WING COCKPIT.
+	Luke is stunned by Biggs' death. His eyes are watering, but
+	his anger is also growing.
+</sd>
+   </scene>
+   <scene n="421">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grand Moff Tarkin watches the projected target screen with
+	satisfaction.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, thirty seconds and closing.
+</sp>
+   </scene>
+   <scene n="422">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader takes aim on Luke and talks to the wingmen.
+</sd>
+      <sp spk="VADER"> I'm on the leader.
+</sp>
+   </scene>
+   <scene n="423">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR -- LUKE'S SHIP.
+	Luke's ship streaks through the trench of the Death Star.
+</sd>
+   </scene>
+   <scene n="424">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia returns her general's worried and doubtful
+	glances with solid, grim determination. Threepio seems nervous.
+</sd>
+      <sp spk="THREEPIO"> Hang on, Artoo!
+</sp>
+   </scene>
+   <scene n="425">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke concentrates on his targeting device.
+</sd>
+   </scene>
+   <scene n="426">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three TIE fighters charge away down the trench toward Luke.
+</sd>
+   </scene>
+   <scene n="427">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's finger's curls around the control stick.
+</sd>
+   </scene>
+   <scene n="428">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke adjusts the lens of his targeting device.
+</sd>
+   </scene>
+   <scene n="429">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship charges down the trench.
+</sd>
+   </scene>
+   <scene n="430">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke lines up the yellow cross-hair lines of the targeting
+	device's screen. He looks into the targeting device, then
+	starts at a voice he hears.
+</sd>
+      <sp spk="BEN'S VOICE"> Use the Force, Luke.
+</sp>
+   </scene>
+   <scene n="431">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The Death Star trench zooms by.
+</sd>
+   </scene>
+   <scene n="432">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks up, then starts to look back into the targeting
+	device. He has second thoughts.
+</sd>
+      <sp spk="BEN'S VOICE"> Let go, Luke.
+		</sp>
+      <sd> A grim determination sweeps across Luke's face as he closes
+	his eyes and starts to mumble Ben's training to himself.
+</sd>
+   </scene>
+   <scene n="433">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's fighter streaks through the trench.
+</sd>
+   </scene>
+   <scene n="434">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+</sd>
+      <sp spk="VADER"> The Force is strong with this one!
+</sp>
+   </scene>
+   <scene n="435">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader follows Luke's X-wing down the trench.
+</sd>
+   </scene>
+   <scene n="436">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks to the targeting device, then away as he hears
+	Ben's voice.
+</sd>
+      <sp spk="BEN'S VOICE"> Luke, trust me.
+		</sp>
+      <sd> Luke's hand reaches for the control panel and presses the
+	button. The targeting device moves away.
+</sd>
+   </scene>
+   <scene n="437">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stand watching the projected screen.
+</sd>
+      <sp spk="BASE VOICE">
+         <sd>over speaker</sd> His computer's off. Luke, you switched off
+your targeting computer. What's wrong?
+</sp>
+      <sp spk="LUKE">
+         <sd>over speaker</sd> Nothing. I'm all right.
+</sp>
+   </scene>
+   <scene n="438">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship streaks ever close to the exhaust port.
+</sd>
+   </scene>
+   <scene n="439">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks at the Death Star surface streaking by.
+</sd>
+   </scene>
+   <scene n="440">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Artoo-Detoo turns his head from side to side, beeping in
+	anticipation.
+</sd>
+   </scene>
+   <scene n="441">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters, manned by Vader and his two wingmen,
+	follow Luke's X-wing down the trench.
+</sd>
+   </scene>
+   <scene n="442">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader maneuvers his controls as he looks at his doomed target.
+	He presses the fire buttons on his control sticks. Laserfire
+	shoots toward Luke's X-wing fighter.
+</sd>
+   </scene>
+   <scene n="443">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	A large burst of Vader's laserfire engulfs Artoo. The arms go
+	limp on the smoking little droid as he makes a high-pitched
+	sound.
+</sd>
+   </scene>
+   <scene n="444">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks frantically back over his shoulder at Artoo.
+</sd>
+   </scene>
+   <scene n="445">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Smoke billows out around little Artoo and sparks begin to fly.
+</sd>
+      <sp spk="LUKE"> I've lost Artoo!
+		</sp>
+      <sd> Artoo's beeping sounds die out.
+</sd>
+   </scene>
+   <scene n="446">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare intently at the projected screen,
+	while Threepio watches the Princess. Lights representing the
+	Death Star and targets glow brightly.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE"> The Death Star has cleared the planet. The
+Death Star has cleared the planet.
+</sp>
+   </scene>
+   <scene n="447">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Tarkin glares at the projected target screen.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, in range.
+</sp>
+      <sp spk="TARKIN"> You may fire when ready.
+</sp>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Commence primary ignition.
+		</sp>
+      <sd> An officer reaches up and pushes buttons on the control
+	panel, as green lighted buttons turn to red.
+</sd>
+   </scene>
+   <scene n="448">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters zoom down the Death Star trench in
+	pursuit of Luke, never breaking formation.
+</sd>
+   </scene>
+   <scene n="449">
+      <sd>INTERIOR: LUKE'S COCKPIT.
+	Luke looks anxiously at the exhaust port.
+</sd>
+   </scene>
+   <scene n="450">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control sticks, checking his projected
+	targeting screen.
+</sd>
+   </scene>
+   <scene n="451">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship barrels down the trench.
+</sd>
+   </scene>
+   <scene n="452">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's targeting computer swings around into position. Vader
+	takes careful aim on Luke's X-wing fighter.
+</sd>
+      <sp spk="VADER"> I have you now.
+		</sp>
+      <sd> He pushes the fire buttons.
+</sd>
+   </scene>
+   <scene n="453">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters move in on Luke. As Vader's center
+	fighter unleashes a volley of laserfire, one of the TIE ships
+	at his side is hit and explodes into flame. The two remaining
+	ships continue to move in.
+</sd>
+   </scene>
+   <scene n="454">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks about, wondering whose laserfire destroyed Vader's
+	wingman.
+</sd>
+   </scene>
+   <scene n="455">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader is taken by surprise, and looks out from his cockpit.
+</sd>
+      <sp spk="VADER"> What?
+</sp>
+   </scene>
+   <scene n="456">
+      <sd>INTERIOR: DARTH VADER'S WINGMAN -- COCKPIT.
+	Vader's wingman searches around him trying to locate the
+	unknown attacker.
+</sd>
+   </scene>
+   <scene n="457">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han and Chewbacca grin from ear to ear.
+</sd>
+      <sp spk="HAN">
+         <sd>yelling</sd> Yahoo!
+</sp>
+   </scene>
+   <scene n="458">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The Millennium Falcon heads right at the two TIE fighters.
+	It's a collision course.
+</sd>
+   </scene>
+   <scene n="459">
+      <sd>INTERIOR: WINGMAN'S COCKPIT.
+	The wingman spots the pirateship coming at him and warns the
+	Dark Lord.
+</sd>
+      <sp spk="WINGMAN"> Look out!
+</sp>
+   </scene>
+   <scene n="460">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	Vader's wingman panics at the sight of the oncoming pirate
+	starship and veers radically to one side, colliding with
+	Vader's TIE fighter in the process. Vader's wingman crashes
+	into the side wall of the trench and explodes. Vader's damaged
+	ship spins out of the trench with a damaged wing.
+</sd>
+   </scene>
+   <scene n="461">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader's ship spins out of control with a bent solar fin,
+	heading for deep space.
+</sd>
+   </scene>
+   <scene n="462">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader turns round and round in circles as his ship spins
+	into space.
+</sd>
+   </scene>
+   <scene n="463">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Solo's ship moves in toward the Death Star trench.
+</sd>
+   </scene>
+   <scene n="464">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Solo, smiling, speaks to Luke over his headset mike.
+</sd>
+      <sp spk="HAN">
+         <sd>into mike</sd> You're all clear, kid.
+</sp>
+   </scene>
+   <scene n="465">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others listen to Solo's transmission.
+</sd>
+      <sp spk="HAN">
+         <sd>over speaker</sd> Now let's blow this thing and go home!
+</sp>
+   </scene>
+   <scene n="466">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks up and smiles. He concentrates on the exhaust port,
+	then fires his laser torpedoes.
+</sd>
+   </scene>
+   <scene n="467">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's torpedoes shoot toward the port and seems to simply
+	disappear into the surface and not explode. But the shots do
+	find their mark and have gone into the exhaust port and are
+	heading for the main reactor.
+</sd>
+   </scene>
+   <scene n="468">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke throws his head back in relief.
+</sd>
+   </scene>
+   <scene n="469">
+      <sd>INTERIOR: DEATH STAR.
+	An Imperial soldier runs to the control panel board and pulls
+	the attack lever as the board behind him lights up.
+</sd>
+      <sp spk="INTERCOM VOICE"> Stand by to fire at Rebel base.
+</sp>
+   </scene>
+   <scene n="470">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Two X-wings, a Y-wing, and the pirateship race toward Yavin in
+	the distance.
+</sd>
+   </scene>
+   <scene n="471">
+      <sd>INTERIOR: DEATH STAR.
+	Several Imperial soldiers, flanking a pensive Grand Moff
+	Tarkin, busily push control levers and buttons.
+</sd>
+      <sp spk="INTERCOM VOICE"> Standing by.
+		</sp>
+      <sd> The rumble of a distant explosion begins.
+</sd>
+   </scene>
+   <scene n="472">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The Rebel ships race out of sight, leaving the moon-like Death
+	Star alone against a blanket of stars. Several small flashes
+	appear on the surface. The Death Star bursts into a supernova,
+	creating a spectacular heavenly display.
+</sd>
+   </scene>
+   <scene n="473">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="HAN"> Great shot, kid. That was one in a million.
+</sp>
+   </scene>
+   <scene n="474">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke is at ease, and his eyes are closed.
+</sd>
+      <sp spk="BEN'S VOICE"> Remember, the Force will be with you...always.
+		</sp>
+      <sd> The ship rocks back and forth.
+</sd>
+   </scene>
+   <scene n="475">
+      <sd>EXTERIOR: DARTH VADER'S TIE FIGHTER.
+	Vader's ship spins off into space.
+</sd>
+   </scene>
+   <scene n="476">
+      <sd>EXTERIOR: SPACE.
+	The Rebel ships race toward the fourth moon of Yavin.
+</sd>
+   </scene>
+   <scene n="477">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN HANGAR.
+	Luke climbs out of his starship fighter and is cheered by a
+	throng of ground crew and pilots. Luke climbs down the ladder
+	as they all welcome him with laughter, cheers, and shouting.
+		 Princess Leia rushes toward him.
+</sd>
+      <sp spk="LEIA"> Luke! Luke! Luke!
+		</sp>
+      <sd> She throws her arms around Luke and hugs him as they dance
+	around in a circle. Solo runs in toward Luke and they embrace
+	one another, slapping each other on the back.
+</sd>
+      <sp spk="HAN">
+         <sd>laughing</sd> Hey! Hey!
+</sp>
+      <sp spk="LUKE">
+         <sd>laughing</sd> I knew you'd come back! I just knew it!
+</sp>
+      <sp spk="HAN"> Well, I wasn't gonna let you get all the credit and take all the
+reward.
+		</sp>
+      <sd> Luke and Han look at one another, as Solo playfully shoves
+	at Luke's face. Leia moves in between them.
+</sd>
+      <sp spk="LEIA">
+         <sd>laughing</sd> Hey, I knew there was more to you than money.
+		</sp>
+      <sd> Luke looks toward the ship.
+</sd>
+      <sp spk="LUKE"> Oh, no!</sp>
+      <sd>The fried little Artoo-Detoo is lifted off the back of the
+	fighter and carried off under the worried eyes of Threepio.
+</sd>
+      <sp spk="THREEPIO"> Oh, my! Artoo! Can you hear me? Say something! <sd>to mechanic</sd>
+You can repair him, can't you?
+</sp>
+      <sp spk="TECHNICIAN"> We'll get to work on him right away.
+</sp>
+      <sp spk="THREEPIO"> You must repair him! Sir, if any of my circuits or gears
+will help, I'll gladly donate them.
+</sp>
+      <sp spk="LUKE"> He'll be all right.
+</sp>
+   </scene>
+   <scene n="478">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN THRONE ROOM.
+	Luke, Han, and Chewbacca enter the huge ruins of the main
+	temple. Hundreds of troops are lined up in neat rows. Banners
+	are flying and at the far end stands a vision in white, the
+	beautiful young Senator Leia. Luke and the others solemnly
+	march up the long aisle and kneel before Senator Leia. From
+	one side of the temple marches a shined-up and fully repaired
+	Artoo-Detoo. He waddles up to the group and stands next to an
+	equally pristine Threepio, who is rather awestruck by the
+	whole event. Chewbacca is confused. Dodonna and several other
+	dignitaries sit on the left of the Princess Leia. Leia is
+	dressed in a long white dress and is staggeringly beautiful.
+	She rises and places a gold medallion around Han's neck. He
+	winks at her. She then repeats the ceremony with Luke, who is
+	moved by the event. They turn and face the assembled troops,
+	who all bow before them. Chewbacca growls and Artoo beeps with
+	happiness.</sd>
+							 FADE OUT</scene>
+					 END CREDITS OVER STARS
+							 THE END
+
+</xml>

--- a/scripts/ANHDraftsXML/XMLtransformed/ANHfirstDraft.xml
+++ b/scripts/ANHDraftsXML/XMLtransformed/ANHfirstDraft.xml
@@ -1,0 +1,5712 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>THE STAR WARS</title>
+      <author>BY GEORGE LUCAS</author>
+      <draft>FIRST DRAFT	LUCASFILM LIMITED</draft>
+      <date>JULY 1974</date>
+   </metadata>
+   <body>
+      <scene n="1">
+         <setting>SPACE</setting>
+         <sd>FADE IN:</sd>
+         <sd>A sea of stars is broken by the vast blue surface of 
+	the planet, OGANA. Five small moons slowly drift into 
+	view from the far side of the planet. The main 
+	titles are followed by a roll-up:</sd>
+         <sd>	Until the recent GREAT REBELLION, 
+		the DAI NOGAS were the most feared 
+		warriors in the universe. For one 
+		hundred thousand years, generations 
+		of DAI perfected their art as the 
+		personal bodyguards of the King. 
+		They were the chief architects of 
+		the invincible ROYAL SPACE FORCE, 
+		which expanded the Kings power 
+		across the galaxy, from the celes-
+		tial equator to the farthest stars.</sd>
+         <sd>	Now these legendary warriors are all 
+		but extinct. One by one, they have 
+		been hunted down and destroyed as 
+		enemies of the NEW GALACTIC KINGDOM 
+		by a ferocious and sinister rival 
+		warrior sect, THE LEGIONS OF LETTOW.</sd>
+         <sd>A small silver spacecraft emerges from behind one of 
+	the Ogana moons.  The deadly little fightercraft 
+	speeds past several of the moons, until it finally 
+	goes into orbit around the FOURTH MOON.</sd>
+      </scene>
+      <scene n="2">
+         <setting>VALLEY OF COLORED LAKES- FOURTH MOON - OGANA</setting>
+         <sd>A harsh gale blows across the bleak grey surface of 
+	the Fourth Moon.  The blood red sky presses down on a 
+	lone figure, JUSTIN VALOR, a tall, heavy-set boy of 
+	sixteen.   He slowly makes his way across a wierd 
+	plain covered with huge sprawling lakes.  The water in 
+	some of the lakes is bright red, while in others it is 
+	a vivid green.  The oddly colored lakes create an 
+	ominous landscape against the eerie red sky.</sd>
+         <sd>The heavy winds whip at the young boy and make the 
+	going extremely difficult.  His face is covered by a 
+	breath mask and goggles.  He stops for a second to 
+	adjust the shoulder strap on his chrome multiplelazer 
+	rifle.  Something in the sky catches his eye, and he
+	instinctively grabs a pair of electrobinoculars from 
+	his belt.  He stands transfixed for a few moments, 
+	studying the heavens, then turns and rushes back in 
+	the direction from which he came.</sd>
+      </scene>
+      <scene n="3">
+         <setting>SUPPLY HUT - FOURTH MOON - OGANA</setting>
+         <sd>A damaged spacecraft, half buried in the dust, rests 
+	next to the remains of an abandoned supply shack.  Justin
+	makes his way across the colorless landscape and 
+	rushes into the crumbling building.  The interior of 
+	the hut is shabby, but manages to abate the howling 
+	winds.  Seated in front of a thermoheater are Justin's
+	father, AKIRA, and his young brother, BINK.  Akira is 
+	a large, burly man, wearing the distinctive robes of a 
+	Dai.  Bink is ten years old, with dusty blond hair and 
+	a large scratch on his cheek.  Justin slams the door 
+	and removes his gear.   His ruggedly handsome face is 
+	caked with many layers of dust.</sd>
+         <sp spk="JUSTIN">
+		Dad!  Dad!  They've found us!</sp>
+         <sd>Bink looks up from a small cube he has been studying. 
+	His father whacks him across the shoulder with a 
+	braided wire connector.</sd>
+         <sp spk="AKIRA">
+		Continue with the problem.  Your 
+		concentration is worse than your 
+		brother's.  <sd>to Justin</sd>  How many?</sp>
+         <sp spk="JUSTIN">
+		Only one this time.  A Cao Four.</sp>
+         <sp spk="AKIRA">
+		Good.  We may not have to repair 
+		this old bucket after all.  Pre-
+		pare yourself.</sp>
+         <sp spk="BINK">
+		Me too!</sp>
+         <sp spk="AKIRA">
+		Do you have the answer?</sp>
+         <sp spk="BINK">
+		I think it's the Corbet dictum: 
+		"What is, is without."</sp>
+         <sd>Akira smiles.  This is the correct answer.  Justin is
+	strapping on a utility belt with chrome lazerpistols 
+	and lazersword.  Akira rises and starts for his equip-
+	ment.</sd>
+         <sp spk="BINK (Cont.)">
+		Ahhh, Pop...</sp>
+         <sp spk="AKIRA">
+		Bink, do you feel you're ready?</sp>
+         <sp spk="BINK">
+		Yes, sir.  I've outmarked Justin in 
+		twelve disciplines.  I'm as good...</sp>
+         <sp spk="AKIRA">
+		All right, son.  Get your gear.</sp>
+         <sd>Bink jumps up with the enthusiasm available only to 
+	a ten-year old and grabs his gear.  His father frowns 
+	and shakes his head.</sd>
+      </scene>
+      <scene n="4">
+         <setting>WASTELAND BLUFF - FOURTH MOON - OGANA</setting>
+         <sd>Akira Valor and his two sons carefully make their way
+	up a rock bluff overlooking the Lettow spacecraft parked
+	among the  colored lakes.Akira inspects the  
+	with his electrobinoculars.</sd>
+         <sp spk="AKIRA">
+		No tracks.  Bi-lock hasn't been opened.
+		Interior systems are still on.</sp>
+         <sp spk="JUSTIN">
+		Are we going to wait for him to come 
+		out?</sp>
+         <sp spk="AKIRA">
+		He's not  in there.  He's baiting us. 
+		I'm surprised they only sent one this 
+		time.  We must be wearing them down, 
+		or they must think this warrior is 
+		something special.  Stay on guard, 
+		and keep hidden.  I'm going to work 
+		my way across the ridge and call his 
+		bluff.  Better we meet in open combat 
+		than wait for him to ambush us.  Keep 
+		your guard!</sp>
+         <sd>Akira leaves his two sons and moves off along the 
+	obscured ridge.  Justin and Bink watch him intently. 
+	Justin throws down his multiplelazer rifle in dis-
+	gust.</sd>
+         <sp spk="JUSTIN">
+		He should have let me go with him.  
+		He's getting too old to make an open 
+		challenge.</sp>
+         <sp spk="BINK">
+		He's not too old to realize you'd 
+		just get in the way.</sp>
+         <sd>Justin ignores his little brother's remark and sneaks 
+	a look over the ridge at the Lettow spacecraft.  Akira 
+	moves out of the rocks some distance away and starts 
+	toward the starship.  Bink moves to the ridge next to 
+	his brother, his chrome lazerrifle sparkling in the 
+	reflected red light of Ogana.</sd>
+         <sp spk="BINK">
+		He's making his move.</sp>
+         <sp spk="JUSTIN">
+		Watch your guard... and cover 
+		that weapon.  It shines like a 
+		beacon.</sp>
+         <sd>Bink reluctantly move away and watches the other 
+	direction.  Akira has almost reached the Lettow 
+	spacecraft and still there is no sign of its 
+	occupant.</sd>
+         <sp spk="BINK">
+		What's happening?</sp>
+         <sp spk="JUSTIN">
+		Nothing.  I don't like it.</sp>
+         <sd>Akira carefully moves to the main hatch of the star-
+	ship.  He kicks a valve and the hatch drops open 
+	with a loud clank and rushing gas.  Justin becomes 
+	more tense as his father carefully moves inside the
+	spacecraft.  Everything is still.  Even the continual 
+	winds seem to have died down.  Moments pass with no 
+	sign of activity inside the enemy starship.  Justin 
+	watches the craft with his electrobinoculars.  The 
+	waiting becomes unbearable.</sd>
+         <sp spk="JUSTIN">
+		Something's happened!  He's been in 
+		there too long.</sp>
+         <sp spk="BINK">
+		Let me look!  Stand my guard.</sp>
+         <sd>Bink takes the electrobinoculars from his brother and 
+	studies the silent spacecraft.  Justin impatiently 
+	scans the distant red horizon.</sd>
+         <sp spk="BINK">
+		I think the power just went off. 
+		We'd better wait here until some-
+		one comes out.</sp>
+         <sp spk="JUSTIN">
+		What if he needs help?</sp>
+         <sp spk="BINK">
+		The power went back on again....</sp>
+         <sd>With the aid of the electrobinoculars, Bink watches 
+	the running lights of the starship flash on and off.
+	Suddenly something huge moves in front of his field 
+	of vision.  Before either of the two young boys can 
+	react, a large, sinister Lettow warrior in black 
+	robes and a face mask  looms over them.  He carries 
+	a long lazersword which cuts young Bink down before 
+	he or his brother is able to raise his weapon.  The 
+	startled Justin backs away in horror, then settles 
+	down and ignites his lazersword which creates an 
+	eerie red glow.  He stumbles over rocks as he attempts 
+	to avoid the charging Lettow warrior.  The evil 
+	warrior swings his mighty lazersword, but Justin 
+	manages to deflect the intended deathblow.</sd>
+         <sd>Finally, Justin is able to assume a defensive stance, 
+	and the two warriors stand, sizing up each other.  The 
+	legionnaire is at least seven feet tall, and dwarfs 
+	the young Dai.  They stand for a few moments, almost 
+	frozen, then in a flurry of blows, lazerswords clash 
+	with the sound of electric snapping and popping. 
+	Justin is barely able to hold his own against the 
+	experienced warrior.  Many blows are exchanged before 
+	the Lettow warrior is able to back Justin up against 
+	a deep crevasse.  Justin stumbles and almost falls 
+	over the cliff to his death.</sd>
+         <sd>The legionnaire suddenly senses something behind him 
+	and whirls around to face Justin's father, Akira Valor, 
+	a Dai Nogas master.  The Lettow warrior raises his 
+	lazersword, but is cut in two before he can bring it 
+	down again.  Akira moves to the fallen legionnaire 
+	and studies him carefully.  Justin, still a little 
+	wobbly from the whole experience, attempts to stand. 
+	Akira sees his dead son Bink and goes to him.  He 
+	lifts him into his arms and begins to weep.  Justin 
+	stands bewildered, watching his father cradle the 
+	dead child.</sd>
+      </scene>
+      <scene n="5">
+         <setting>INTERIOR LETTOW STARSHIP - VALLEY OF COLORED LAKES - 
+	OGANA</setting>
+         <sd>Akira Valor slides into one of the four seats of the
+	small Lettow starship.  Through the front viewing 
+	canopy, he watches Justin drag Bink's body to a small
+	crevasse.  Justin places a small locket around his 
+	brother's neck, makes a complicated sign, and dumps 
+	the body into the shallow depression.  The giant 
+	engines of the spacecraft begin to whine, kicking up 
+	large clouds of dust.</sd>
+         <sd>Justin climbs into the seat beside his father and 
+	removes his breath mask and goggles.   There are 
+	tears in his eyes.  Father and son look out across 
+	the wasteland towards Bink's grave.  The thunderous 
+	clap of an explosion is followed by a small mushroom 
+	cloud rising out of the depression.  Justin throws a
+	container down in a fit of rage.</sd>
+         <sp spk="JUSTIN">
+		How many more of them are there?  I 
+		want to finish it, once and for all. 
+		I'm sick of running.  When will it 
+		stop?</sp>
+         <sd>Justin's father waits silently until the tirade is
+	finished.  Justin sits silently for a few moments.</sd>
+         <sp spk="JUSTIN (Cont.)">
+		I'm sorry.</sp>
+         <sp spk="AKIRA">
+		Son, plot a course for TOWNOWI.</sp>
+         <sd>Justin lights up like a Geenick at feeding time.</sd>
+         <sp spk="JUSTIN">
+		Townowi!  You mean we're going home?</sp>
+         <sp spk="AKIRA">
+		We both need a rest.</sp>
+         <sd>Akira pulls back on the throttle and the powerful 
+	spaceship lifts off the surface of the Fourth Moon 
+	of Ogana.</sd>
+      </scene>
+      <scene n="6">
+         <setting>CLOUD SEA - GRANICUS</setting>
+         <sd>A title card appears over a sea of billowing clouds 
+	on the gaseous planet of GRANICUS:</sd>
+         <sd>	Granicus:   Capital of the New 
+		Galactic Empire.</sd>
+         <sd>The towering yellow oxide clouds pass, revealing the 
+	Royal City of Granicus.  The magnificent domed and 
+	gleaming city is perched, mushroom-like, on a tall 
+	spire which disappears deep into the misty surface 
+	of the planet.  The peacefulness of this nebulous 
+	idyll is broken by the increasing wail of ion 
+	engines.  Four sleek stardestroyers from the Royal 
+	Fleet burst out of the huge cumulus range.  The 
+	craft are flying in a tight formation as they bank 
+	steeply, and head toward the royal   capital of the 
+	New Galactic Kingdom.</sd>
+      </scene>
+      <scene n="7">
+         <setting>INTERIOR STARDESTROYER - GRANICUS</setting>
+         <sd>Stardestroyers are two-man spacecraft crammed with
+	sophisticated electronic weaponry.  The pilot and 
+	gunnery officers sit side-by-side surrounded by 
+	lighted readouts and switches.  They wear the gleaming 
+	black uniforms of the Kings elite corps.</sd>
+         <sp spk="PILOT">
+		Tok-One to Chicks:  Shape it up. 
+		Let's make it good.</sp>
+         <sp spk="CHICK-ONE">
+		Does that glare bother you?</sp>
+         <sp spk="PILOT">
+		Use your face shield, Chick-One.</sp>
+         <sd>The pilot is cold and professional as he maneuvers 
+	his craft closer to the others.  The positions of 
+	the ships are displayed on a read-out, along with a 
+	graphic representation of the city.  The pilot gives 
+	the gunner a quick look before he flips his sunshield 
+	over his eyes.</sd>
+         <sp spk="PILOT">
+		Here we go.  Count:  three, two, 
+		one, now!</sp>
+      </scene>
+      <scene n="8">
+         <setting>REVIEW STAND - PLAZA OF THE DONNS - GRANICUS</setting>
+         <sd>On a huge austere platform stands the dark SON HHAT, 
+	Lord of Granicus, Consul to the Supreme Tribunal, and 
+	ruler of the Galactic Kingdom.  He is a thin gray 
+	looking man with an evil mustache hanging limply 
+	over his insidious lip.  Standing at rigid attention 
+	on his right are several generals  dressed in the 
+	black and grey uniform of the realm.  Five members 
+	of the Supreme Tribunal sit off to the side.  On 
+	Hhat's    left stands MARA HORUS, newly appointed 
+	Governor of the Townowi Systems.  He is a young 
+	treacherous man with stone-cut angular features and 
+	piercing gray eyes.</sd>
+         <sd>They all gaze skyward as the four gleaming star-
+	destroyers scream low overhead in an impressive 
+	barrel-roll formation.  As the sound of the space-
+	craft resonates throughout the glass canyon of the 
+	Plaza, the group of dignitaries return their atten-
+	tion to the parade of  royal   shock troops and 
+	giant air tanks (which ride magically, two or three 
+	feet above the ground).</sd>
+         <sd>The Plaza of the Donns is filled with hundreds of rows 
+	of troops as the last brigade marches into position. 
+	The sound of three thousand men snapping to attention 
+	is followed by a strange silence.  A light wind blows 
+	the great red banner of the kingdom creating a subtle
+	flapping sound.  The king's amplified voice startles 
+	many of the troops as it cuts through the quiet.</sd>
+         <sp spk="SON HHAT">
+		Upon this battle depends the survival 
+		of the Galactic Kingdom. Upon this 
+		battle depends the life and long con-
+		tinuity of our civilization.  Not 
+		since the great Dai Rebellion has our 
+		destiny been placed in such a balance. 
+		This is to be the most magnificent 
+		campaign of all!  You have never been 
+		called without doing something to be 
+		remembered, something notable and 
+		striking.  The conquering of the 
+		Townowi System, the last of the inde-
+		pendent systems and the last refuge 
+		of the outlawed, vile sect of the Dai, 
+		will have such important and lasting 
+		consequences, that I can't but consider 
+		it as an epoch in history.</sp>
+         <sd>To the rear of the Plaza, watching the spectacle over 
+	the shoulder of a curious bureaucrat, stands CLIEG OXUS, 
+	a tall, blond young man about twenty years old.  He seems
+	interested in what the  King   has to say, but keeps 
+	looking around nervously as if someone were after him. 
+	His arm rests across his head, as he carefully but coolly
+	adjusts a glowing blue ring on his index finger.  The 
+	King nears the end of his speech.  Mara Horus has moved 
+	up to stand next to the sinister monarch.  The troops 
+	shout a royal salute in response to a particularly 
+	partisan statement.</sd>
+         <sp spk="SON HHAT (Cont.)">
+		... I have personally asked the Townowians 
+		to accept this Treaty of Alliance.  During 
+		the period of negotiation, they have only 
+		decided to be undecided.  We will barter no 
+		longer.  Governor Horus has been appointed 
+		the First Lord of the Townowi System and 
+		Surrounding Territories.  This is the last 
+		frontier and the final stone in the great 
+		wall of the Galactic Kingdom.</sp>
+         <sd>The troops cheer, and the King escorts Horus inside.
+	Oxus moves quickly away from the Plaza, passing through
+	several check stations, where he is forced to show his
+	identification.</sd>
+      </scene>
+      <scene n="9">
+         <setting>NIGHT CLUB - GRANICUS</setting>
+         <sd>Oxus walks into the glass and chrome splendor of one 
+	of the famous nightclubs of Granicus.  He moves to the 
+	long mirrored bar and sits next to a rough looking man, 
+	BOMOJE ESPAA, dressed in the distinctive gold and furs 
+	of the galactic traders.</sd>
+         <sp spk="OXUS">
+		Your glass is empty.</sp>
+         <sd>Oxus speaks into a small intercom on the bar front.</sd>
+         <sp spk="OXUS (Cont.)">
+		A dantic and...</sp>
+         <sd>He looks in Espaa's glass.</sd>
+         <sp spk="ESPAA">
+		No thanks, Clieg.  I've had enough.</sp>
+         <sp spk="OXUS">
+		Just a dantic, then.  Espaa, it's 
+		not like you to refuse a drink. 
+		You're going to give the galactic 
+		traders a bad name.</sp>
+         <sd>A drink appears magically from a small elevator in the 
+	bar.  Oxus takes it, and then places a pen-like trans-
+	mitter he has taken from his pocket next to the inter-
+	com.  It creates a low electronic buzz.</sd>
+      </scene>
+      <scene n="10">
+         <setting>BAR OBSERVATION CENTER - GRANICUS</setting>
+         <sd>A controller sitting in front of a row of monitors taps 
+	his headphones, then flips a switch back and forth a 
+	couple of times.  He is obviously annoyed.</sd>
+         <sp spk="CONTROLLER">
+		Number eighteen is out again.  Give 
+		me a maintenance check.</sp>
+         <sd>The controller yawns and puts his feet up on the control
+	panel.</sd>
+      </scene>
+      <scene n="11">
+         <setting>NIGHTCLUB - GRANICUS</setting>
+         <sd>Espaa leans in close to Oxus.  He is suddenly very serious.</sd>
+         <sp spk="ESPAA">
+		Clieg, we've got problems.  They've 
+		just grounded all spacecraft, in-
+		cluding trade frigates.  Even the 
+		ships under royal registry can't 
+		move.  Something big is up.</sp>
+         <sp spk="OXUS">
+		I'm afraid they're not waiting for 
+		the Alliance Treaty.  They're 
+		already moving against the System. 
+		I've got to get word back.</sp>
+         <sp spk="ESPAA">
+		The chrome companies are protesting 
+		the embargo, but it's going to take 
+		some time.</sp>
+         <sp spk="OXUS">
+		Isn't anything moving?</sp>
+         <sp spk="ESPAA">
+		Military ships, but...</sp>
+         <sd>They are interrupted by a royal officer and several
+	storm troopers.  The officer shouts over the P.A. 
+	system as the troops rush to block the exits.  Oxus 
+	and the galactic trader are tense, but remain cool.</sd>
+         <sp spk="OFFICER">
+		Attention:  All captains and first 
+		officers of Guild Trade frigates 
+		will accompany me to the Ministry 
+		of Transport immediately.</sp>
+         <sd>Espaa gives Oxus a hopeless look as the troops check 
+	their papers, and then take Espaa away.  A small fight 
+	breaks out in the back of the nightclub as one of the 
+	trader captains expresses his dislike of the kingdom. 
+	Oxus slams his glass to the bar in a gesture of hate 
+	and frustration.</sd>
+      </scene>
+      <scene n="12">
+         <setting>GOVERNOR HORUS QUARTERS - GRANICUS</setting>
+         <sd>The large white-on-white executive quarters resound 
+	with the high-pitched laugh of the evil Governor
+	Horus.  He slaps DARTH VADER, a tall, grim looking 
+	general, on the back and the general's mouth makes 
+	the slightest gesture at a smile.</sd>
+         <sp spk="HORUS">
+		Success!  I told you.  We are no 
+		longer under the control of the 
+		GREAT FAMILIES.  We've gained a 
+		true advantage.</sp>
+         <sd>VANTOS COLL, a member of the Supreme Tribunal, and a 
+	man of the grossest dimensions, appears to be a little
+	worried.</sd>
+         <sp spk="COLL">
+		A rather dangerous advantage. 
+		You still have a system to 
+		conquer.</sp>
+         <sp spk="HORUS">
+		But this system will bring us 
+		more scientific wealth than that 
+		of any other house in the 
+		tribunal.  We will easily gain 
+		control of the directorship.</sp>
+         <sp spk="COLL">
+		Don't underestimate the armies of 
+		Townowi.  They're lead by a Dai 
+		warrior.</sp>
+         <sp spk="HORUS">
+		I've told you about Commissioner 
+		Coll, General.  He worries a lot.</sp>
+         <sp spk="VADER">
+		It's a myth that any Dai still exists.</sp>
+         <sp spk="COLL">
+		General Skywalker is no myth.  When 
+		I first arrived at court, he was 
+		the first bodyguard to the King.
+		He lead the Dai Rebellion.</sp>
+         <sp spk="VADER">
+		NGAI THUC lead the Rebellion.</sp>
+         <sp spk="COLL">
+		So the King would have you beieve, 
+		but I was there.</sp>
+         <sp spk="VADER">
+		Then why wasn't he hunted down like 
+		the others?</sp>
+         <sp spk="COLL">
+		Because he is too dangerous, too 
+		clever.  Besides, his presence on 
+		Townowi is still only a rumor.</sp>
+         <sp spk="HORUS">
+		Then why do you believe it?</sp>
+         <sp spk="COLL">
+		Because I knew him.  He's there 
+		all right.  I can sense it.  Mark 
+		my words, Townowi will not be 
+		easily conquered.</sp>
+      </scene>
+      <scene n="13">
+         <setting>COURTYARD - PALACE OF LITE - TOWNOWI</setting>
+         <sd>A low, sleek landspeeder (an auto-like transport which
+	travels a few feet above the ground on a magnetic field) 
+	glides into the courtyard of the palace of Townowi. 
+	The planet, with its bright green sky, is a desert 
+	wilderness;  but the palace is a sparkling oasis, with 
+	low concrete walls and great turrets spilling over with 
+	foliage from rooftop gardens.  The speeder stops before 
+	an enormous shaded corridor.  Fountains line the 
+	beautiful and highly polished  tile  walkway.  Two 
+	young boys, OETA (7) and PUCK (5) are helped out of the 
+	speeder by AMBER, a one-armed bodyguard dressed in the 
+	flowing white robes of the Townowi military.  The two 
+	boys run through the long corridors, yelling and 
+	screaming, their little footsteps echoing throughout 
+	the palace.</sd>
+      </scene>
+      <scene n="14">
+         <setting>LIBRARY - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The palace library is a dim, cool room, projecting an 
+	aura of time-worn comfort and security.  In the 
+	distance, the children can be heard screaming through 
+	the corridors.  KING KAYOS, silver haired but amazingly 
+	youthful under a tanned and leathery face, motions for 
+	one of his aides to shut the partially closed door. 
+	He is in the middle of an emergency meeting of the 
+	Townowi High Senate.  The twelve men sit in overstuffed 
+	chairs, placed in a large circle.  A large, sallow-eyed 
+	galactic trader named AAY ZAVOS, fiddlesnervously with 
+	a small scrap of leather as he speaks.</sd>
+         <sp spk="ZAVOS">
+		My Lord, the chrome companies are with 
+		you in spirit, but you must understand, 
+		they can't openly support you.  Royal 
+		trade restrictions are very unfavorable 
+		and we, of course, favor your indepen-
+		dence.</sp>
+         <sp spk="KAYOS">
+		If there were to be war, would your 
+		frigates still supply us?</sp>
+         <sp spk="ZAVOS">
+		Your bluntness is to be commended. 
+		It could be arranged.</sp>
+         <sd>COUNT SANDAGE, a corrupt noble of the senate, jumps to 
+	his feet in a rage.</sd>
+         <sp spk="SANDAGE">
+		This is nonsense!  We have no choice 
+		but to approve the treaty.  If there 
+		is war, the New Galactic Kingdom will 
+		destroy our entire system with a snap 
+		of the finger.  General Skywalker is 
+		a dreamer if he thinks he can mount 
+		any meaningful resistance, and you're 
+		dreamers if you believe him.  So much 
+		trust in one aged man.  You must see...</sp>
+         <sd>At that moment, all heads turn as someone enters the 
+	room.  It is General Luke Skywalker, Commander of the 
+	Townowi Star Force.  He is a large man, apparently in 
+	his early forties, but actually much older.  Every-
+	one senses the aura of power that radiates from this 
+	great warrior.  Here is a leader:  a Dai general.  He 
+	looks weary, but is still a magnificent looking warrior. 
+	His face, cracked and weathered by exotic climates, is 
+	set off by a close silver beard, and dark, penetrating 
+	eyes.  Sandage is somewhat embarrassed and quietly sits 
+	down.</sd>
+         <sp spk="SKYWALKER">
+		Is there anyone here so naive he 
+		believes the Galactic Kingdom 
+		would even bother negotiating if 
+		they were contemplating destruction 
+		of this system?  Your Excellencies, 
+		this is more than a simple raid on 
+		your resources.  You must reach a 
+		decision.</sp>
+         <sd>MIR NASH, a thin, birdlike senator, turns to General 
+	Skywalker.</sd>
+         <sp spk="NASH">
+		General Skywalker, war is a serious 
+		business... a deadly business.</sp>
+         <sp spk="SKYWALKER">
+		Procrastination is a deadly business, 
+		Senator.  War is my business.  Have 
+		you approved my defense measures?</sp>
+         <sd>The GRANDE MOUFF TARKIN wears the long black robes of 
+	the Townowian religion.  He speaks with a high, 
+	cracking voice.</sd>
+         <sp spk="TARKIN">
+		An actual war with the Galactic Kingdom
+		is still only a remote possibility.  As 
+		a military treatise, your proposal has 
+		certain merits, but in the harsh light 
+		of reality, an attack against the Galac-
+		tic Kingdom appears to be a somewhat 
+		extreme defense.</sp>
+         <sp spk="NASH">
+		You must understand, General, were
+		interested in avoiding a war, not 
+		starting one.</sp>
+         <sp spk="SKYWALKER">
+		There are times when offense makes 
+		the best defense.  If that Alliance 
+		Treaty isn't signed, we will need 
+		all the advantage we can get.</sp>
+         <sp spk="KAYOS">
+		Count Sandage, I want you to head 
+		the delegation to Granicus.  You 
+		will leave tomorrow with our answer 
+		regarding the treaty.  My decision 
+		will be forthcoming.</sp>
+         <sd>The senators whisper among themselves.</sd>
+         <sp spk="KAYOS (Cont.)">
+		All right, then.  May the force 
+		of others be with you all.</sp>
+         <sd>The senators leave in a flurry of hushed conversation. 
+	The general is lost in thought, and remains in his chair. 
+	Oeta and Puck, King Kayos two young sons, storm through 
+	the existing senators, and rush on to Kayos' lap.  The 
+	King is obviously very proud of the two young princes. 
+	He throws Oeta into the air, and then catches him again.</sd>
+         <sp spk="PUCK">
+		Me too! Me too!</sp>
+         <sp spk="OETA">
+		Zara's leaving!  Zara's leaving and 
+		you gotta say good-bye.</sp>
+         <sd>The King picks up Puck and swings him around, then puts 
+	him down.</sd>
+         <sp spk="KAYOS">
+		Okay, whippersnapper, go tell your 
+		mother and your sister that I'm on 
+		my way.</sp>
+         <sd>The two boys run out of the room and are heard yelling 
+	and screaming down the hallway. The king starts out, but
+	stops in front of the general.</sd>
+         <sp spk="KAYOS">
+		Luke, my daughter is leaving for the 
+		academy at Chathos. Won't you come 
+		and wish her well?  It would mean a 
+		lot to her.  She truly idolizes you, 
+		you know.  Come on, the war will 
+		wait.</sp>
+         <sp spk="SKYWALKER">
+		Of course. I'm sorry, My Lord. 
+		Politics always seem to distress me.</sp>
+         <sd>General Skywalker rises, and as they head for the door, 
+	Kayos pats him on the back.</sd>
+         <sp spk="KAYOS">
+		I know, Luke.  I feel THE FORCE also.</sp>
+      </scene>
+      <scene n="15">
+         <setting>COURTYARD - PALACE OF LITE - TWONOWI</setting>
+         <sd>A large, four-seat speeder sits gleaming in the sun-
+	soaked courtyard.  The PRINCESS ZARA, about fourteen 
+	years old, possessing a soft beauty and iron will, is
+	embracing her mother, QUEEN BREHA, a warm, silver-
+	haired matron.  There are tears in the princess' blue 
+	eyes.  Oeta and Puck jump around inside the speeder, 
+	disrupting the efforts of the one-armed Amber to pack 
+	several plaxiform cases.</sd>
+         <sd>Zara embraces the King as he approaches with the 
+	general.</sd>
+         <sp spk="ZARA">
+		Oh, Daddy, I'll miss you so.</sp>
+         <sp spk="KAYOS">
+		The semester will be over before you 
+		know it.  You'll have a grand time. 
+		There are so many new things to learn. 
+		I wish I were going.
+	He gives her a fatherly smile, and she hugs him again. 
+	The general stands rather formally to one side.  The 
+	princess, her long auburn hair tied in braids, moves 
+	to the general and he bows before her.</sp>
+         <sp spk="SKYWALKER">
+		May your studies do you honor.</sp>
+         <sd>Zara is somewhat embarrassed by the general's formality 
+	and can only manage an awkward smile before returning 
+	to her parents at the speeder.</sd>
+         <sp spk="BREHA">
+		Hurry, Zara.  You must make it to 
+		Yuell before nightfall.</sp>
+         <sd>The princess' maids-in-waiting, ALANA, a short stocky 
+	girl, and MINA, more comely (somewhat that same stature 
+	as Zara) with long dark hair, giggle and straighten 
+	Zara's dress before she enters the speeder.  The prin-
+	cess and Mina hug Alana, whose giggles have turned to 
+	tears.  The two boys scramble out of the speeder as 
+	Amber helps the princess and her maid into the back 
+	seat.  The speeder is piloted by a trooper of the 
+	first order.  Amber jumps into the seat beside him, 
+	and the speeder starts with a low buzzing sound.  The 
+	princess waves to her family, and Mina waves to Alana 
+	as the speeder slowly glides out of the courtyard.</sd>
+      </scene>
+      <scene n="16">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The huge war room is a mass of glass enclosures, 
+	electronic wall displays, monitors, and computer 
+	stations.  General Skywalker enters a control station, 
+	followed by a covey of military aides of various ranks. 
+	As the group hurry through the crowded room, men rise 
+	and salute the new arrivals.  The general stops before 
+	a giant display of the galaxy.  Small symbols flash on 
+	and off over various portions of the big board.  The 
+	general studies it intently.</sd>
+         <sp spk="SKYWALKER">
+		Montross!</sp>
+         <sd>CAPTAIN MONTROSS, one of the general's aides, snaps to
+	attention.</sd>
+         <sp spk="MONTROSS">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		What's the TQ on this?</sp>
+         <sp spk="MONTROSS">
+		The last frigate to leave Granicus 
+		was at twenty-three forty, Sir.</sp>
+         <sp spk="SKYWALKER">
+		Have any ships at all left the 
+		planet?  <sd>to another aide</sd>  Check 
+		with the Guild on NORTON THREE.</sp>
+         <sp spk="MONTROSS">
+		At twenty-four hundred, a full 
+		battalion of stardestroyers left 
+		for what is projected to be 
+		ANCHORHEAD, or a nearby system.</sp>
+         <sp spk="SKYWALKER">
+		And no word from Oxus.  He should 
+		have reported by now.  CAPTAIN PRUE!</sp>
+         <sd>An older, academic looking aide, steps forward.</sd>
+         <sp spk="PRUE">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		What do you make of this?</sp>
+         <sp spk="PRUE">
+		A battalion is invasion force, but the 
+		Royal Galactic Kingdom controls that 
+		entire part of the galaxy.  A revolution, 
+		maybe?  At any rate, they're going in the 
+		wrong direction to be any trouble for us.</sp>
+         <sd>The general ponders this for a few moments, then speaks
+	almost to himself.</sd>
+         <sp spk="SKYWALKER">
+		I don't know.  It doesn't feel good.</sp>
+         <sp spk="MONTROSS">
+		Put 'em on alert.</sp>
+         <sd>A loud uproar is heard on the far side of the war room.
+	Everyone turns to see a foreign dressed warrior pushing 
+	his way past several guards and war-room bureaucrats. 
+	The warrior, with his long hair tied in an odd bun on 
+	the top of his head, is Akira Valor.  He is followed by 
+	his son, Justin, who rudely pushes the pesky bureaucrats 
+	out of the way.</sd>
+         <sp spk="BUREAUCRATS">
+		It's restricted.  You'll have to 
+		wait.  <sd>etc.</sd>
+         </sp>
+         <sp spk="AKIRA">
+		Get out of my way, boy, before I 
+		grind you into the surface. <sd>etc.</sd>
+         </sp>
+         <sd>As the dauntless Akira approaches the general, the guards
+	stop in bewilderment as General Skywalker rushes up to 
+	the warrior and embraces him.  The two Dai warriors 
+	laugh jubilantly and slap one another, as the aides and
+	bureaucrats look on in amazement.</sd>
+         <sp spk="SKYWALKER">
+		Akira Valor - you old muscle-rat! 
+		What a sight!  We heard that you 
+		had been executed.</sp>
+         <sp spk="AKIRA">
+		So the Galactic Kingdom would have 
+		you believe.  I've been in the 
+		KESSIL System.  You remember little 
+		Justin.</sp>
+         <sd>Akira puts his arms around his son, who has been making 
+	eyes at one of the cute young female aides. He bows 
+	before the general.</sd>
+         <sp spk="SKYWALKER">
+		He takes after his mother!  <sd>they laugh</sd>  
+		It's so good to see you.</sp>
+         <sp spk="AKIRA">
+		It's wonderful to be with another 
+		Dai again.  There are so few of us 
+		left.</sp>
+         <sd>The cute aide goes back to her duties, flirting with 
+	Justin as she passes.  The young warrior pinches her 
+	on the ass, which startles her, but she goes on like 
+	nothing has happened.</sd>
+         <sp spk="SKYWALKER">
+		What a sight!</sp>
+         <sd>The two Dai stand looking at one another, hardly believing
+	the other is real.  Finally, the general realizes his 
+	aides are standing around, gawking at the duo.</sd>
+         <sp spk="SKYWALKER (to the aides)">
+		Wake up, gentlemen.  You're on alert. 
+		Keep me posted on that battalion.</sp>
+      </scene>
+      <scene n="17">
+         <setting>CONTROL STATION - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general, Akira and Justin enter a small glass enclosed
+	control office.  They sit, and an awkward silence ensues 
+	as each man waits for the other to speak.</sd>
+         <sp spk="AKIRA">
+		I've come for your help.</sp>
+         <sp spk="SKYWALKER">
+		Anything you ask.  You're a Dai 
+		brother.  We're one.</sp>
+         <sp spk="AKIRA">
+		My friend, we've been through much 
+		together.  I've been through much 
+		since we parted.  I've lost much. 
+		The Legions of Lettow have chased 
+		us half way across the galaxy.  There 
+		is no refuge.  One day they will come 
+		here.  Take my son as your JUWO 
+		learner.  He would be a Dai.  I've
+		trained him from birth.  He's reached 
+		the fifth stage. He fought in the 
+		Kessilian civil wars and commanded a 
+		Hubble expedition to the CONE Systems. 
+		He's a good boy, Luke, and one hell 
+		of a fighter.</sp>
+         <sd>The general looks down, somewhat embarrassed. He scratches
+	his head, then smiles.</sd>
+         <sp spk="SKYWALKER">
+		Old friend, you do me too much honor. 
+		I was never a match for you.  Why don't 
+		you finish his training yourself?</sp>
+         <sp spk="AKIRA">
+		I'm too old, Luke. I can't go on. 
+		You must finish it.</sp>
+         <sp spk="SKYWALKER">
+		What kind of talk is this?  You're 
+		not the old Valor I remember.  Too 
+		old?!?</sp>
+         <sd>Akira Valor suddenly ignites in a rage and swings 
+	his left forearm down with a mighty blow across the 
+	solid chrome desk the general is sitting at.  The 
+	old Dai warrior's forearm cracks in two, spewing forth 
+	wires  and many fine multicolored electronic components. 
+	The artificial limb flops lifelessly to Valor's side. 
+	The warrior rips open his tunic, revealing a plastic 
+	chest stuffed with flashing electronic parts.</sd>
+         <sp spk="AKIRA (angrily)">
+		I'm not the same.  There is nothing 
+		left but my head and right arm.  I've 
+		lost too much, Luke.  I'm dying.</sp>
+         <sd>The general bows his head in sorrow for one of the 
+	greatest warriors in the galaxy and a dear friend.</sd>
+         <sp spk="SKYWALKER">
+		I'm sorry...</sp>
+         <sp spk="AKIRA">
+		I'm sorry.  I keep losing control. 
+		I'm very tired.  Take my son!  The DAI 
+		NOGAS must survive.  We must pass it 
+		on.  Only a Dai can stop Son Hhat. 
+		We're very old, Luke.  A new 
+		generation of Dai must be started. 
+		Take him;  teach him the way of 
+		the Dai Nogas.</sp>
+         <sd>Captain Montross bursts into the office and somewhat
+	excitedly salutes the general.</sd>
+         <sp spk="MONTROSS">
+		Sir, we have picked up something! 
+		An asteroid, or solid comet moving 
+		away from the Anchorhead System.</sp>
+      </scene>
+      <scene n="18">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general rushes out of the control station and back 
+	to the giant galactic display.  He is followed by 
+	Montross, Akira and Justin.</sd>
+         <sp spk="SKYWALKER">
+		Are you sure it's not the battalion?</sp>
+         <sp spk="MONTROSS">
+		A solid object.  It's as big as our 
+		Third Moon.</sp>
+         <sp spk="PRUE">
+		It's too large to be man-made, and it's 
+		too slow to be a comet.</sp>
+         <sp spk="SKYWALKER">
+		Analysis?</sp>
+         <sp spk="MONTROSS">
+		It's too far out.</sp>
+         <sp spk="SKYWALKER">
+		I'll be with the king.  Report as soon 
+		as you can get a reading on it.  (turning 
+		to Akira's son)  Captain Valor, from now 
+		on you stick close to me.</sp>
+         <sd>The older Valor smiles, and puts his good arm around 
+	his old friend.</sd>
+      </scene>
+      <scene n="19">
+         <setting>DINING CHAMBER - PALACE OF LITE - TOWNOWI</setting>
+         <sd>King Kayos moves his arm around Breha's waist as they 
+	stand on a balcony watching two giant twin suns in the 
+	green sky disappear behind a distant dune range.  The 
+	general enters, rather in a rush, followed by the 
+	young Valor, who is now dressed in the white uniform of 
+	the Townowi star force.  (He still wears the distinctive
+	Kessilian hair knot.)  They bow before the King.</sd>
+         <sp spk="KAYOS (pointing to the suns)">
+		Aren't they beautiful, General? 
+		"Always and never the same." 
+		You're just in time for dinner.</sp>
+         <sp spk="SKYWALKER">
+		I have come for other reasons.  
+		Could...?</sp>
+         <sp spk="KAYOS">
+		Relax, General.  We will discuss it, 
+		but over dinner.  There are times, 
+		Luke, when I find you a bit too rigid. 
+		Is this your new disciple?</sp>
+         <sd>Justin is ill at ease and bows again.</sd>
+         <sp spk="JUSTIN">
+		Justin Valor, sir.</sp>
+         <sp spk="KAYOS">
+		Where's your father?</sp>
+         <sp spk="SKYWALKER">
+		He left for the spaceport at GORDON 
+		to visit an old friend, Han Solo, 
+		the UREALLIAN.</sp>
+         <sp spk="KAYOS">
+		We are becoming quite a refuge.</sp>
+         <sd>The group sit at a large table and food is brought in by
+	servants.  They eat.  Justin is nervous and watches the
+	general, to make sure he is being proper.</sd>
+         <sp spk="SKYWALKER">
+		My Lord, several events have occurred 
+		which lead me to believe we are in 
+		imminent danger of attack.  There is 
+		no longer time for discussion and debate.</sp>
+         <sp spk="KAYOS">
+		What events?</sp>
+         <sp spk="SKYWALKER">
+		Oxus, our best agent, has disappeared 
+		in the galactic capital. There is 
+		unusual military traffic in the S-4 
+		sectors.</sp>
+         <sp spk="KAYOS">
+		Unless you have direct, concrete proof 
+		of a pending attack, there is nothing 
+		I can do.</sp>
+         <sp spk="SKYWALKER">
+		By the time we have proof, it may be 
+		too late.</sp>
+         <sp spk="KAYOS">
+		Luke, I'm leaving tonight for AMSEL. 
+		I'm meeting with the full assembly 
+		first thing in the morning.  I am not 
+		going to approve the Alliance Treaty, 
+		and I will get your defense measure 
+		approved.  Just be patient.  You will 
+		have the war code.</sp>
+         <sp spk="SKYWALKER">
+		Tomorrow may be too late.  My Lord, 
+		I need the war code now.  We must 
+		get our forces into space.</sp>
+         <sp spk="KAYOS">
+		But it must be done legally, with 
+		everyone's approval.  Tomorrow you 
+		will have that.  I doubt the New 
+		Galactic Kingdom would attack before 
+		receiving our answer.  The separation 
+		of war powers is the one condition 
+		upon which you assumed command of our 
+		forces.  You're a friend, Luke, and  
+		I trust you;  but you're also an out-
+		lander who controls a great deal of 
+		power.  I can't forsake my oath any 
+		more than you can.  Just be patient. 
+		You will have the code tomorrow.</sp>
+         <sd>Captain Montross enters the large chamber and bows before 
+	the King.</sd>
+         <sp spk="MONTROSS">
+		I bring a report to General Skywalker, 
+		My Lord.</sp>
+         <sp spk="KAYOS">
+		You may deliver it.</sp>
+         <sp spk="MONTROSS">
+		Sir, the asteroid has disappeared from 
+		our scopes.  There is no trace of it.</sp>
+         <sp spk="SKYWALKER">
+		Were they able to analyze it?</sp>
+         <sp spk="MONTROSS">
+		It never came within range, sir.</sp>
+         <sd>The general rises, quickly followed by Captain Valor.</sd>
+         <sp spk="GENERAL">
+		Excuse us, My Lord.  We'd better 
+		get back.  I will wait patiently 
+		for the approval.</sp>
+         <sd>The general and Montross exit the chamber.  Valor takes 
+	one last bite of his dinner, then dashes after his mentor.</sd>
+      </scene>
+      <scene n="20">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general sits rigidly  facing the big galactic display
+	board.  Several aides and bureaucrats rush to and fro,
+	ignoring the general.  He is asleep.  Captain Prue 
+	approaches the general and snaps to attention.  The 
+	general's eyes open.</sd>
+         <sp spk="SKYWALKER">
+		What are the results?</sp>
+         <sp spk="PRUE">
+		Negative, Sir.</sp>
+         <sp spk="SKYWALKER">
+		Are you sure?</sp>
+         <sp spk="PRUE">
+		Absolutely.</sp>
+         <sp spk="SKYWALKER">
+		It's just not possible.  Something 
+		that size can't just disappear with-
+		out a trace.  Check it again.</sp>
+         <sp spk="PRUE">
+		That's the tenth negative, Sir.</sp>
+         <sp spk="SKYWALKER">
+		I said check it again.</sp>
+         <sd>Captain Prue retreats to a computer station. The general
+	looks around for Captain Valor.</sd>
+         <sp spk="SKYWALKER">
+		Valor!</sp>
+         <sd>Everyone near the general turns, but Valor doesn't show.</sd>
+         <sp spk="SKYWALKER">
+		Where is that boy?  Montross!</sp>
+         <sd>Montross rushes up to the general and snaps to attention.</sd>
+         <sp spk="SKYWALKER">
+		Page Captain Valor.</sp>
+         <sd>Montross goes back to his station and a few moments later,
+	Captain Valor is paged over the P.A. system.  The general
+	waits, watching the big board.  Eventually, Justin stumbles
+	out of an enclosed computer closet, fastening his pants and
+	tucking in his tunic.  A moment later, the cute female aide
+	rather sheepishly exits the computer closet.  She also is 
+	in the process of putting her uniform back together.  Justin
+	rushes up to the general and snaps to attention.</sd>
+         <sd>The general lets him stand there for a moment, not acknow-
+	ledging his presence;  then, suddenly without warning and 
+	in one masterful flash motion, the general stands, grabs 
+	a small baton attached to his belt (which immediately 
+	ignites into a four-foot glowing lazersword) and swings 
+	at the young warrior's head.  In an equally quick movement,
+	Justin ignites his lazersword and blocks the general's 
+	blow.  Everyone in the war room is surprised and startled.
+	After a moment, they rush to the general.  Justin and the
+	general stand motionless for a few moments, with lazer-
+	swords locked in mid-air.  Finally, the general grins and Justin
+	hesitantly relaxes.  They lower their swords and turn them off.</sd>
+         <sp spk="SKYWALKER">
+		You are trained well, but remember, 
+		a Dai must be single-minded, a 
+		discipline your father obviously 
+		never learned, hence your existence.
+		Clean yourself up.  Discipline is 
+		essential.  Your mind must follow 
+		the way of the Nogas.</sp>
+         <sp spk="JUSTIN">
+		It won't happen again, sir.  There 
+		are many new....</sp>
+         <sd>			 P.A.
+		General Skywalker, white com.</sd>
+         <sd>The general moves to a control station and picks up a phone.</sd>
+         <sp spk="PHONE VOICE">
+		Sir, Captain Oxus has just been 
+		admitted to Med Vac.</sp>
+         <sp spk="SKYWALKER">
+		What's his condition?</sp>
+         <sp spk="PHONE VOICE">
+		No data, sir.</sp>
+         <sp spk="SKYWALKER">
+		I'm on my way.</sp>
+      </scene>
+      <scene n="21">
+         <setting>MED VAC EMERGENCY ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor waits in an outer chamber as General Sky-
+	walker rushes into the Med Vac emergency room where
+	several doctors are working on the prostrate Oxus.</sd>
+         <sp spk="SKYWALKER">
+		What's his condition?  Is 
+		he conscious?</sp>
+         <sp spk="DOCTOR">
+		Partially.  He'll be all right - 
+		a few bruises, primary exhaustion...</sp>
+         <sd>Oxus thrashes around in a semi-conscious state.  He sees 
+	the general.</sd>
+         <sp spk="SKYWALKER">
+		What happened, boy?  What's going on?</sp>
+         <sp spk="OXUS (with difficulty)">
+		The Royal Starforce is already on its 
+		way, not far behind me.  They're going 
+		to attack.</sp>
+         <sp spk="SKYWALKER">
+		Are you sure?</sp>
+         <sp spk="OXUS">
+		I have tapes.  A giant space fortress...</sp>
+         <sd>He struggles to give General Skywalker his ring.</sd>
+         <sp spk="SKYWALKER">
+		As big as our Third Moon?</sp>
+         <sp spk="OXUS">
+		Bigger.  It's unlike anything 
+		I've ever seen.  Sophisticated 
+		deflection systems - works in 
+		opposition to the suns.</sp>
+         <sp spk="SKYWALKER">
+		Then they will show up on our 
+		screens at sunrise.  They'll 
+		attack before that.</sp>
+         <sd>The general rushes into the outer chamber where Captain
+	Valor is waiting for him.</sd>
+         <sp spk="SKYWALKER">
+		Take the fastest landspeeder to 
+		Chathos.  Pick up Princess Zara -
+		and only Princess Zara.  Return by 
+		way of the Great Reef.  Most speed.</sp>
+         <sd>Valor exits and the general goes to an intercom and
+	pushes several buttons.</sd>
+         <sp spk="SKYWALKER">
+		Montross!</sp>
+         <sp spk="MONTROSS">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		Full alert - everything!  Get the 
+		Royal Family back here.</sp>
+         <sp spk="MONTROSS">
+		The princess is at Chathos.  There 
+		are no transports...</sp>
+         <sp spk="SKYWALKER">
+		I've already sent Captain Valor for 
+		her!  Contact the King, first priority. 
+		He's probably still en route to Amsel.  
+		Use the scan com.  I'm on my way.</sp>
+      </scene>
+      <scene n="22">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The war room is on full alert.  Everyone is at attention
+	waiting for the command that will put each of them into 
+	action.  The general enters a communication center, 
+	followed by many aides.  Captain Montross and the com 
+	aide salute.</sd>
+         <sp spk="MONTROSS">
+		We're having a problem getting 
+		through, sir.  There is a great 
+		deal of interference.</sp>
+         <sp spk="PRUE">
+		It could be jamming.</sp>
+         <sp spk="SKYWALKER">
+		Try a surface link through Amsel.</sp>
+         <sd>The aides go back to the com-link system to try to get a 
+	line through to the King.</sd>
+         <sp spk="PRUE">
+		We should be able to spot them at 
+		sunrise.  That's not too far off.</sp>
+         <sp spk="SKYWALKER">
+		They'll attack with sunrise.  Until 
+		the King gives us the code to start 
+		the war computers, we'll just have 
+		to sit tight.</sp>
+         <sp spk="PRUE">
+		All units are on alert, sir.</sp>
+         <sp spk="SKYWALKER (to Montross)">
+		Have you made contact yet?  <sd>to himself</sd>  
+		This is one hell of a way to run a war.</sp>
+         <sp spk="PRUE">
+		Sir?</sp>
+      </scene>
+      <scene n="23">
+         <setting>COURTYARD - ACADEMY OF CHATHOS - TOWNOWI</setting>
+         <sd>A landspeeder roars into a courtyard of the academy at
+	Chathos.  Valor jumps out, and runs up to the large,
+	heavy doors of the academy.  They are locked.  He 
+	bangs madly on the carved metallic door until finally 
+	an old woman manages to swing it open.  Valor rushes 
+	past her into the main courtyard, where Princess Zara 
+	and her handmaiden, Mina, struggle with two large cases. 
+	They are followed by two very old matrons, dragging 
+	several more cases.</sd>
+         <sp spk="JUSTIN">
+		Forget the cases;  we've no time.</sp>
+         <sp spk="ZARA">
+		These are my things.  They must...</sp>
+         <sp spk="JUSTIN">
+		I said forget them, and hurry.</sp>
+         <sp spk="ZARA">
+		Just who do you think you are?</sp>
+         <sd>Valor grabs the princess by the arm, and hauls her to the
+	speeder.  Mina and the old women run after them.</sd>
+         <sp spk="ZARA">
+		I will not be treated like this!  You 
+		bring my things.  My father will have 
+		your head <sd>etc.</sd>
+         </sp>
+         <sd>Zara struggles to break away from the young warrior's grasp, 
+	as he opens the door of the speeder.</sd>
+         <sp spk="JUSTIN">
+		Settle down!</sp>
+         <sd>When the door to the speeder is opened, Mina starts in, 
+	and Valor stops her.</sd>
+         <sp spk="JUSTIN">
+		You must stay.  Here, take the crest.</sp>
+         <sd>Captain Valor rips the royal crest from the princess' 
+	neck, and hands it to the startled handmaiden.  The old 
+	women gasp in horror.  The princess starts hitting 
+	Captain Valor with little result.</sd>
+         <sp spk="PRINCESS">
+		Mina's not staying.  I'm not leaving 
+		her.  You can't...</sp>
+         <sd>Valor punches her square on the jaw and knocks her cold. 
+	Mina is panic stricken, one of the old women faints, and 
+	another starts for Valor with a large staff.</sd>
+         <sp spk="JUSTIN">
+		She'll be all right.  I'm taking her 
+		to safety, as ordered.  You will wear 
+		the crest and continue as before.</sp>
+         <sd>The authority of Captain Valor's voice stops the old lady.  
+	He places the princess into the speeder, and maneuvers it 
+	out of the courtyard.  Mina puts on the crest as the speeder
+	races away from the academy.</sd>
+      </scene>
+      <scene n="24">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Queen Breha, Oeta and Puck are escorted into a rest area 
+	of the war room.  General Skywalker sits rigidly in a chair 
+	in the communications area, apparently asleep.</sd>
+         <sp spk="MONTROSS">
+		We've made contact, sir!</sp>
+         <sd>The general opens his eyes and takes the intercom mike.</sd>
+         <sp spk="KAYOS">
+		What is it, General?</sp>
+         <sp spk="SKYWALKER">
+		The Royal Starforce will attack on the 
+		rising of the sun.  My agent made it 
+		back.  I now have proof.  I need the 
+		war code.</sp>
+         <sp spk="KAYOS">
+		I'll relay it directly to the computer. 
+		Is Breha...?</sp>
+         <sp spk="SKYWALKER">
+		The Royal Family is safe.  Captain 
+		Valor has gone after Princess Zara.</sp>
+         <sp spk="KAYOS">
+		I'm on my way back.</sp>
+      </scene>
+      <scene n="25">
+         <setting>RED PLAINS - TOWNOWI</setting>
+         <sd>The small caravan of four speeders sits motionless on the 
+	vast red plains of Townowi.  The King returns the intercom 
+	to the pilot and takes a small metallic card from around 
+	his neck and gives it to the co-pilot.</sd>
+         <sp spk="KAYOS">
+		Send this sub-land, priority one.  
+		<sd>to the pilot</sd>  Get us back to 
+		CALVAS immediately!</sp>
+         <sd>The four speeders turn around and scream away in the
+	direction from which they came.   They pass a huge, ultra-
+	sleek powerplow which is planting green fungus in endless
+	furrows.  Two clay-covered farmers riding atop the pon-
+	derous machine watch the speeders disappear over the 
+	horizon.  The twin suns peek over the distant hillside. 
+	and make their way into the vivid green sky.  A bright 
+	object twinkling in early morning heavens  catches the 
+	eye of the older of the two farmers  and he brings the 
+	machine to a lumbering halt.  The younger farmer also 
+	notices the object  and stares into the green sky, shading 
+	his eyes to get a better view.</sd>
+         <sd>Suddenly there is a huge, bright atomic flash on the 
+	horizon.  A few moments later, a thunderous shaking, 
+	followed by high winds, tumbles the older farmer from his
+	perch.  A second flash on the opposite horizon brings 
+	another jolting earthquake, and the younger farmer col-
+	lapses, terror frozen on his face.</sd>
+      </scene>
+      <scene n="26">
+         <setting>READYROOM - SPACEPORT OUTPOST - TOWNOWI</setting>
+         <sd>Chaos - red scramble lights are flashing.  Alert horns 
+	and attack buzzers create an unbelievable cacophony. 
+	Air warriors, with the distinctive circle and cross 
+	medallion on their white space suits, scramble out of 
+	the low concrete readyroom, grabbing helmets and space-
+	packs as they race out of the door.</sd>
+      </scene>
+      <scene n="27">
+         <setting>ATTACK RUNWAY - SPACEPORT OUTPOST - TOWNOWI</setting>
+         <sd>Thirty pilots and navigators dash in unison to a line of
+	waiting two-man starships of the destroyer class.  Ground
+	crews scurry back and forth, loading last-minute armament
+	and unlocking power couplings.  PILOT LEADER, a rugged,
+	handsome boy  of twenty, gives his ground crew a signal 
+	that his is okay.  He has a winning smile and a distinctive 
+	scar along the side of his face.  His crew chief pats him 
+	on the back.</sd>
+         <sp spk="CHIEF">
+		Knock them all the way back to 
+		Granicus.</sp>
+         <sd>The canopy is closed and the powerful starship moves 
+	onto the runway.  Other crewmen say good-bye to their 
+	pilots, some grinning and others kidding - all with a 
+	great deal of hidden emotion.  The din of four dozen
+	retrorockets cuts through the uproar, and fifteen 
+	silver spacecraft leave the runway and disappear into 
+	the morning cloud cover.</sd>
+      </scene>
+      <scene n="28">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general stands before a giant display of the 
+	Townowian solar system.  Montross signals the general.</sd>
+         <sp spk="MONTROSS">
+		They're away, sir.  Fifteen from 
+		Gordon, twenty from Amsel.  All 
+		other spaceports were destroyed. 
+		The King hasn't arrived yet.</sp>
+         <sp spk="SKYWALKER">
+		Keep checking.  Put the starships 
+		intercom over the P.A.</sp>
+         <sd>The general sits at one of the intercom panels  and puts 
+	on a headphone.  A row of monitors is before him.  He 
+	turns to Montross.</sd>
+         <sp spk="SKYWALKER">
+		Where are they?</sp>
+      </scene>
+      <scene n="29">
+         <setting>SPACE - TOWNOWI IN ECLIPSE</setting>
+         <sd>The eerie reddish-yellow planet of Townowi slowly drifts
+	into view from total eclipse.  A small, bright speck, 
+	orbiting the planet, sparkles in the light of the twin 
+	suns.  The six deadly starships settle ominously into the
+	foreground, moving swiftly toward the orbiting speck.  As 
+	the sleek starships move closer, the orbiting speck is 
+	revealed to be a gargantuan space fortress.  The moon-
+	sized satellite fortress dwarfs the approaching fighters. 
+	Every few moments, explosions create blinding flashes on 
+	the planet's surface, as the fortress bombards the planet 
+	with a fusillade of lazer bolts.</sd>
+      </scene>
+      <scene n="30">
+         <setting>TOWNOWIAN STARSHIP - INTERIOR</setting>
+         <sd>Pilot Leader, in the first ship, signals to his navigator 
+	who sits in a small, isolated glass bubble to the rear of 
+	the craft.  General Skywalker is seen on one of many 
+	monitors.  A view of the space fortress is on another. 
+	The rest are filled with various computer readouts and
+	displays.  One of the other starships reports to Pilot 
+	Leader.</sd>
+         <sp spk="DEVIL SIX (intercom)">
+		Look at the size of that thing! 
+		Hey, Coelo, I hope you remembered 
+		to bring your pop gun, 'cause I 
+		think we caught us a big one this 
+		time.</sp>
+         <sp spk="PILOT LEADER">
+		Cut off, Devil Six.  Stand by.</sp>
+         <sp spk="SKYWALKER (monitor)">
+		It looks like they're still using 
+		the basic quad-tristation configura-
+		tion.  Use a "ranger defense." 
+		Concentrate on breath ports and lock 
+		areas.</sp>
+         <sp spk="PILOT LEADER">
+		Affirmative base.  Copy and transmit.
+		Devil Two, check your rotation plates.</sp>
+         <sp spk="DEVIL TWO">
+		Roger, Boss.  We're getting a thresh-
+		hold disturbance on gyro-three.</sp>
+         <sp spk="SKYWALKER (monitor)">
+		Switch over, Five.  Cover it! 
+		Devil pack, generate a spread six 
+		formation.  May the force of others 
+		protect you.</sp>
+         <sp spk="PILOT">
+		Settle in. Devil pack, stand by. 
+		Mark five, break off. Here we go! </sp>
+      </scene>
+      <scene n="31">
+         <setting>SPACE - TOWNOWIAN STARSHIP</setting>
+         <sd>Fuel pods are jettisoned.  The half-dozen fighters break 
+	off into a powerline attack on the huge fortress.  Multiple
+	lazer bolts streak from the starships, creating small 
+	explosions on the complex surface of the fort.</sd>
+      </scene>
+      <scene n="32">
+         <setting>INTERIOR MAIN CORRIDOR - ROYAL SPACE FORTRESS</setting>
+         <sd>The chaos of battle echoes through the vast corridors of 
+	the fortress.  Walls buckle and cave in, sucking debris 
+	and personnel into the vacuum of outer space.  Alarm 
+	sirens scream as soldiers scramble to large turbo-powered 
+	lazer gun emplacements.  Sergeants yell orders through the 
+	smoke and confusion.  Men and robots of various shapes and 
+	sizes run to their battle stations.</sd>
+      </scene>
+      <scene n="33">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The monitors with pictures from the starships suddenly go 
+	blank.  Technicians check channels as others in the war 
+	room silently listen to the action over the intercom. The
+	general remains calm but concerned.</sd>
+         <sp spk="PILOT LEADER (intercom)">
+		Tighten it up, Devil Two.  Tighten it up. 
+		Watch those towers.</sp>
+         <sp spk="DEVIL TWO ">
+		Heavy fire, Boss, twenty-three degrees.</sp>
+         <sp spk="PILOT LEADER">
+		I see it. Pull in.  We're picking up some 
+		interference.</sp>
+         <sp spk="DEVIL SIX">
+		Wow!  I've never seen such fire power.</sp>
+         <sp spk="PILOT LEADER">
+		Pull in, Devil Two.  Pull in! </sp>
+         <sp spk="DEVIL TWO ">
+		I'm all right, Boss.  I've got a target.</sp>
+         <sp spk="DEVIL SIX">
+		Theres too much action.  Get out!</sp>
+         <sp spk="PILOT LEADER">
+		Break off...acknowledge.  Devil Six, 
+		can you see Devil Two?</sp>
+         <sp spk="DEVIL SIX">
+		I've lost him.  There's a very heavy 
+		fire zone on this side.  My radar's 
+		jammed.</sp>
+         <sp spk="DEVIL FIVE">
+		He's gone....No, wait.  There he is.
+		Fin damage, but he's all right.</sp>
+         <sd>A sigh of relief sweeps across the war room.  The monitors 
+	flash on, then off again.</sd>
+         <sp spk="DEVIL FOUR (intercom)">
+		Watch your back, Boss!  Watch your 
+		back!!</sp>
+      </scene>
+      <scene n="34">
+         <setting>TOWNOWI STARSHIP</setting>
+         <sd>The speedy little fighters dart back and forth across the 
+	soft underbelly of the fortress, leaving a trail of des-
+	truction behind them.</sd>
+         <sp spk="PILOT LEADER">
+		Converge on south axis point, point three 
+		nine four.  It appears accessible.  I'm 
+		going to map the surface.  Devil Four, 
+		cover me.</sp>
+         <sd>Pilot Leader and Devil Four dive in unison through a forest 
+	of radar domes, antennae, and gun towers.  Devil Four fires 
+	into the protrusions as the two starships criss-cross the
+	surface of the fortress.  Suddenly, a dense barrage of 
+	lazerfire erupts from a tower, catching Devil Four broad-
+	side.  The spacecraft bursts into a million flaming pieces.
+	Pilot Leader reacts to the loss of his wing man, but con-
+	tinues on his mission.</sd>
+      </scene>
+      <scene n="35">
+         <setting>SUB-HALLWAY - ROYAL SPACE FORTRESS</setting>
+         <sd>Constant explosions rock the interior of the fortress.
+	Civilians, including women and children, scurry for safety 
+	in the panic-ridden hallways.  Two construction robots, 
+	A-2 and C-3, are blown, slipping and sliding across the 
+	hallway floor into some freight canisters.  Both robots 
+	are rather old and battered.  A-2 is a short (three feet) 
+	claw-armed triped.  His face is a mass of computer lights,
+	surrounding a radar eye.  C-3 is a tall, gleaming android of
+	human proportions.  He is thin, with a totally metallic 
+	surface.  The robots attempt to get out from under the
+	canisters, but rushing gas from a broken pipe keeps knocking
+	them over.</sd>
+         <sd>			 C-3
+		This is madness.  We're going to be 
+		destroyed.  I'm still not accustomed 
+		to space travel.</sd>
+         <sd>			 A-2
+		The external bombardment does appear 
+		to be concentrated in this area.  The 
+		structure has exceeded the normal 
+		stress quotient by point four, although 
+		there appears to be no immediate danger.</sd>
+         <sd>			 C-3
+		No immediate danger!  You're faulty. 
+		This is madness!</sd>
+         <sd>A-2 gives C-3 a sheepish look and clings to a siderail for 
+	dear life, as debris flies through the hallway.</sd>
+      </scene>
+      <scene n="36">
+         <setting>TOWNOWI STARSHIP</setting>
+         <sd>Devil Two, a young hotshot of about sixteen years, miracu-
+	lously dives his ship through a virtual wall of lazerfire, 
+	and blasts a huge radar disc into dust.  Devil Two signals 
+	his navigator, who lets out a whooping cheer as the craft 
+	veers into a victory roll.</sd>
+         <sp spk="PILOT LEADER">
+		Great moves, Devil Two.  Re-group at point 
+		two, zero one.  Coincide, Devil Six.</sp>
+         <sp spk="SKYWALKER">
+		Devil One, your map projection shows a 
+		weak point at south portal:  niner point 
+		six.  Concentrate the attack on that 
+		point.  Coordinate.
+		
+				 PILOT LEADER
+		I see it.  It looks good.</sp>
+         <sd>Devil Five and Devil Three bob and weave in formation 
+	toward a giant transformer jutting from the fort's 
+	surface.</sd>
+         <sp spk="DEVIL THREE">
+		I've got a... We're hit.  We're hit!</sp>
+         <sp spk="PILOT LEADER">
+		Eject...Eject.  Babs, Babs, do you read?</sp>
+         <sp spk="DEVIL THREE">
+		I'm okay.  I can hold it.  Clear me
+		a little, Devil Five.  Watch it! 
+		Watch it!</sp>
+         <sd>Devil Three wobbles a little, then drops away sharply,
+	plowing into a lazergun emplacement, causing a hideous 
+	series of chain reaction explosions.</sd>
+      </scene>
+      <scene n="37">
+         <setting>SUB-HALLWAY - ROYAL SPACE FORTRESS</setting>
+         <sd>A huge explosion rips a large hole in the ceiling of a sub-
+	hallway.  A-2 and C-3 are in a state of shock as they 
+	scramble through the rubble.  There is a constant sound of
+	creaking and snapping as the sections of the hallway re-
+	settle in the fortress superstructure.</sd>
+         <sd>			 A-2
+		You're a mindless, useless philosopher. 
+		Come on!  Let's go back to work;  the 
+		system is all right.</sd>
+         <sd>			 C-3
+		You overweight glob of grease.  Quit 
+		following me.  Get away!  Get away!</sd>
+         <sd>Suddenly, the hallway lurches, and a dead trooper falls
+	through a gaping hole in the ceiling.  The foot of a carcass 
+	is caught in the rubble and it hangs upside down, staring at 
+	the two robots.  A-2 grabs C-3 and they cling to each other 
+	in terror.</sd>
+         <sd>			 A-2
+		We're lost.  We're destroyed.</sd>
+         <sd>Three sharp blasts from an airhorn send the two androids 
+	running for cover in a burned-out doorway.  Five grim-
+	faced troopers riding small rocket platforms  pass the 
+	two mechanical men.</sd>
+      </scene>
+      <scene n="38">
+         <setting>GOVERNOR'S QUARTERS - ROYAL SPACE FORTRESS</setting>
+         <sd>The five troopers race through several hallways, and 
+	finally stop in front of an important-looking office 
+	complex.  Two officers dismount and enter the complex. 
+	They pass through several heavily guarded doorways 
+	until they reach the main chamber.  Seated behind a large
+	cluttered desk, surrounded by generals and attaches, is
+	Governor Horus.  General Vader paces in front of a row of 
+	blank monitors.  The two officers salute General Vader.</sd>
+         <sp spk="FIRST OFFICER">
+		All com-link power is out.  Twenty-
+		two transformer sections have been 
+		destroyed.  The situation is grave 
+		on all southern levels.  Com-link 
+		communication should be repaired 
+		shortly.</sp>
+         <sd>The officers salute, turn and leave the chamber.  The 
+	general turns to Governor Horus, who looks a little
+	worried.</sd>
+         <sp spk="VADER">
+		Don't look so worried.  Not even a 
+		Dai could penetrate this fortress.
+		We've already wiped out most of 
+		their forces.</sp>
+         <sp spk="HORUS">
+		If it goes on too long, we'll run 
+		over budget.  When do the landings 
+		begin?</sp>
+         <sp spk="VADER">
+		As soon as the attack has been 
+		broken:  not long.</sp>
+         <sd>A short, stocky attache salutes the general.</sd>
+         <sp spk="ATTACHE">
+		Contamination has set in on quadrants 
+		B-5 and R-4.  All sections are sealed. 
+		We've lost two major power stations 
+		in the southern quadrants.  That puts 
+		section 5-1 in serious trouble.</sp>
+         <sd>The general turns away in controlled anger and embarrass-
+	ment.</sd>
+      </scene>
+      <scene n="39">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general sits in a glass-enclosed computer station,
+	watching the battle progress on several monitors.  An 
+	officer enters and salutes the general.</sd>
+         <sp spk="OFFICER">
+		Analysis reports those ZQ configurations 
+		are definitely power transformers.  Every-
+		thing in the southern sectors of the 
+		fortress is out.</sp>
+         <sd>			 SKYWALKER</sd>
+         <sd>	I'm surprised they are still using exter-
+		nal power units.  It's a definite weak 
+		point.  Concentrate on searching for the 
+		main crosslink transformer.</sd>
+         <sd>The officer exits as Montross rushes in.</sd>
+         <sd>			 MONTROSS</sd>
+         <sd>	The senate has voted to end the war.</sd>
+         <sp spk="SKYWALKER">
+		They can't do anything without the 
+		King's approval, which gives us a 
+		little time.  Have you been able to 
+		regain contact with the King?</sp>
+         <sp spk="MONTROSS">
+		No, sir.  All ground communications 
+		are jammed.</sp>
+         <sp spk="SKYWALKER">
+		Send four men  from third squad  to 
+		meet the King  and escort him back. 
+		Let me know before he arrives.  Is 
+		Captain Valor back with the princess?</sp>
+         <sp spk="MONTROSS">
+		No, sir.  They're long overdue.</sp>
+         <sd>Pilot Leader checks in over the intercom.</sd>
+         <sp spk="PILOT LEADER">
+		All right, base one, we're in 
+		position.</sp>
+         <sd>An officer with headphones looks to the general.  He 
+	signals to attack.</sd>
+      </scene>
+      <scene n="40">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>All four starships dive in formation toward a main trans-
+	former area  flanked by several solar towers.</sd>
+         <sp spk="PILOT LEADER">
+		Hold your fire until we're within point 
+		zero five four.  Make it count.</sp>
+         <sd>Several ack-ack lazers begin to open fire on the approaching 
+	spacecraft.  The starships direct their fire at a large 
+	black transformer  which when hit  spurts bright blue and 
+	white electrical arcs.  One of the starships (Devil Five) 
+	explodes and careens out of formation, leaving an erratic 
+	trail of smoke, before eventually crashing into a solar 
+	panel.</sd>
+      </scene>
+      <scene n="41">
+         <setting>SUB-HALLWAYS - ROYAL SPACE FORTRESS</setting>
+         <sd>The impact of the exploding starship can be felt throughout 
+	the giant fortress.  The tall gleaming C-3 races through 
+	several corridors, yelling at A-2, who struggles vainly to 
+	keep pace with his stubby mechanical feet.</sd>
+         <sd>			 C-3
+		I don't care what you do, but I'm 
+		getting out.  All the power's out. 
+		Those explosions are coming from 
+		the reactor section.  This is the 
+		end. Abandon ship!</sd>
+         <sd>			 A-2
+		Our work - we can't leave!  It's 
+		desertion.  It's not possible. 
+		It's not possible.</sd>
+         <sd>			 C-3
+		Your programming is so limited. 
+		My first order is preservation. 
+		You stay.  I'm going to eject 
+		before the whole thing goes up.</sd>
+         <sd>C-3 breaks open the seal on an emergency lifepod.  A 
+	red warning light begins to flash, and a low hum is 
+	heard.  The lanky chrome android works his way into 
+	the cramped four-man craft.</sd>
+         <sd>			 A-2
+		These lifepods aren't for us. 
+		It's not right!</sd>
+         <sd>A new explosion, this time very close, sends dust and 
+	debris through the narrow passageway.  Flames lick at 
+	the two robots.  The runt-sized A-2 jumps  into the 
+	lifepod.</sd>
+         <sd>			 A-2
+		It's the end.  Eject.  Eject.</sd>
+         <sd>The safety door snaps shut, and the pod ejects from the
+	fortress.</sd>
+      </scene>
+      <scene n="42">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>The terrified androids in the lifepod speed away from 
+	the fortress  and pass the attacking starships.</sd>
+         <sp spk="DEVIL TWO">
+		Object approaching.  Attack bearing.</sp>
+         <sp spk="DEVIL FOUR">
+		It's a lifepod.  Forget it.  We've got...</sp>
+         <sd>Devil Four is hit by lazerfire, and disintegrates, leaving 
+	a trail of flaming particles.  The two remaining craft 
+	continue the assault.  Devil Two and Pilot Leader watch 
+	the remains of Devil Four disappear.  The general appears 
+	over one of the monitors.</sd>
+         <sp spk="SKYWALKER">
+		Analysis indicates transformer code 
+		zero three is the main relay.  Hit it, 
+		and the whole thing goes dead.</sp>
+         <sp spk="PILOT LEADER">
+		We're on our way.</sp>
+      </scene>
+      <scene n="43">
+         <setting>GOVERNOR'S QUARTERS - ROYAL SPACE FORTRESS</setting>
+         <sd>A row of monitors and the main overhead lights go on, and 
+	a trooper appears on one of the screens.</sd>
+         <sp spk="TROOPER">
+		Internal relays operative.  All 
+		power restored.  All contaminated 
+		areas sealed.</sp>
+         <sd>An officer appears on another monitor.</sd>
+         <sp spk="OFFICER">
+		Only two enemy craft remain operative. 
+		We calculate victory by zero three 
+		hundred.</sp>
+         <sd>General Vader switches to another monitor.</sd>
+         <sp spk="VADER">
+		Alert the invasion forces.  (turning 
+		to the governor)  The planet is ours. 
+		A three-hour war.  You expected 
+		longer.  Dai or not, we've beaten 
+		him, and the culture is intact.</sp>
+         <sp spk="HORUS">
+		A truly great prize for the kingdom. 
+		They have a treasure of biotic science. 
+		Genetics, cloning - they've added two
+		hundred years to a lifespan.  Remember, 
+		you must capture at least one member of 
+		the Royal Family alive.  The Townowi 
+		family has ruled this system for ten 
+		thousand years.  The people will follow 
+		no other.  If the royal line is broken, 
+		there is a good chance the entire 
+		population will destroy themselves and 
+		their knowledge before submitting to our 
+		rule.</sp>
+         <sd>The general is interrupted by a call on one of the 
+	monitors.</sd>
+         <sp spk="OFFICER (on monitor)">
+		We've received a message from the 
+		planet.</sp>
+      </scene>
+      <scene n="44">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker watches a giant computer display of 
+	the space fortress mapped by the starships.  An aide
+	approaches.</sd>
+         <sp spk="AIDE">
+		Sir!  The King's convoy has destroyed 
+		at Caldin.  All the bodies were con-
+		taminated.</sp>
+         <sp spk="SKYWALKER">
+		I will audience with the Queen. 
+		Who knows of this?</sp>
+         <sp spk="AIDE">
+		Many.  It came through civilian 
+		sources.</sp>
+         <sp spk="SKYWALKER">
+		Confine Senator Sandage to his 
+		quarters.  Use any pretext.  Where 
+		is the senator now?</sp>
+         <sd>Sandage and several other senators enter the computer
+	station.</sd>
+         <sp spk="SANDAGE">
+		Right here, General.  It's over. 
+		We've already relayed peace terms 
+		to the kingdom, and they've been 
+		accepted.  Your war has ended.</sp>
+         <sd>The general is angry and stands pointing at the senators.
+	They jump back, as if the general were pointing a gun at
+	them.</sd>
+         <sp spk="SKYWALKER">
+		Senator, this war isn't over.  It's 
+		just begun.  I take my commands 
+		from the Royal Family.</sp>
+         <sp spk="SANDAGE">
+		The Queen concurs.  I have her 
+		written decree.  It is to be 
+		implemented immediately.  I order 
+		you to cease the attack.</sp>
+         <sp spk="SKYWALKER">
+		Not likely.</sp>
+         <sp spk="SANDAGE">
+		Treason?  Revolution?  The people 
+		won't follow you, General, nor will 
+		your troops.  I suggest you follow 
+		your orders.</sp>
+         <sd>General Skywalker stands angrily pondering the situation.
+	Sandage and the other senators are tense, a little afraid
+	that he might cut them down on the spot.</sd>
+         <sp spk="SANDAGE">
+		Well, General?</sp>
+      </scene>
+      <scene n="45">
+         <setting>LIFEPOD - GREEN SKY OVER TOWNOWI</setting>
+         <sd>The reddish-yellow mass of Townowi seems to engulf the 
+	tiny lifepod containing the two fleeing androids, as it 
+	descends into the greenish atmosphere.</sd>
+         <sd>			 A-2
+		It's desertion.  They'll destroy us. 
+		How could this happen?</sd>
+         <sd>			 C-3
+		That's funny.  The damage doesn't 
+		look as bad from out here.</sd>
+      </scene>
+      <scene n="46">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>Pilot Leader and Devil Two make a second dive on the now
+	smoldering transformer area.  All firing from the fortress 
+	suddenly stops.  Pilot Leader looks back to his navigator, 
+	who is equally puzzled.  The two fighters continue to attack 
+	the now silent fortress.</sd>
+         <sp spk="DEVIL TWO">
+		I don't get it.  What do you 
+		think, Boss?</sp>
+         <sd>General Skywalker appears on the monitors.</sd>
+         <sp spk="SKYWALKER (with difficulty)">
+		Base one to Devil Leader, scramble code 
+		niner.  Break your attack and return to 
+		base.  Repeat, break your attack. 
+		Confirm.</sp>
+         <sp spk="PILOT LEADER">
+		They're hurt, sir, but they still have 
+		power.  We should finish...</sp>
+         <sp spk="SKYWALKER">
+		Break off.  The war is over.  Run on 
+		white lights.  Get back here, Mace. 
+		We're going to need you.</sp>
+         <sp spk="PILOT LEADER">
+		Confirmed base one.  We're on our way. 
+		Did you copy, Devil Two?</sp>
+         <sp spk="DEVIL TWO">
+		Roger, Boss.</sp>
+         <sd>The two starfighters break off the attack and start back
+	toward the planet.  Without warning, the fort directs
+	concentrated fire at the two starfighters.  Devil Two
+	instantly bursts into flames, then disintegrates.  Pilot
+	Leader's tail section is hit, and the ship pinwheels 
+	toward the planet.  Blood covers Pilot Leader's immobile 
+	face.</sd>
+         <sp spk="PILOT LEADER'S NAVIGATOR">
+		We're under fire.  They're still shooting.  
+		I thought it was over.  We're hit!  We're 
+		hit!  Pilot is dead.... Ejecting.</sp>
+         <sd>The dead Pilot Leader is jettisoned free of the craft, but 
+	the navigator's eject panel is dead.  He struggles with it, 
+	then bangs on the canopy to no avail.  The navigator is 
+	still trapped in the craft when it explodes, leaving only 
+	a puff of pink smoke reflected in the rim light of the 
+	planet.</sd>
+      </scene>
+      <scene n="47">
+         <setting>DESERT NEAR OUTPOST - TOWNOWI</setting>
+         <sd>Pilot Leader's dead body drifts toward his arid mother-
+	planet.  Automatic rockets kick in occasionally to direct 
+	and soften the landing.  Two gray-clad troopers stand next 
+	to a military landspeeder, watching the descending air-
+	warrior through electrobinoculars.  Mace's corpse hits the
+	ground rather hard, creating a whirlwind of dust, and the 
+	two troopers rush over to the pilot.  The younger of the 
+	two troopers, a young boy in his teens, cradles the dead 
+	starpilot in his arms and begins to cry.</sd>
+      </scene>
+      <scene n="48">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker sits alone, meditating in the deserted 
+	war room.  Montross approaches the contemplative general.</sd>
+         <sp spk="MONTROSS">
+		No sign of Captain Valor or the 
+		princess.  There was much damage 
+		in that area.  The Queen will see 
+		you at ten hundred.</sp>
+         <sd>The general doesn't reply.</sd>
+      </scene>
+      <scene n="49">
+         <setting>ASSEMBLY - DEPARTURE AREA - ROYAL SPACE FORTRESS</setting>
+         <sd>General Vader stands behind a row of men at computer 
+	control panels overlooking a huge assembly of troop, 
+	tanks, and transports. A commander reports to the general.</sd>
+         <sp spk="COMMANDER">
+		All enemy craft destroyed.  First 
+		and fifth division troops and 
+		equipment standing by.</sp>
+         <sd>The general gives a sly smile of approval and takes a
+	microphone from one of the computer technicians.  He 
+	speaks to the troops and pilots waiting in their huge 
+	war machines for the invasion order.</sd>
+         <sp spk="VADER">
+		The war is won.  With the conquering 
+		of this  system, we have ushered in a 
+		new millennium for the New Galactic 
+		Kingdom which will echo throughout the 
+		universe.  Our reward is the knowledge 
+		this system possesses.  This planet 
+		must be controlled with a minimum 
+		of force, but you must not think 
+		lightly of this enemy.  They have 
+		exacted a heavy toll.  Today you will 
+		make the kingdom complete.  Do so with 
+		pride and care.</sp>
+         <sd>Vader puts down the mike, and turns to his commander.</sd>
+         <sp spk="VADER">
+		Let the invasion begin.</sp>
+      </scene>
+      <scene n="50">
+         <setting>EDGE OF THE DUNE SEA - TOWNOWI</setting>
+         <sd>KUROLAND, or "No-Man's Land," where the rugged desert 
+	mesas meet the foreboding dune sea.  The two helpless astro 
+	robots kick up clouds of dust as they clumsily work their 
+	way across the desert coastline.  The short A-2 struggles 
+	desperately to keep up with the long-legged C-3.</sd>
+         <sd>			 A-2
+		It's not possible.  We're not 
+		built for this.  You're nothing 
+		more than a dim-witted, emotion
+		brained intellectual.  Why you 
+		were created is beyond my logic 
+		systems.  Thanks to you, we're 
+		now deserters, and will probably 
+		be destroyed on sight.  And on 
+		top of that, you're going the 
+		wrong way!  All this filth is 
+		getting...</sd>
+         <sd>The towering C-3 stops short and turns on the blabbering 
+	mechanical runt.</sd>
+         <sd>			 C-3
+		I've had enough of you, you 
+		pragmatic, nearsighted scrap 
+		pile.  You go your own way.</sd>
+         <sd>He picks up the tiny robot and tosses him several feet into 
+	a large sand dune.  C-3 starts off in the direction of the 
+	dune sea.  A-2 struggles to his feet and shakes a metallic 
+	claw arm at his disappearing ex-partner.</sd>
+         <sd>			 A-2
+		You'll be malfunctioning within a 
+		day.  You're going the wrong way, 
+		but your way is always the wrong 
+		way.</sd>
+         <sd>C-3 stops and yells to the smaller android.</sd>
+         <sd>			 C-3
+		And don't let me catch you following 
+		me, begging for help, because you 
+		won't get it from me.</sd>
+         <sd>A-2s reply is a rather rude sound, which only an electronic 
+	person could make.  He turns and trudges off in the opposite 
+	direction into the rocky desert mesas.</sd>
+      </scene>
+      <scene n="51">
+         <setting>DUNE SEA - TOWNOWI</setting>
+         <sd>C-3, hot and tired, struggles up over the ridge of the dune, 
+	only to find more dunes, which seem to go on for endless 
+	miles.  He looks back in the direction he came.</sd>
+         <sd>			 C-3
+		You little malfunctioning twerp. 
+		This is all your fault.  You tricked
+		me into going this way, but you'll do 
+		no better!</sd>
+         <sd>He sits in a huff of anger and frustration, knocking the 
+	sand from his joints.</sd>
+      </scene>
+      <scene n="52">
+         <setting>DESERT MESA - TOWNOWI</setting>
+         <sd>A-2 stumbles through a narrow canyon until he climbs over 
+	a small boulder and sees before him a sight he first thinks 
+	is a mirage.  Nestled in a rock formation is a deserted 
+	landspeeder.  Once the little robot is convinced that he 
+	is alone, he approaches the battered speeder and begins to 
+	analyze it.  He climbs into the pilot's seat  and attempts 
+	to start the unfamiliar transport.  He hears a sound and 
+	stops for a moment.  He sees nothing, so he continues to 
+	fiddle with the control panel until the speeder lurches 
+	forward with a start, banging into a large rock.  The 
+	stubby android is shaken, but neither he  nor the speeder 
+	seems to be damaged.</sd>
+         <sd>Shivers run down A-2's metal spine, and again he has an
+	eerie feeling that he is being watched.  He slowly looks
+	around  and sees a large man, Captain Valor, standing 
+	directly behind him.  He is startled, then terrified.</sd>
+         <sp spk="JUSTIN">
+		Where is your master?</sp>
+         <sd>The little robot clicks and rattles, but doesn't speak.</sd>
+         <sp spk="JUSTIN (Cont.)">
+		Can't you speak?  How do you relate 
+		your data?  You're of Karollian manu-
+		facture.  You should be able to talk. 
+		Are you damaged?</sp>
+         <sd>Valor pokes at the machine  but doesn't see any damage. 
+	A-2 eyes him suspiciously.  The robot turns with a start 
+	and discovers a young girl, Princess Zara, has been 
+	standing next to him for some time.</sd>
+         <sp spk="PRINCESS (sarcastically)">
+		Well, General, who's your friend?</sp>
+         <sp spk="JUSTIN">
+		I don't know.  He doesn't seem to 
+		be able to talk.  Damaged, probably...
+		Jettisoned from a damaged ship...</sp>
+         <sp spk="PRINCESS">
+		What do you intend to do with it?</sp>
+         <sp spk="JUSTIN">
+		We'll take it with us.  Could be a 
+		storehouse of valuable information.</sp>
+         <sd>Justin guides the android into the small luggage area 
+	behind the front seat, then hops into the driver's seat.</sd>
+         <sp spk="PRINCESS">
+		I don't want to ride with that thing. 
+		I order you to destroy it immediately.</sp>
+         <sp spk="JUSTIN">
+		Get in!  We've got to hurry if we're 
+		going to get across the "dunehedge" 
+		by nightfall.  You're coming, one way 
+		or the other.  Will you join us peace-
+		ably?</sp>
+         <sd>The princess reluctantly gets into the speeder, and it starts 
+	with a jolt.</sd>
+      </scene>
+      <scene n="53">
+         <setting>LANDSPEEDER - DESERT MESAS - TOWNOWI</setting>
+         <sd>The speeder flies along, a foot or so above the landscape.</sd>
+         <sp spk="PRINCESS">
+		You are such a barbarian.  I'll have 
+		my father cut you into little pieces 
+		when we get back...and I'll take 
+		pleasure in feeding you to the Gonthas,
+		a little bit each day.  I may save your 
+		eyes though.  I'll have them petrified 
+		and made into a necklace.</sp>
+         <sp spk="JUSTIN">
+		Your sweetness is only surpassed by your 
+		beauty.  Just try to remember, I'm only 
+		following orders.</sp>
+         <sp spk="PRINCESS">
+		To beat and abuse me?
+					 
+				 JUSTIN
+		I'm afraid I've only learned one way 
+		to treat wild animals.</sp>
+         <sd>A-2 thrashes about, trying to relieve the pressure on his	 
+	cramped legs.</sd>
+         <sp spk="PRINCESS">
+		You stay out of this.</sp>
+      </scene>
+      <scene n="54">
+         <setting>DUNE SEA</setting>
+         <sd>C-3 struggles to the top of a large dune.  He is dirty and 
+	hot.  His plight seems hopeless.  He searches the horizon 
+	for any sign of life.  A glint of reflected light in the 
+	distance  reveals an object speeding toward him.  The 
+	chrome android waves frantically  and yells at the 
+	approaching speeder.  The sleek landspeeder races past 
+	him about a hundred yards away.  He runs after it, 
+	screaming in desperation, until he stumbles and falls 
+	head over heels down an enormous sand dune.  Silently,	 
+	the speeder sweeps around in a circle and stops behind 
+	the immobile robot.  Valor jumps out of the speeder and 
+	is quickly followed by A-2.</sd>
+         <sp spk="PRINCESS">
+		We're in a hurry, remember!  If 
+		you're going to stop for every 
+		unfortunate along the way, we'll 
+		never get back.  We're lucky you 
+		got the speeder running as it is.</sp>
+         <sd>A-2 waddles up to his fallen partner and starts pulling on 
+	his leg, then runs up and starts pulling on his arm.</sd>
+         <sd>			 A-2
+		Function!  Function!  It's me. 
+		Come on, function.</sd>
+         <sp spk="VALOR">
+		Well, my little friend, you've 
+		found your tongue.</sp>
+         <sd>			 A-2
+		We must help him.  We've been 
+		lost.</sd>
+         <sp spk="VALOR">
+		Where did you come from?</sp>
+         <sd>The little robot runs around his fallen partner giving him 
+	small electric charges from his claw hand.  C-3 shudders 
+	from head to toe, then regains consciousness.</sd>
+         <sd>			 C-3
+		What happened?</sd>
+         <sd>			 A-2
+		You're overheated.</sd>
+         <sp spk="VALOR">
+		Where did you come from?</sp>
+         <sd>			 A-2
+		We were jettisoned from six twenty-
+		nine P.R. one.</sd>
+         <sp spk="VALOR">
+		I'm unfamiliar with that ship. 
+		What type is it?</sp>
+         <sd>			 C-3
+		It's a class M station, not a 
+		conventional craft.</sd>
+         <sd>C-3 then stands and shakes the young Dai's hand.</sd>
+         <sd>			 C-3
+		I'm C-3, Human-Cyborg Relations.  
+		Your kindness is greatly appreciated.</sd>
+         <sd>Captain valor and the two robots walk back to the speeder.</sd>
+      </scene>
+      <scene n="55">
+         <setting>LANDSPEEDER - DESERT CANYON - TWONOWI</setting>
+         <sd>Both A-2 and C-3 are stuffed into the tiny luggage com-
+	partment.  It is late in the day when the speeder rumbles 
+	to a stop in a small desert canyon surrounded by steep 
+	cliffs and broken boulders.</sd>
+         <sp spk="JUSTIN">
+		We'll rest here.</sp>
+         <sd>			 C-3
+		At last.  The transport is welcome 
+		but my joints are frozen.</sd>
+         <sd>Everyone climbs out of the low-slung speeder.  Valor
+	watches the two androids as they stretch their mechanical 
+	limbs.</sd>
+         <sd>			 A-2
+		I've got a bad case of dust contami-
+		nation.  I can barely move.</sd>
+         <sd>			 C-3
+		What a foresaken place this is.  We 
+		seem to be made to suffer.  It's 
+		our lot in life.  Sir, could you 
+		tell...?</sd>
+         <sd>C-3 turns and notices that Valor and the princess have 
+	disappeared.  He looks all around.</sd>
+         <sd>			 C-3
+		Where did they go?  They've dis-
+		appeared.</sd>
+         <sd>			 A-2
+		Maybe they were attacked. 
+		I sense danger!</sd>
+      </scene>
+      <scene n="56">
+         <setting>HIDDEN FORTRESS ENTRANCE - DESERT CANYON - TOWNOWI</setting>
+         <sd>Captain Valor and Princess Zara hurry through a maze of 
+	large boulders  until they reach a sheer rock face.  Valor 
+	looks around to see if they were followed.  Suddenly  a 
+	large section of the rock slides away  revealing a well-
+	lit corridor carved out of the rock.  They enter  and are 
+	greeted by two jubilant guards.  Valor gives them some 
+	orders and points in the direction of the speeder.  The 
+	secret rock door silently slides closed.</sd>
+      </scene>
+      <scene n="57">
+         <setting>MAIN HALLWAY - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor and the princess are greeted by General 
+	Skywalker and Montross.  They bow before the princess.</sd>
+         <sp spk="PRINCESS (angrily pointing at Valor)">
+		General, I want you to do something 
+		with this...this barbarian.  Where's 
+		my father?</sp>
+         <sp spk="GENERAL">
+		The King is dead, Your Highness.</sp>
+         <sd>All anger suddenly drains from the princess. She almost
+	timidly asks the next question.</sd>
+         <sp spk="PRINCESS">
+		My mother?... and brothers?</sp>
+         <sp spk="GENERAL">
+		She's here.  She's safe, so are your 
+		brothers.  They're in the main chamber.</sp>
+         <sd>Zara, now looking more like a frightened young girl than 
+	a vindictive princess, runs down the hallway toward the 
+	main chamber.  She vainly attempts to hold back the tears.</sd>
+      </scene>
+      <scene n="58">
+         <setting>DESERT CANYON - TOWNOWI</setting>
+         <sd>The two puzzled androids sit on the landspeeder, pondering 
+	the disappearance of their saviour.</sd>
+         <sd>			 C-3
+		Do you suppose we're in danger?</sd>
+         <sd>			 A-2
+		The logic of this environment 
+		escapes me.</sd>
+         <sd>As night begins to fall, and the shadows begin to lengthen, 
+	the two robots begin to get a little edgy.  The sound of 
+	approaching feet startles A-2, and he ducks behind his 
+	taller friend.  Two guards approach the robots.</sd>
+         <sp spk="GUARD">
+		You will remain calm, and you will 
+		remain here.</sp>
+         <sd>			 C-3
+		Certainly. I'm C-3, Human Cyborg 
+		Relations.  Your kindness is greatly 
+		appreciated.</sd>
+         <sd>A-2 sits rather suspiciously behind his extroverted friend.</sd>
+      </scene>
+      <scene n="59">
+         <setting>ROYAL CHAMBER - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker bows low before Princess Zara.  She sits 
+	on a raised platform, dressed in the royal robes of a 
+	planetary ruler.  The Queen sits off to one side on a
+	smaller platform.  The princess waits for a few moments 
+	before she allows the general to rise.</sd>
+         <sp spk="QUEEN">
+		The senate has been corrupted.</sp>
+         <sp spk="SKYWALKER">
+		They cannot rule without your 
+		wish.</sp>
+         <sp spk="QUEEN">
+		I rule by marriage.  With the King 
+		dead, I am not strong enough to stop 
+		them.  Zara is now the true Queen. 
+		She must be protected.  The line must 
+		be preserved.  I am placing the 
+		future of our people in your hands. 
+		You must deliver Zara and her 
+		brothers to the OPHUCHI System. 
+		They will be safe there.  General, 
+		you must understand.  I had no 
+		alternative but to condone an end 
+		to the hostilities.  I deeply 
+		believe your campaign could have 
+		been successful, but there are 
+		things that...</sp>
+         <sp spk="SKYWALKER">
+		I understand, Your Highness.</sp>
+         <sp spk="QUEEN">
+		The chrome companies on Ophuchi have 
+		offered to supply you with the men 
+		and ships necessary to return Zara 
+		to the throne.</sp>
+         <sp spk="SKYWALKER">
+		Can the chrome companies be trusted?</sp>
+         <sp spk="QUEEN">
+		The price for their cooperation is 
+		high.  It is waiting for you in 
+		Med Center blue.  Guard it as you 
+		would the princess herself.  No-one 
+		must know of this mission.  There 
+		are those among the trusted who 
+		would wish us ill.  Take only two 
+		of your best officers with you, the 
+		most loyal.  May the force of others 
+		be with you.</sp>
+         <sp spk="ZARA">
+		Mother, you must not stay.</sp>
+         <sp spk="QUEEN">
+		I am too old for such a journey.  The 
+		kingdom already controls the space-
+		port cities.  You have a long way to 
+		travel.  It won't be easy.</sp>
+         <sp spk="SKYWALKER">
+		We will have to travel in disguise. 
+		I must have full command.  No-one 
+		can suspect wealth or royal training. 
+		I fear the new Queen will not stand 
+		for this.</sp>
+         <sp spk="ZARA">
+		Do not put words into my mouth. 
+		I will stand for what is necessary.</sp>
+         <sd>The general simply smiles.</sd>
+      </scene>
+      <scene n="60">
+         <setting>SUB-HALLWAY - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general walks briskly through an isolated hallway,
+	closely followed by Montross.</sd>
+         <sp spk="SKYWALKER">
+		How is Captain Oxus recovery?</sp>
+         <sp spk="MONTROSS">
+		Very good;  he's up and around.</sp>
+         <sp spk="SKYWALKER">
+		Fine!  Have Oxus and...ah, Captain 
+		Valor report at zero three hundred. 
+		I want two converted transports,  
+		agricultural type, and two days' 
+		provisions, travel papers, weapons. 
+		Contact Han Solo at the Gordon 
+		spaceport.  I'll talk to him...with 
+		speed!</sp>
+         <sd>Montross turns and rushes down another hallway.</sd>
+      </scene>
+      <scene n="61">
+         <setting>MEDICAL CENTER BLUE - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general enters a stark white waiting area filled 
+	with scholarly looking gentlemen.  An attendant greets 
+	General Skywalker and takes him into a small observation 
+	chamber overlooking a large operating theatre. An 
+	elderly doctor greets him.</sd>
+         <sp spk="DOCTOR">
+		Good to see you, General.  I'm afraid 
+		we're not quite ready yet.  Thank God 
+		you'll be the one taking them, though.</sp>
+         <sd>An attendant brings in one of the scholars from the waiting 
+	area and places him on a large operating table surrounded 
+	by strange looking equipment.  An ominous looking clamp is 
+	placed on the man's head.</sd>
+         <sp spk="SKYWALKER">
+		How many are going?</sp>
+         <sp spk="DOCTOR">
+		Thirty-three of the greatest scientific 
+		minds in our system...A high price for 
+		freedom.</sp>
+         <sp spk="SKYWALKER">
+		Thirty-three scientists!  Transporting 
+		a group that size, undetected... I don't...</sp>
+         <sp spk="DOCTOR">
+		Don't worry, General.  All you'll be 
+		taking are their minds.</sp>
+         <sd>The doctor moves over to a safe-like cabinet guarded by 
+	two attendants.  The doctor gingerly picks up a small 
+	clear vial filled with gray fluid.  It has a label which
+	reads:  Faubun, Astro-dynamics.  In the background , the 
+	scholar on the operating table is undergoing a form of
+	mechanized brain surgery.</sd>
+         <sp spk="SKYWALKER">
+		"Bloodory's distillation?"</sp>
+         <sp spk="DOCTOR">
+		Yes.  It has been greatly perfected. 
+		The brain is condensed into five 
+		ounces of fluid.  Cloning cell samples 
+		are included so that a structural 
+		duplicate of the scientist can be 
+		reproduced.  When the  duplicate child 
+		reaches the age of six, he or she 
+		begins a series of injections of the 
+		brain fluid.  By the age of ten years, 
+		they have received all the knowledge 
+		and memory of an experienced scientist:  
+		an old mind in a young body.  We have 
+		prepared a special shock belt to carry 
+		the vials.</sp>
+         <sd>In the background, the limp body of the scholar on the
+	operating table is removed, and another scientist is 
+	escorted into the operating threatre.  Dr. Bloodory, a 
+	portly doctor in his forties, enters the room and shakes 
+	hands with the general.</sd>
+         <sp spk="DOCTOR">
+		General, this is Dr. Bloodory. 
+		He'll be making the trip with 
+		you.</sp>
+         <sp spk="BLOODORY">
+		It's an honor to meet you, General. 
+		I'm sure I couldn't be in safer 
+		hands.
+					
+				 SKYWALKER
+		The chrome companies are exacting 
+		a high price indeed!  Politics will 
+		be the ruin of us all.</sp>
+         <sp spk="BLOODORY">
+		Careful.  If we could rid ourselves 
+		of the politicians, generals would 
+		no longer be necessary.</sp>
+         <sp spk="DOCTOR">
+		We should be ready by zero three 
+		hundred.</sp>
+         <sd>The doctors exit, leaving the general alone to watch the 
+	huge machine extract another brain.</sd>
+      </scene>
+      <scene n="62">
+         <setting>SPACEPORT - OBSERVATION DECK - TOWNOWI</setting>
+         <sd>Governor Horus, General Vader walk down a boarding ramp to 
+	an observation deck overlooking the conquered city of 
+	Gordon.  They are followed by a number of aides and officers 
+	from the royal fleet.  Below them, air tanks and other 
+	military equipment and supplies are being unloaded.</sd>
+         <sp spk="VADER">
+		Not much of a planet.</sp>
+         <sp spk="HORUS">
+		Darth, you've done well.  Do you 
+		think you will have the Royal 
+		Family by nightfall?</sp>
+         <sp spk="VADER">
+		An advance expedition is already 
+		on its way to their underground 
+		hideaway.  They should reach it 
+		by nightfall, but only if this 
+		Count Sandage can be trusted.</sp>
+         <sp spk="HORUS">
+		A man hungry for power can always 
+		be trusted... to betray those in 
+		power.  I'm sure his information 
+		is correct.</sp>
+      </scene>
+      <scene n="63">
+         <setting>HIDDEN FORTRESS CANYON -TOWNOWI</setting>
+         <sd>The huge rock face of the canyon opens, and two shabby
+	agricultural landspeeders are pushed into the late after-
+	noon sun.  A-2 and C-3 stand on the far side of the canyon 
+	with their guards  watching in amazement.  The general and 
+	Captain Valor walk behind the men pushing the landspeeder.</sd>
+         <sp spk="SKYWALKER">
+		We'll take them with us.  They 
+		know more about that fortress 
+		than any ten men.  They will be 
+		very useful.</sp>
+         <sp spk="JUSTIN">
+		Can they be trusted?</sp>
+         <sp spk="SKYWALKER">
+		Loyalty can't be programmed. 
+		They can be trusted never to 
+		harm a living creature, and to 
+		always give accurate information
+		as they know it, to anyone who 
+		asks.  You just have to remember 
+		not to tell them anything that 
+		you don't want to fall into the 
+		wrong hands.</sp>
+         <sd>The general approaches the two robots. A-2 shyly moves
+	around his taller companion.</sd>
+         <sp spk="SKYWALKER">
+		Greetings.  I'm Luke:  Agricultural 
+		Engineering.  We're going to be 
+		travelling together.  You're going 
+		with us to help set up a hortastation 
+		on KANDALAR.</sp>
+         <sd>C-3 shakes hands with the general.</sd>
+         <sd>			 C-3
+		I'm C-3:  Human Cyborg Relations.  
+		Your kindness is greatly appreciated.</sd>
+         <sd>C-3 and the general both look down at A-2.  C-3 gives the 
+	smaller android a little kick.</sd>
+         <sd>			 A-2
+		A-2:  Fusion Repair.</sd>
+         <sp spk="SKYWALKER">
+		Load them into one of the speeders.</sp>
+         <sd>Captain Oxus, walking with a slight limp, emerges from the 
+	underground fortress with the Royal Family.  A small group 
+	of guards and aides are lined up, standing at attention. 
+	The two young princes, Oeta and Puck, hug and kiss their 
+	mother good-bye, then jump into the back of the larger 
+	four-man speeder.  The princess bows before her mother, 
+	then embraces her.  Tears roll down her cheeks.  Her 
+	mother wipes them away.</sd>
+         <sp spk="QUEEN">
+		You must learn strength.</sp>
+         <sd>The princess turns and moves to the larger speeder where 
+	she is helped aboard by Captain Valor.</sd>
+         <sp spk="PRINCESS (fuming)">
+		I don't need your help, thank you.</sp>
+         <sd>She gives the general an angry look.</sd>
+         <sp spk="SKYWALKER">
+		I'm afraid he's necessary.</sp>
+         <sd>A commotion erupts at the mouth of the underground fortress. 
+	Count Sandage, several senators and ten to twelve troopers 
+	rush into the canyon and block the speeders.</sd>
+         <sp spk="SANDAGE">
+		Where are you going?  What is 
+		this?</sp>
+         <sd>In one quick movement the general moves between Sandage and 
+	the Queen.  Oxus and Valor assume defensive positions in 
+	front of the princess and her brothers.</sd>
+         <sp spk="QUEEN">
+		Zara and the boys are being taken to 
+		safety.  It is my wish.</sp>
+         <sp spk="SANDAGE">
+		The King has assured their safety.  
+		They must stay.</sp>
+         <sp spk="QUEEN">
+		It is not my wish....</sp>
+         <sp spk="SANDAGE">
+		General, you've gone too far this 
+		time.  <sd>to the troops</sd>  Arrest him.</sp>
+         <sd>Five troops start to move on the general, as Sandage draws 
+	his lazerpistol.  Before anyone can complete his action, the 
+	general ignites his lazersword and cuts the senator in two. 
+	He drops to the ground in a heap, and the approaching troops 
+	stop in their tracks.</sd>
+         <sp spk="QUEEN">
+		Stop this!</sp>
+         <sd>The general, Valor, and Oxus replace their swords, and bow 
+	low to the Queen.  All of the troops, senators, and aides 
+	do the same.  The formalness of the occasion is broken when 
+	the Queen embraces the general.  She then turns and embraces 
+	each of the captains.  They are both flustered, and somewhat 
+	embarrassed.</sd>
+         <sp spk="QUEEN">
+		May the force of others be with you.</sp>
+         <sd>The general and his captains head for the speeders, while 
+	the Queen and all the others return to the underground 
+	fortress.</sd>
+      </scene>
+      <scene n="64">
+         <setting>DESERT BLUFF - TOWNOWI</setting>
+         <sd>The two speeders edge their way onto a bluff overlooking the 
+	hidden fortress canyon.  They stop for one last reflective 
+	moment.  Forced to leave their closest friends and relatives, 
+	the group is deeply moved.  The two robots, for the most 
+	part, are puzzled.  Suddenly, there is a huge atomic flash, 
+	followed by a loud rumble, and the entire canyon collapses 
+	into a large crater.  The group quietly watches the dust 
+	settle.  The hidden fortress and all its inhabitants have 
+	been destroyed.  The general watches the princess, who 
+	appears to take it well.</sd>
+         <sp spk="SKYWALKER">
+		It was the only way we could be 
+		safe from treachery.</sp>
+      </scene>
+      <scene n="65">
+         <setting>DUNE SEA - TOWNOWI</setting>
+         <sd>The two sleek landspeeders glide effortlessly through the 
+	vast hills and valleys of the dune sea.  At the base of the 
+	towering ridge, the four-man speeder stops.   The smaller 
+	speeders, with Valor and the two robots, makes its way to the 
+	top of the ridge.  Captain Valor stops the speeder just short 
+	of the top of the ridge.  He gets out and continues the rest 
+	of the way on foot.  The young captain peeks over the ridge 
+	into the canyon below.  Muted sounds and large dust clouds 
+	rise from the canyon floor.  Valor immediately ducks back 
+	behind the ridge with an amazed look on his face.  He 
+	quickly returns to the speeder  and picks up the intercom.</sd>
+         <sp spk="JUSTIN">
+		Sir, you'd better take a look at 
+		this.  But come easy.</sp>
+         <sd>The four-man speeder starts with a crack  and slowly moves 
+	up the side of the imposing dune.  It stops next to the 
+	smaller speeder.  The general and Oxus get out and make 
+	their way to the top of the ridge where they join Valor. 
+	Far in the distance, crossing the endless dune sea, is the 
+	royal invasion army.  It is immense.  A convoy of giant 
+	tanks, troop carriers, and supply ships stretch from 
+	horizon to horizon.  Cavalry, mounted on giant dunebirds 
+	ride the line from one end of the convoy to the other. 
+	Hundreds of troops ride one-man jetsticks in precision 
+	formation.  Their lances form a giant pin-cushion. It is 
+	an awesome sight.</sd>
+         <sp spk="SKYWALKER">
+		They're coming from the spaceport at 
+		Anchorhead, which means they control 
+		everything between here and the space-
+		port at Gordon.</sp>
+         <sp spk="JUSTIN">
+		Can we go around them?</sp>
+         <sp spk="SKYWALKER">
+		No.  We'll have to wait for them to 
+		pass.  Captain Valor, see if you can 
+		monitor any of their communications 
+		on the com-link in the big speeder.</sp>
+         <sd>Valor returns to the speeder.  He collapses in the large 
+	speeder next to the princess  and flips on the com-link 
+	radio, moving back and forth across the dial.</sd>
+         <sp spk="PRINCESS">
+		Must you do that?</sp>
+         <sd>Valor smiles rather sarcastically.</sd>
+         <sp spk="JUSTIN">
+		Orders... The invasion force has cut 
+		us off.  We'll probably be here for 
+		some time.  You ought to stretch a 
+		bit.</sp>
+         <sp spk="PRINCESS">
+		Is that a command, General?  Maybe I 
+		feel like watching after my brothers.</sp>
+         <sd>Valor looks back at the two sleeping boys.</sd>
+         <sp spk="JUSTIN">
+		They're not going anywhere.  They're 
+		asleep.</sp>
+         <sp spk="PRINCESS">
+		I want to stay with them.</sp>
+      </scene>
+      <scene n="66">
+         <setting>LIBRARY - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The King's old library has been converted into an office 
+	for General Vader.  He is sitting behind his desk as 
+	Captain Dodona of the Lettow legions enters and salutes. 
+	The legionnaire is dressed in the fascist black and chrome 
+	uniform of the legendary Lettow One Hundred.  The general 
+	returns his salute.</sd>
+         <sp spk="VADER">
+		Welcome, Captain Dodona.  Your 
+		exploits are legendary.  I have 
+		long waited to meet you.  If there 
+		is any way I can assist you, my 
+		entire command is at your bidding.</sp>
+         <sp spk="DODONA">
+		I want a tie-in to your computer 
+		network, a control center, and 
+		communication access.</sp>
+         <sp spk="VADER">
+		Right away!  I'll also transfer 
+		all information we have on the general. 
+		His command post was destroyed, but we 
+		believe he is still alive.  Do you 
+		really believe he's a Dai?</sp>
+         <sp spk="DODONA">
+		If he was not a Dai  I wouldn't be 
+		here.</sp>
+      </scene>
+      <scene n="67">
+         <setting>WASTELAND - TOWNOWI</setting>
+         <sd>The speeders make their way across the gray desert.  It is 
+	dawn.  The twin suns have yet to rise in the green sky.  The 
+	speeders are coated with dust and grime, indicating that 
+	they have travelled far.  The two captains drive through the 
+	night as everyone else sleeps.  Valor calls Oxus on the 
+	intercom.</sd>
+         <sp spk="JUSTIN">
+		How are your fuel packs?  I'm reading 
+		minus four.</sp>
+         <sp spk="OXUS">
+		I'm too low to transfer any.</sp>
+         <sd>The general, who appeared to be asleep, opens his eyes, and 
+	takes the microphone from Oxus.</sd>
+         <sp spk="SKYWALKER">
+		There is a fuel station fourteen 
+		degrees by two meters.  The occu-
+		pation force should have control 
+		of it by now, so hide your weapons,
+		but keep them within reach.</sp>
+      </scene>
+      <scene n="68">
+         <setting>FUEL STATION - TOWNOWI</setting>
+         <sd>A series of low concrete structures rise out of the desert. 
+	The speeders stop in front of an old weather-beaten block 
+	house.  The rusted hulk of a landspeeder lies half-buried 
+	to one side of the building.  Valor and Oxus jump out of the 
+	speeder and go into the block house.</sd>
+      </scene>
+      <scene n="69">
+         <setting>INTERIOR - FUEL STATION - TOWNOWI</setting>
+         <sd>The two young captains, dressed as farmers, enter the dingy 
+	little fuel station.  It is quiet.  A few power packs line 
+	the walls and a dismantled speeder rests in the repair bay. 
+	There is a sharp dripping sound coming from the speeder.  It 
+	appears that no-one is there.</sd>
+         <sp spk="JUSTIN">
+		Greetings!  Who's in charge here?</sp>
+         <sd>They look around the deserted station, but find no attendant. 
+	An eerie quiet pervades the building.</sd>
+         <sp spk="OXUS">
+		I don't get it.</sp>
+         <sp spk="JUSTIN">
+		You don't have to.  It's abandoned.</sp>
+         <sd>Oxus opens a door leading to a storage area, and stops 
+	short.</sd>
+         <sp spk="OXUS">
+		Not quite abandoned.</sp>
+         <sd>Valor moves to the doorway and sees the attendant, his wife, 
+	and small daughter hanging upside down, tortured to death. 
+	Oxus cuts them down.</sd>
+         <sp spk="OXUS">
+		They shouldn't have resisted.</sp>
+         <sd>Valor grabs two power packs from the shelf.</sd>
+         <sp spk="JUSTIN">
+		Help me with these power packs. 
+		We'd better move out of here.</sp>
+         <sd>Oxus covers the family with an old work tarp.  He bows to 
+	the dead, then reluctantly grabs a couple of power packs 
+	and they start for the door.  Oxus stops for a moment.</sd>
+         <sp spk="OXUS">
+		Hear that?  Someone's here.  <sd>yelling</sd>  
+		We're friends.  Show yourself.
+		
+	Silence.  Oxus shrugs his shoulders and they start out the 
+	door, only to run straight into a burly stormtrooper.</sp>
+         <sp spk="STORMTROOPER">
+		Get out of here!</sp>
+      </scene>
+      <scene n="70">
+         <setting>FUEL STATION - TOWNOWI</setting>
+         <sd>Oxus and Valor are pulled out of the doorway and shoved into 
+	the center of a group of fifteen or twenty royal storm-
+	troopers who have surrounded the two speeders.  Several 
+	troops have pulled General Skywalker out of the speeder. He 
+	acts senile, like a man twice his age.</sd>
+         <sp spk="SKYWALKER">
+		I'm all right.  I can still move 
+		about by myself.</sp>
+         <sd>A rough looking sergeant grabs Captain Oxus.</sd>
+         <sp spk="SERGEANT">
+		What are you doing here?
+			
+				 OXUS
+		We're out of power, sir.</sp>
+         <sp spk="SERGEANT">
+		Let me see your passes!</sp>
+         <sp spk="OXUS">
+		I have it here, somewhere.  We've 
+		been relocated to a hortastation, 
+		by royal order...</sp>
+         <sd>Oxus fumbles to retrieve something from his pocket, and 
+	eventually pulls out a small  round disc.  The sergeant 
+	puts the disc in a small portable reader.  Various computer 
+	readouts are displayed on the monitor.  Valor starts to put 
+	a power pack into one of the speeders.</sd>
+         <sp spk="SERGEANT">
+		What are you doing there?  All 
+		power has been restricted.</sp>
+         <sp spk="SKYWALKER">
+		We've run out.  We must have power, 
+		or be forced to stay here  and 
+		become your responsibilities.</sp>
+         <sd>The sergeant thinks about this for a moment  as the old 
+	wise general watches him.  Tension fills the air.  Valor 
+	shuffles around to a position where he can reach his weapon. 
+	A trooper hands the sergeant a message.</sd>
+         <sp spk="SERGEANT (to Oxus)">
+		Take only two of those power packs 
+		and then move out quickly.</sp>
+         <sd>The sergeant hurries to a military craft, where he takes a 
+	call on an intercom.  General Skywalker and his two young 
+	captains load the remaining power packs into the speeder 
+	and roar away from the station.</sd>
+      </scene>
+      <scene n="71">
+         <setting>WASTELAND - TOWNOWI</setting>
+         <sd>The speeders race along through the rocky desert wasteland. 
+	The general speaks into the intercom to Valor</sd>
+         <sp spk="SKYWALKER">
+		Keep a close watch.  If that sergeant 
+		runs an analysis on those passes  we 
+		might be seeing him again.  We should 
+		be safely inside Gordon within the day.</sp>
+         <sd>Everyone is in good spirits.  The princess and her young
+	brothers sing a Townowi melody, which is transmitted to Valor 
+	in the smaller speeder.  The general takes little Puck,  and 
+	lets him sit on his lap in the forward compartment of the 
+	speeder.  A-2 flexes C-3's arm back and forth  attempting 
+	to discover the cause of a loud squeak.</sd>
+         <sd>			 A-2
+		Oilar doesn't seem to help at all.</sd>
+         <sd>			 C-3
+		It's all this filth and dust.  This 
+		environment is murderous.</sd>
+         <sd>Valor notices a small speck on the horizon.</sd>
+         <sp spk="JUSTIN (into intercom)">
+		Object approaching, bearing three 
+		point two.</sp>
+         <sd>The general looks through an electrotelescope mounted in the 
+	speeder.  He spots a distant row of troopers riding strange 
+	dune birds.</sd>
+         <sp spk="SKYWALKER (to Justin)">
+		It's a patrol.  It could mean trouble. 
+		We'd better split up.  You stay on a 
+		direct course.  We'll meet you at the 
+		western edge of ravine 23-64.  Stay in 
+		contact.</sp>
+         <sd>The larger speeder makes a sharp left turn, speeding off
+	across a deep ravine.  Valor can begin to distinguish the 
+	approaching troopers.</sd>
+         <sp spk="JUSTIN">
+		It looks like there are ten of them. 
+		They're heading right for me.  Wait 
+		a second.  They've disappeared.  I've 
+		lost them.</sp>
+         <sp spk="SKYWALKER">
+		Continue on ahead.</sp>
+      </scene>
+      <scene n="72">
+         <setting>WASTELAND LAKEBED - TOWNOWI</setting>
+         <sd>Oxus deftly maneuvers the bulky speeder through a narrow 
+	boulder-strewn ravine.  They eventually come out on a dry 
+	lake bed, where they stop.  Standing not more than a hundred 
+	feet away, apparantly waiting for the speeder, are five 
+	royal troops on their dune birds.</sd>
+         <sp spk="SKYWALKER">
+		We've found them, five of them, 
+		anyway.  Watch yourself.</sp>
+         <sd>The troops slowly ride their huge birds over to the speeder 
+	and dismount.  The officer in charge is a vicious looking 
+	warrior  with a large scar across his face.</sd>
+         <sp spk="OFFICER">
+		Let me see your passes.</sp>
+         <sd>Oxus hands him the small pass disc, and he places it in his 
+	reader.  He studies the computer readout for a few moments 
+	and then returns the disc to Oxus.</sd>
+         <sp spk="OFFICER">
+		Have you seen any other transports 
+		in this area?</sp>
+         <sp spk="SKYWALKER">
+		We saw two heading south.  Going 
+		towards Ansel, looked like to me.</sp>
+         <sp spk="OFFICER">
+		All right.  Be on your way.</sp>
+         <sd>The officer mounts his dune bird, and the patrol moves away. 
+	Oxus winks at the princess  and smiles at the general, as 
+	the speeder starts off across the dry lake.  The general 
+	fiddles with the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, are you clear?</sp>
+         <sp spk="JUSTIN">
+		I have five troopers approaching. 
+		Any problem your end?</sp>
+         <sp spk="SKYWALKER">
+		We came through all right.  You 
+		shouldn't have any trouble, but stay 
+		alert.</sp>
+         <sp spk="JUSTIN">
+		Best wishes!  Here they come.</sp>
+         <sd>Everyone rides along in silence, a little worried about
+	Captain Valor, especially the princess.</sd>
+         <sp spk="PRINCESS">
+		Do you think he'll be all right?</sp>
+         <sp spk="SKYWALKER">
+		He can take care of himself.</sp>
+         <sd>Oeta is looking out the back window of the speeder.</sd>
+         <sp spk="OETA">
+		Hey look!  They're coming back.</sp>
+         <sd>Everyone looks to see the patrol quickly gaining on them.</sd>
+         <sp spk="SKYWALKER">
+		Stop!  They're faster.  Get 
+		your weapon.</sp>
+         <sd>The speeder screeches to a halt in a cloud of dust.  The
+	general and his captain jump from the transport with lazer-
+	pistols drawn.  The patrol bears down on them, swords drawn, 
+	at full charge.  Both the general and Oxus fire.  Two of the 
+	troopers and their dunebirds explode in a cloud of smoke. 
+	The remaining three troopers are upon the duo in a matter 
+	of seconds.  The general ignites his lazersword and cuts down 
+	two of the troops as they pass.  The last turns his bird 
+	around before reaching the speeder, and hightails it back 
+	towards the ravine.  The general jumps onto one of the 
+	riderless dunebirds and takes off in pursuit.  Oxus checks 
+	the dead troopers.</sd>
+      </scene>
+      <scene n="73">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The general rides at breakneck speed after the fleeing
+	trooper.  His lazersword is raised high over his head, ready 
+	to deal a deathblow.  The lumbering birds race through the 
+	winding ravine.</sd>
+      </scene>
+      <scene n="74">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The intercom warning buzzer begins to scream.  Oxus rushes 
+	for it  but the princess gets there first.
+					 
+				 PRINCESS
+		Are you all right?</sd>
+         <sp spk="JUSTIN">
+		Two riders heading your way.  I 
+		got three, but two got away. 
+		Watch yourselves!</sp>
+      </scene>
+      <scene n="75">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The general is riding neck and neck with the trooper.  He
+	swiftly brings his sword down and the trooper drops from 
+	his saddle.  The momentum of his charge carries the general 
+	around a bend in the ravine  and right inTO the path of two 
+	more troops charging down on him.  The two troopers are 
+	taken by surprise.  They stop their birds  and so does the 
+	general.  They stand there, about fifty yards apart, sizing 
+	up each other.  Suddenly, the two troopers start for the Dai 
+	warrior at full speed.  The general raises his sword  and 
+	starts for them.  The troopers are no match for the general 
+	who kills them both before they are even able to swing their 
+	swords.</sd>
+      </scene>
+      <scene n="76">
+         <setting>WASTELAND LAKEBED - TOWNOWI</setting>
+         <sd>Valor stops near the larger landspeeder and gets out.  He 
+	is wounded.  Blood streams from his left arm.  Oxus rushes 
+	to help him.  The princess shows a great deal ofconcern.</sd>
+         <sp spk="OXUS">
+		It looks worse than it is.  You'll 
+		be all right.</sp>
+         <sd>Oxus motions to the princess, who looks a little relieved.</sd>
+         <sp spk="OXUS">
+		Bring me the med aid pack.</sp>
+         <sp spk="PRINCESS">
+		It he was clumsy enough to get hurt, 
+		maybe we ought to let him bleed to 
+		death.</sp>
+         <sd>She hands Oxus the kit, as the general rides up and dis-
+	mounts.  He moves to Valor.</sd>
+         <sp spk="SKYWALKER">
+		You missed two.</sp>
+         <sp spk="JUSTIN">
+		I know. I couldn't...</sp>
+         <sp spk="SKYWALKER">
+		Don't let it happen again. 
+		We'd better move out.  They might 
+		have reported in.</sp>
+      </scene>
+      <scene n="77">
+         <setting>CONTROL ROOM - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The dark and sinister Dodona moves several markers on a
+	large map readout to form a line from the destroyed under-
+	ground fortress to the spaceport at Gordon.  An aide enters 
+	with General Vader.</sd>
+         <sp spk="AIDE">
+		The patrol was lost, sir.  All 
+		ten of them.</sp>
+         <sp spk="DODONA">
+		It's to be expected.</sp>
+         <sp spk="VADER">
+		Have you found them?</sp>
+         <sp spk="DODONA">
+		They're heading for the spaceport 
+		at Gordon.  I'm going there.  Have 
+		all security doubled.  Make it an 
+		alert.</sp>
+      </scene>
+      <scene n="78">
+         <setting>THE OUTSKIRTS OF GORDON - TOWNOWI</setting>
+         <sd>The speeders stop on a bluff overlooking a small cantina on 
+	the outskirts of Gordon.  The spaceport can be seen in the 
+	distance.  The general and Captain Oxus walk over to the 
+	smaller speeder.  Valor helps the two androids out of their 
+	cramped quarters.</sd>
+         <sd>			 C-3
+		Your kindness is greatly appreciated.</sd>
+         <sp spk="JUSTIN (to Skywalker)">
+		I'm fit enough to...</sp>
+         <sd>The general gives him a hard look and he shuts up.  Oxus 
+	and the general climb into the speeder.</sd>
+         <sp spk="SKYWALKER">
+		We'll make contact at zero four 
+		hundred.  If we're not back by 
+		fifty-five forty, get worried.</sp>
+         <sd>The speeder starts off toward the cantina.</sd>
+      </scene>
+      <scene n="79">
+         <setting>SPACEPORT CANTINA - TOWNOWI</setting>
+         <sd>The speeder pulls up in front of the low  blockhouse style 
+	cantina.  Various strange forms of transport are parked out-
+	side the bar.</sd>
+         <sp spk="SKYWALKER">
+		Take care here.  If there is any 
+		trouble, get back to the others.</sp>
+         <sd>The general and Oxus enter the shabby cantina.  The murky 
+	little den is filled with a startling array of weird and 
+	exotic alien creatures, laughing at the bar.  At first, the 
+	sight is horrifying.  One-eyed, thousand-eyed, slimy, furry, 
+	scaly armed creatures with tentacles and claws huddle over 
+	drinks.  The general looks over the patrons, but does not 
+	see the contact, Han Solo. A large multiple-eyed creature 
+	shoves the general.</sd>
+         <sp spk="CREATURE">
+		Assha dughi wouldugga?</sp>
+         <sd>The general tries to ignore the creature  and turns back to 
+	his drink.  A short  grubby looking human  and an even 
+	smaller  rodent-like creature join the first creature.</sd>
+         <sp spk="HUMAN">
+		He doesn't like you.</sp>
+         <sp spk="SKYWALKER">
+		I understood him.</sp>
+         <sp spk="HUMAN">
+		I don't like you either.</sp>
+         <sp spk="SKYWALKER">
+		I'm sorry.</sp>
+         <sd>The big creature is getting agitated  and yells at the
+	general.</sd>
+         <sp spk="HUMAN">
+		Don't insult us.  You just watch 
+		yourself.  We're wanted men.  I 
+		have the death sentence on twelve 
+		systems.</sp>
+         <sp spk="SKYWALKER">
+		I'll be careful then.</sp>
+         <sp spk="HUMAN">
+		You'll be dead.</sp>
+         <sd>The short rodent yells something  and everything at the bar 
+	moves away.  The general assumes a defensive position.  His 
+	three adversaries ready their weapons.</sd>
+         <sp spk="SKYWALKER">
+		You insist on a fight then?</sp>
+         <sp spk="HUMAN">
+		Just try and kill us.</sp>
+         <sp spk="SKYWALKER">
+		It will hurt a little.</sp>
+         <sp spk="HUMAN">
+		We aren't cowards.</sp>
+         <sp spk="SKYWALKER">
+		Then it can't be helped.</sp>
+         <sd>The general's lazersword sparks to life.  An arm lies on the 
+	floor.  The rodent is cut in two  and the large  multiple-
+	eyed creature lies doubled, cut from chin to groin.  The 
+	general  with quiet dignity  replaces his sword in its sheath. 
+	The entire fight has lasted only a matter of seconds.  A 
+	figure stands in the doorway watching the general.  As soon 
+	as the general notices him, he leaves.  The cantina goes back 
+	to normal, as if nothing had happened, although the general 
+	is given a respectable amount of room at the bar.  The Dai 
+	finishes his drink  and then leaves.  Captain Oxus follows.</sd>
+      </scene>
+      <scene n="80">
+         <setting>SPACEPORT ALLEYWAY - GORDON - TOWNOWI</setting>
+         <sd>General Skywalker embraces Han Solo, the underground contact. 
+	Han is a huge  green skinned monster with no nose and large 
+	gills.</sd>
+         <sp spk="HAN">
+		You old stardog.  Took a war to get 
+		you out here...</sp>
+         <sd>Oxus arrives with Captain Valor, the princess, and her
+	brothers, and the two puzzled androids.</sd>
+         <sp spk="SKYWALKER">
+		It's been too long.  We've been through 
+		much together.  It will be good to have 
+		you out of retirement and back at my 
+		side.  How is General Valor?  (putting 
+		his arm around the young Captain Valor)  
+		This is his son.</sp>
+         <sp spk="HAN">
+		You're all the old boy will talk about. 
+		He's still holding up.  Come, let's get 
+		off the street.</sp>
+         <sd>The group enters a small doorway at the far end of the alley-
+	way.  On the main street, within view of the doorway, giant 
+	royal airtanks and other military hardware rumble through 
+	the city.  Starving refugees sit in the gutter watching the 
+	immense display of force with a mixture of awe and terror. 
+	The princess stops for a moment  and stares at her people, 
+	watching the might of the kingdom.  The general escorts her 
+	through the doorway with the others.</sd>
+      </scene>
+      <scene n="81">
+         <setting>SLUM DWELLING - LIVING AREA - TOWNOWI</setting>
+         <sd>The seedy dwelling is dark and dingy.  The group is greeted 
+	by three underground leaders, and the old Dai, Akira Valor. 
+	Justin embraces his father as the underground leaders bow 
+	before the princess.</sd>
+      </scene>
+      <scene n="82">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>The princess walks through the dining area, followed by Oxus 
+	and Valor, who carry the two sleeping princes.  The general 
+	sits at a large table  finishing dinner with Han, Akira, 
+	and the three underground leaders.  Oxus returns from the 
+	bedroom.</sd>
+         <sp spk="SKYWALKER (to Oxus)">
+		Captain, why don't you take the 
+		androids into the other room for 
+		a game of chess?  I'm sure they'd 
+		enjoy it.</sp>
+         <sd>			 C-3
+		A wonderful idea.  Your kindness 
+		is greatly appreciated.</sd>
+         <sd>Oxus escorts the two robots into the next room.  DATOS, a 
+	thin  wizened old man, seems greatly relieved.</sd>
+         <sp spk="DATOS">
+		You're taking a great risk travelling 
+		with them.  This whole operation 
+		sounds bad to me.  I don't trust the 
+		chrome companies.  Time is growing 
+		short.  The King's attempts at control 
+		have already caused a great deal of 
+		suffering to our people.</sp>
+         <sd>OCCO, a brash young rebel  about the same age as Captain
+	Valor  slams his fist on the table.</sd>
+         <sp spk="OCCO">
+		It must happen now!  We are ready. 
+		Each day the royal S.B.T. finds and 
+		destroys a few more in the organiza-
+		tion.  We cannot wait any longer.</sp>
+         <sp spk="SKYWALKER">
+		Any uprising without a coordinated 
+		attack on the death star is out of 
+		the question.</sp>
+         <sp spk="HAN">
+		He's right.  As long as it's 
+		operational, any action down here 
+		would be meaningless.  We must 
+		proceed as planned.  Are the 
+		arrangements secure?</sp>
+         <sd>QUIST, the third member of the underground, sparks to life 
+	and places several discs and badges on the table.</sd>
+         <sp spk="QUIST">
+		All passenger transport has been 
+		suspended, so we've arranged for 
+		you to travel as the crew of a 
+		Baltarian freighter.  The boys 
+		will have to be placed in suspended 
+		animation and hidden in shielded 
+		micropacks.  It's the only way we 
+		will be able to get them past the 
+		scanners.</sp>
+         <sp spk="DATOS">
+		Were you able to aquire the necessary 
+		power packs?</sp>
+         <sp spk="QUIST">
+		It's become a serious problem.  All 
+		power supplies have been restricted. 
+		S-4 units are impossible to come by.</sp>
+         <sp spk="HAN">
+		I know an agent who might be able to 
+		acquire them for us.  I'll check with 
+		him.  It will be risky, but we've no 
+		other choice.</sp>
+      </scene>
+      <scene n="83">
+         <setting>SPACEPORT OBSERVATION DECK - TOWNOWI</setting>
+         <sd>The dark figure of Dodona stands overlooking a group of
+	Townowi partisans who are being tortured in the plaza below. 
+	Two royal officers are finishing a report to the evil legion-
+	naire.  They salute smartly, then leave the observation 
+	balcony  passing KURO, one of General Vader's aides, who 
+	approaches Dodona  and bows low before him.  Kuro and the 
+	legionnaire carry on an animated conversation;  it is 
+	inaudible over the screams of the tortured partisans.</sd>
+      </scene>
+      <scene n="84">
+         <setting>SLUM DWELLING - ALLEYWAY - TOWNOWI</setting>
+         <sd>Residents glance fearfully from their windows as six royal 
+	stormtroopers make their way through the crowded slum alley-
+	way.  Han Solo and Captain Valor move cautiously past the 
+	royal patrol  and disappear into the shabby hideout of the 
+	partisan underground.</sd>
+      </scene>
+      <scene n="85">
+         <setting>SLUM DWELLING - MAIN AREA - TOWNOWI</setting>
+         <sd>The two men enter the dingy main room of the slum dwelling 
+	and are immediately attacked by Oeta, wielding a toy sword. 
+	Valor good-naturedly fends off the young prince  as Han, in 
+	a more serious mood, goes into the other room.  A-2 and C-3 
+	are helping Puck put together a block-like puzzle.  Princess 
+	Zara comes in to see what all the commotion is about, just 
+	as the young captain grabs Oeta by the foot and holds him 
+	upside-down.   Valor and Oeta are laughing uproariously. 
+	Zara gives the captain a stern  disapproving look, then 
+	returns to the other room.</sd>
+      </scene>
+      <scene n="86">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>General Skywalker, Captain Oxus, and Datos are in the process 
+	of assembling two micropacks on the kitchen table.  Han pulls 
+	a small silver powerpack from his pocket, and places it on 
+	the table.  The old Dai, Akira Valor, reaches over with his 
+	one good arm  and takes it.  He inspects it carefully. 
+	Princess Zara sits quietly behind the general.</sd>
+         <sp spk="HAN">
+		We could only get one unit.  Their 
+		methods are proving to be very 
+		effective.</sp>
+         <sd>Akira places the powerpack back on the table.  The pain from 
+	those simple movements shows on his face.</sd>
+         <sp spk="AKIRA">
+		This will work fine.</sp>
+         <sp spk="HAN">
+		One of the boys will have to stay.
+		
+				 DATOS
+		We can't hide him for very long.
+		The risk is too great.  Which-
+		ever boy doesn't go must be des-
+		troyed.</sp>
+         <sd>The princess is alarmed, and looks to the general for support. 
+	He gives her an understanding look.</sd>
+         <sp spk="SKYWALKER">
+		Not while they're in my charge. 
+		Find another way to get him through.</sp>
+         <sp spk="DATOS">
+		There's no other way.  We've 
+		analyzed every possible alter-
+		native.  You can't jeopardize 
+		the enitre...</sp>
+         <sd>Captain Valor enters the room.</sd>
+         <sp spk="HAN">
+		We have no time for discussion. 
+		The freighters leave at zero 
+		three hundred.  We must get 
+		started.</sp>
+         <sd>Through a break in the door, Oxus watches A-2 and C-3 
+	play with the two young princes.</sd>
+         <sp spk="OXUS">
+		What about A-2?  Could we loboto-
+		mize him and use his energy pack?</sp>
+         <sp spk="SKYWALKER">
+		They're not compatible.  We'd 
+		have to completely change the 
+		system.</sp>
+         <sp spk="HAN">
+		It could work.</sp>
+         <sp spk="DATOS">
+		There isn't enough time.  You can't 
+		do it.</sp>
+         <sp spk="AKIRA">
+		You won't have to.  My power unit 
+		has more than half life.  Use it.</sp>
+         <sd>The withered Dai opens his tunic  revealing a metallic chest 
+	covered with electrodes.  With his one good arm  he grabs 
+	his chest and rips loose a miniature power unit similar to 
+	the one on the table.  Everyone is taken by surprise.  The 
+	general and the young Valor both rush to the side of the 
+	dying Dai.  The old man turns to his son.</sd>
+         <sp spk="AKIRA">
+		Trust my judgment, Son.  Serve your 
+		new teacher well.</sp>
+         <sd>The Dai's breathing becomes more difficult as he turns to 
+	the general.</sd>
+         <sp spk="AKIRA (Cont.)">
+		An honorable death, my friend. 
+		May the force of others be with 
+		you.</sp>
+         <sd>Akira Valor passes on to the other world.  Everyone is 
+	stunned.  The general breaks the moment of silence.</sd>
+         <sp spk="SKYWALKER">
+		May he be welcomed as a man above 
+		men.  Take him downstairs.</sp>
+         <sd>Justin takes his father in his arms and is followed out of 
+	the room by Han and Datos.</sd>
+         <sp spk="SKYWALKER">
+		Prepare the boys!  We have little 
+		time.</sp>
+         <sd>Princess Zara and Captain Oxus rush out of the room, as the 
+	general places the power units in the micropacks.</sd>
+      </scene>
+      <scene n="87">
+         <setting>SLUM DWELLING - MAIN AREA - TOWNOWI</setting>
+         <sd>Oeta and Puck are not happy about being dragged away from 
+	their puzzle.  Oxus takes the robots into the sleep area.</sd>
+         <sp spk="ZARA">
+		Now straighten up, Oeta.  Remember, 
+		father expects you to follow his ways. 
+		We are going on a trip.  There will be 
+		great danger.  You must go to sleep. 
+		When you wake, you will be in a strange 
+		land, so don't be alarmed.</sp>
+         <sp spk="OETA">
+		Are you going to sleep too?</sp>
+         <sp spk="ZARA">
+		I will be looking after you.  Now 
+		be good boys and stand still.  Lift 
+		your sleeve.</sp>
+         <sd>Puck lifts his sleeze and Zara injects him with a sleep
+	serum.  Oxus enters just as the little prince collapses 
+	into a deep sleep.  Quick as lightening, he catches the 
+	boy before he can hit the floor.  The princess injects 
+	her other brother  and he collapses into her arms.</sd>
+      </scene>
+      <scene n="88">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>The limp bodies of the two young princes are carried in 
+	by Zara and Captain Oxus.  They are carefully squeezed 
+	into the hollowed out microcases.  Zara pensively watches 
+	as the general expertly attaches electrodes to her 
+	brother's skull.  Han and Datos return from the burial 
+	of Akira.  The general looks up from his operation.</sd>
+         <sp spk="HAN">
+		He is at rest.  Are the systems 
+		working all right?</sp>
+         <sp spk="SKYWALKER">
+		Full power.  Is everything ready?</sp>
+         <sd>Datos nods yes, as the general closes the case holding Puck. 
+	The strain of watching her brothers placed in suspended 
+	animation is too great for Zara  and she retreats into the 
+	main room.</sd>
+      </scene>
+      <scene n="89">
+         <setting>SLUM DWELLING - MAIN ROOM - TOWNOWI</setting>
+         <sd>Captain Valor stands brooding near a window overlooking 
+	the crowded alleyway.  He does not acknowledge Zara's 
+	entrance.  She walks over to the window and stands next to 
+	the young captain.  They are very close but do not touch.</sd>
+         <sp spk="ZARA">
+		I'm sorry.</sp>
+         <sd>He does not respond.  She is moved by his sorrow  and 
+	starts to touch the side of his face  but can't bring her-
+	self to do it.  Her royal training is too strong to let her 
+	show her true affection for Justin.  She breaks down and 
+	runs from the room.  The young Dai continues his meditation.</sd>
+      </scene>
+      <scene n="90">
+         <setting>SPACEPORT AT GORDON - SECURITY RAMP - TOWNOWI</setting>
+         <sd>The spaceport is very crowded.  People rush about in a
+	panicked rush as loudspeakers blurt out indiscernible
+	announcements.  The Royal Galactic Kingdom is in the process 
+	of changing the boarding procedures and the result is chaos. </sd>
+         <sd>Many flights are delayed, and people are running to and 
+	fro, switching boarding ramps.  Han guides the rebel group, 
+	dressed as a Baltarian crew, through the crowded terminal. 
+	Oxus and Valor carry the large micropacks strapped to their 
+	backs.  The robots follow a few paces behind.</sd>
+         <sp spk="HAN">
+		They're changing the boarding 
+		procedures.  I don't like it.</sp>
+         <sd>They are swept into a boarding gate and finally reach a
+	security ramp scan station.  There are a great number of
+	troops and guards standing around the security area.  An
+	officer demands to see their passes and orders.  The ten-
+	sion builds as the officer confers with an aide about the 
+	passes.  The aide speaks quietly into a phone.</sd>
+         <sp spk="OFFICER">
+		Where are your component receipts?</sp>
+         <sd>Valor and Oxus hand the officer two additional discs, 
+	which are placed in the computer.  A few moments later, 
+	the readout appears  and the group is motioned through the 
+	electron scanners.  On the other side of the scanner, new 
+	computer discs are issued to the group.  The group seems 
+	slightly relieved as they walk through several hallways 
+	leading to where the freighter is docked.  Valor moves 
+	next to  the general.</sd>
+         <sp spk="JUSTIN">
+		I don't like the feel of this.</sp>
+         <sp spk="SKYWALKER">
+		Your senses are strong.  It's a 
+		very small disruption.</sp>
+         <sp spk="JUSTIN">
+		It's a Lettow legionnaire.</sp>
+         <sp spk="SKYWALKER">
+		Possibly.  Stay alert.  Warn 
+		the others.</sp>
+         <sd>The group walks through the docking links and into the
+	Baltarian spacecraft.  Several royal guards pass them, 
+	and everyone is ready for the suspected trap, but 
+	nothing happens.</sd>
+      </scene>
+      <scene n="91">
+         <setting>INTERIOR - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The group stops in a narrow electronic  passageway near 
+	the bridge of the ship.  Valor and Oxus unstrap the 
+	micropacks containing the two young princes, and check 
+	the voltage packs.</sd>
+         <sp spk="OXUS">
+		Little Oeta is losing power faster 
+		than normal.  I'd better check it 
+		out.
+		
+				 SKYWALKER
+		Wait until the situation is secure. 
+		Stay here, and keep on your guard.
+		Han!</sp>
+         <sd>The two young captains grow suspicious of several workmen 
+	gathering around the main exit hatch.  Han and the general 
+	enter the bridge area.  Several crewmen sit at elaborate 
+	controls and computer stations.</sd>
+         <sp spk="SKYWALKER">
+		Where is your captain?</sp>
+         <sd>One of the crewmen directs him to a small chamber above the 
+	bridge.  Valor and Oxus strap on their micropacks as more 
+	workmen converge at the main hatch and begin to close it. 
+	The two robots, A-2 and C-3 are confused about what is 
+	going on  and wear their gear in anticipation of moving.</sd>
+      </scene>
+      <scene n="92">
+         <setting>PILOT CHAMBER - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Han and the general enter the small pilot's chamber and 
+	greet the captain, whose face is hidden in the shadows of 
+	a computer bank.</sd>
+         <sp spk="CAPTAIN">
+		Welcome, gentlemen.  You must 
+		have had a difficult journey. 
+		We'll be departing shortly.</sp>
+         <sd>Four 	armed troopers silently enter the room behind the two 
+	old Dai;  their lazerswords are drawn.</sd>
+         <sp spk="CAPTAIN ">
+		I have been authorized to accept 
+		payment for the chrome company 
+		cooperation.  I assume you've 
+		brought it with you.</sp>
+         <sd>The captain moves out of the shadows  and is revealed to 
+	be Dodona.  Instantly, both Han and the general understand 
+	the situation.  They turn, drawing their lazerswords in 
+	the move  and cut down the four royal troopers.  The door 
+	to the chamber instantly seals shut.  Dodona hasn't made 
+	any moves  and remains unusually calm.  The two Dai turn
+	to face him.</sd>
+         <sp spk="DODONA">
+		Its over, gentlemen.  The chamber 
+		is sealed.  Dont force me to 
+		release the Jai gas.</sp>
+         <sd>A tone sounds, and Dodona turns to an intercom.</sd>
+         <sp spk="INTERCOM">
+		Situation secure.  Prisoners taken to 
+		hold "B";  Twelve casualties... gas 
+		was necessary.</sp>
+         <sd>Han and the general relax and drop their weapons.  The 
+	door silently opens behind them and six guards enter wearing 
+	facemasks.  They bind the two Dai with chrome microcuffs.  A 
+	satisfied smile creeps across Dodona's face.  General Sky-
+	walker seems unimpressed with the trap.</sd>
+         <sp spk="DODONA">
+		At last, it's ended.  <sd>to guard</sd>  Take 
+		them to hold "G."  I don't want them 
+		with the others.  Prepare for departure.</sp>
+         <sd>The troopers escort Han and the general out of the chamber 
+	and down several hallways.</sd>
+      </scene>
+      <scene n="93">
+         <setting>INTERIOR - BALTARIAN FREIGHTERS - TOWNOWI</setting>
+         <sd>Eight troops march Han and the general into the hold of the 
+	ship.  They pass near the main exit  where A-2 and C-3 
+	stand deserted, looking lost.  C-3 sees the general pass in
+	a nearby hallway</sd>
+         <sd>			 C-3
+		Well, there he is.  Come on.</sd>
+         <sd>The robots waddle off after the Dai prisoners.  As the 
+	small procession passes detention cell B where the princess 
+	and the others are being held, Han and the general let out 
+	a horrifying Dai scream and leap to the corridor ceiling, 
+	thrusting their bound wrists into the lighting fixtures. 
+	They land on top of the troops, instantly breaking the 
+	necks of four guards, with expertly placed blows.  The 
+	eight surviving guards are momentarily dumbfounded.  Han 
+	and the general grab lazerswords from their victims  and 
+	swiftly cut down the remaining troops.  Han grabs a small 
+	card from one of the dead guards  and starts for detention 
+	cell  B.</sd>
+         <sp spk="SKYWALKER">
+		Watch it!   Those are cutters.</sp>
+         <sd>The general grabs one of the dead troopers and tosses him
+	against the cell door.  Red rays engulf the body  and holds 
+	it there.  Han then places the card in a slot  and the door 
+	silently slides open.  Valor and Oxus leap for the dead 
+	guard, then notice the death ray surrounding him.  General 
+	Skywalker grabs another body and throws it into the doorway.</sd>
+         <sp spk="SKYWALKER">
+		Pass between them!</sp>
+         <sd>Captain Valor squeezes between the slain guards  and is 
+	untouched by the rays.  Oxus and the princess quickly follow, 
+	picking up weapons as they leave.</sd>
+         <sp spk="JUSTIN">
+		They've taken the cases.</sp>
+         <sp spk="SKYWALKER">
+		Are they aware of the boys?</sp>
+         <sp spk="OXUS">
+		I don't think so.</sp>
+         <sp spk="SKYWALKER">
+		Find them.  Use your seeker. 
+		We'll meet you at the main 
+		hatch.  Watch yourselves.  If 
+		an alarm is given, they'll gas 
+		the entire ship.</sp>
+         <sp spk="OXUS">
+		Yes, Sir.</sp>
+         <sd>Oxus and Valor each take a small humming device from their 
+	utility belts and head down a narrow hallway.  The general, 
+	Han, and the princess continue toward the main hatch.  A-2 
+	and C-3 have been completely confused by the turn of events. 
+	They eventually follow the general toward the exit hatch.</sd>
+      </scene>
+      <scene n="94">
+         <setting>ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The two young captains reach a storage area of the huge
+	spacecraft.  They watch their seekers as they move along a 
+	row of electroclosets.  They quietly sneak past a group of 
+	workmen assembling a large gyrohousing.  A second row of 
+	micropacks is searched to no avail.</sd>
+         <sp spk="OXUS">
+		If they were discovered, they would 
+		have been sent to a medical station.</sp>
+         <sp spk="JUSTIN">
+		There are more storage areas on the 
+		far side.</sp>
+      </scene>
+      <scene n="95">
+         <setting>MAIN HATCH AREA - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Han and the general reach the main hatch, closely followed 
+	by Zara and the two robots.  Several lights over the hatch 
+	flash on and off.  The general cuts a camera off the wall 
+	with his lazersword.</sd>
+         <sp spk="HAN">
+		They're going to take off.  It's 
+		too late.
+		
+				 SKYWALKER
+		C-3,  come over here!</sp>
+         <sd>The lanky chrome man approaches the general, who is studying 
+	a complex computer control panel next to the hatch.</sd>
+         <sd>			 C-3
+		Yes sir.  May I be of service?</sd>
+         <sp spk="SKYWALKER">
+		Get this hatch open.  Counterlock 
+		the departure pattern.</sp>
+         <sd>The robot immediately starts pushing buttons on the panel.</sd>
+      </scene>
+      <scene n="96">
+         <setting>ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Captain Valor and Oxus reach a second series of electro-
+	closets.  A signal appears on the seekers  and Valor cuts 
+	down the door of one of the small cabinets.  Oxus stands 
+	guard.  Approaching troops are heard in the distance. 
+	Valor quickly rummages through the electropacks until he 
+	spots the familiar cases containing the two boys.</sd>
+         <sp spk="OXUS">
+		Troops!</sp>
+         <sd>Valor straps on one of the backpacks  and hands the other 
+	to Oxus, as they duck into a narrow passageway.  Four 
+	troops march through a nearby hallway.  After they have 
+	passed, the young captain checks to make sure the way is 
+	clear, then runs down a hallway toward the main hatch.</sd>
+      </scene>
+      <scene n="97">
+         <setting>BRIDGE - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>As the crew makes the final preparations for the blast off, 
+	the main hatch light blinks on.  One of the pilots notices 
+	the light and begins to check it out.</sd>
+         <sp spk="PILOT (into intercom)">
+		Is the main hatch secure?</sp>
+      </scene>
+      <scene n="98">
+         <setting>MAIN HATCH - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The intercom sparks to life, and the general answers it.</sd>
+         <sp spk="SKYWALKER">
+		Everything looks secure, but give 
+		me a minute to check it out.</sp>
+         <sp spk="PILOT">
+		All right.  Stand by.</sp>
+         <sd>The general winks to Han, as C-3 continues his attempt to 
+	override the hatch computer.</sd>
+      </scene>
+      <scene n="99">
+         <setting>HALLWAYS - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Captain Valor and Oxus cautiously move down a long hallway, 
+	ever watchful of royal troops.  They reach an intersection, 
+	carefully check in all directions, then rush down a main 
+	hallway.  They are about half-way down the hallway, when a 
+	squad of royal guards appears at the end of the hallway 
+	facing them.  The troops start toward the two captains, with 
+	lowered lazerrifles.</sd>
+         <sp spk="VALOR">
+		Here's where it gets tricky.</sp>
+         <sd>Valor, then Oxus, quickly and smoothly draw their lazer-
+	pistols and fire at the troops.  A giant explosion destroys 
+	the far end of the hallway.  A few lazerbolts are returned, 
+	but streak harmlessly overhead  and explode out of range. 
+	The exchange of gunfire lasts only a few moments.  When the 
+	smoke clears, the troops have been destroyed.</sd>
+      </scene>
+      <scene n="100">
+         <setting>MAIN HATCH - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The main hatch slowly begins to slide open, when the 
+	rumbling explosion of lazerfire echoes through the hallways. 
+	Han looks to the general  and they both instantly realize 
+	what has happened.  Han draws his weapons.  The hatch is 
+	now fully open.  Everyone stands silently  watching for the 
+	two captains.  Alarms start screaming throughout the ship, 
+	and the giant hatch slowly begins to close.</sd>
+         <sp spk="SKYWALKER">
+		Come on.  We can't wait.</sp>
+         <sd>The group reluctantly exit the spacecraft, giving one last 
+	look back to their lost friends.  The hatch continues to 
+	slowly close, as the alarm sirens wail.  Suddenly, Valor 
+	and Oxus round a corner and head for the ever-closing 
+	hatch, battling several royal troopers as they go.  Han and 
+	the general move up to the hatch and give cover fire.  Oxus 
+	slips through the shrinking opening, and yells to Valor to 
+	hurry.  Many more troops bear down on the young Dai as he 
+	squeezes through the very slim opening.  One of the troops 
+	dives after him  but is caught  and crushed by the emergency 
+	hatch.</sd>
+      </scene>
+      <scene n="101">
+         <setting>BOARDING RAMPS - GORDON SPACEPORT - TOWNOWI</setting>
+         <sd>The general leads the group through various corridors.</sd>
+         <sp spk="HAN">
+		Once the alarm sounds, the entire 
+		spaceport will shut down.</sp>
+         <sd>They stop at a junction.  At the far end of one hallway,
+	several troops guard a restricted passageway.</sd>
+         <sp spk="SKYWALKER">
+		That's the military section.</sp>
+         <sp spk="JUSTIN">
+		Fighter craft!</sp>
+         <sp spk="HAN">
+		But it's very heavily guarded. 
+		We can't take it with subtlety.</sp>
+         <sd>Before the general can answer, the acute scream of the
+	spaceport alarm reverberates through the corridors.  The
+	general, followed by his two young captains, charge toward 
+	the heavily guarded military passageway.  Han, with the 
+	princess and two robots, follow at a safe distance behind. 
+	A guard sees them coming  and orders them to stop.  Captain 
+	Valor and the general fire their lazerpistols and the 
+	passageway entrance and the troops disappear in a huge 
+	explosion.</sd>
+         <sd>The group jump over the dead guards and smoking rubble, then 
+	run through a series of hallways leading to a starship. 
+	They  stop just short of an intersection leading to a boarding 
+	ramp.  Valor peeks around a corner at two guards standing in 
+	front of the boarding ramp.</sd>
+         <sp spk="JUSTIN">
+		Cutters!  We'll have to draw them 
+		out. A blast might alert the crew.</sp>
+         <sp spk="SKYWALKER">
+		A-2,    Come here.</sp>
+         <sd>The little robot waddles over to the old Dai.</sd>
+         <sp spk="SKYWALKER">
+		Move to that intersection and sound the 
+		alarm.</sp>
+         <sd>The mechanical dwarf dutifully marches into the intersection 
+	and lets out a high, electronic scream.  The guards shut off 
+	the deadly lazer cutters, and cautiously approach the wailing 
+	robot.</sd>
+         <sp spk="GUARD">
+		What is it?  What's wrong?</sp>
+         <sd>With incredible speed, both guards are dropped by a few
+	precision blows from the two young captains.  They immediately 
+	drag the unconscious guards into the starship.</sd>
+         <sp spk="SKYWALKER">
+		Valor!  Oxus!  Stand guard.  I'll 
+		signal at take-off minus thirty.
+		And reverse that cutter!</sp>
+      </scene>
+      <scene n="102">
+         <setting>INTERIOR - ROYAL STARSHIP - TOWNOWI</setting>
+         <sd>Han and the general, followed by Zara and the robots, enter 
+	the royal starship.  They rush through several narrow hall-
+	ways leading to the bridge.  Two crew members leaving a con-
+	trol station  stumble into the group and are quickly dis-
+	patched by Han.  The princess waits with the robots as the 
+	general and Han enter the bridge.  The two pilots and 
+	navigator are taken by surprise and are promptly subdued. 
+	Han switches on the intercom and listens.</sd>
+         <sp spk="HAN">
+		How are we going to get them to 
+		open the silo cover?</sp>
+         <sp spk="SKYWALKER">
+		Send C-3 in here.  Dispose of any 
+		crewmen left on board.</sp>
+      </scene>
+      <scene n="103">
+         <setting>BOARDING RAMP - SPACEPORT - TOWNOWI</setting>
+         <sd>Valor and Oxus now wear the uniform of the royal guard. 
+	Oxus has removed a plate from the cutter machinism and is 
+	crossing a few wires.  He replaces the cutter plate just as a 
+	squad of stormtroopers rushes toward the door.  An officer 
+	salutes them.</sd>
+         <sp spk="OFFICER">
+		Have you seen them?</sp>
+         <sp spk="JUSTIN">
+		No, Sir.</sp>
+         <sp spk="OFFICER">
+		They're in this section somewhere. 
+		I'm doubling all the guards.  Stay 
+		alert.</sp>
+         <sd>Two guards take up positions just outside the cutter areas, 
+	and the squad moves on to another starship.  Valor gives 
+	his partner a philosophical look.</sd>
+      </scene>
+      <scene n="104">
+         <setting>INTERIOR - ROYAL STARSHIP - TOWNOWI</setting>
+         <sd>The gleaming chrome C-3 sits in the pilot's seat  talking 
+	on the intercom to a controller.  He breaks off his continual 
+	drone of take-off instructions to the controller  and turns 
+	to the general, shaking his head.</sd>
+         <sd>			 C-3
+		They won't buy it.  I think they're 
+		getting suspicious.</sd>
+         <sd>Han enters.</sd>
+         <sp spk="HAN">
+		The crew is taken care of.</sp>
+         <sp spk="SKYWALKER">
+		Well, they're not going to open 
+		the silo cover, so I'm afraid we'll 
+		have to take it with us.</sp>
+         <sp spk="HAN">
+		We're going to sustain considerable 
+		damage if we blast off through that 
+		cover.</sp>
+         <sp spk="SKYWALKER">
+		It's a thin  shell.  There is no 
+		choice.  <sd>to C-3</sd>  Signal the boys.</sp>
+      </scene>
+      <scene n="105">
+         <setting>BOARDING RAMPS - SPACEPORT - TOWNOWI</setting>
+         <sd>Warning lights flash and the main hatch to the starfighter 
+	slowly begins to close.  The two royal stormtroopers yell 
+	at Valor and Oxus.</sd>
+         <sp spk="STORMTROOPERS">
+		Watch it!  Don't fire into those 
+		cutters!  <sd>to Valor</sd>  Shut down 
+		the cutters!</sp>
+         <sd>The two captains pretend to be confused  and not understand. 
+	At the last minute  they leap aboard the starship.  The hatch 
+	slides closed  and the boarding ramp drops away.  Several 
+	more guards arrive  and give the troopers a special card, 
+	which turns the small cutter warning lights from red to green. 
+	The guards rush on to the boarding ramp and are wiped out by 
+	the reversed cutters.</sd>
+      </scene>
+      <scene n="106">
+         <setting>INTERIOR - STARSHIPS - TOWNOWI</setting>
+         <sd>They strap themselves into lifepods.  C-3 and the general 
+	move forward, and the giant ship shudders as it starts to 
+	lift off the launch pad.  With tense expressions, they all 
+	brace for the impact of the silo cover.</sd>
+      </scene>
+      <scene n="107">
+         <setting>STARSHIP - SPACEPORT SILO - TOWNOWI</setting>
+         <sd>The mighty starship thunders out of the silo, crashing
+	through the cover plate, sending shrapnel in all directions. 
+	The ship leaps toward the heavens.</sd>
+      </scene>
+      <scene n="108">
+         <setting>BOARDING CAMPS - SPACEPORT - TOWNOWI</setting>
+         <sd>Royal flight crews rush to their starships.  Pilots receive 
+	their clearances  and several giant silo covers swing away 
+	revealing deadly hunter-destroyer spaceships.</sd>
+      </scene>
+      <scene n="109">
+         <setting>INTERIOR - BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han and the general watch as five hunter-destroyers leave the 
+	spaceport at Gordon.</sd>
+         <sp spk="SKYWALKER">
+		We suffered light damage to a deflector 
+		fin.  It will take them quite a while 
+		to catch up with us now.  Tell the boys 
+		to get some rest.</sp>
+      </scene>
+      <scene n="110">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Han retreats to the aft section of the ship, where the two 
+	captains are checking out the two main lazercannons mounted 
+	in large rotating bubble turrets.</sd>
+         <sp spk="HAN">
+		The old boy says you two should get 
+		some rest.  You've got some time 
+		before they catch up to us.</sp>
+         <sd>Han notices the packs containing the young princes.</sd>
+         <sp spk="HAN (Cont.)">
+		Better store the boys in a lifepod. 
+		Secure them well.</sp>
+         <sd>He heads back toward the bridge, followed by Oxus.  Valor 
+	carries the two mircropacks to a lifepod and straps them in. 
+	He checks Oeta's energy supply.  It is low.  Zara approaches 
+	him.</sd>
+         <sp spk="ZARA">
+		Couldn't we let them out now?</sp>
+         <sp spk="JUSTIN">
+		It's better this way.  Things are 
+		going to get rough.</sp>
+         <sp spk="ZARA">
+		Will we make it?  Is there any 
+		hope?  Stay with me.  I love you.</sp>
+         <sd>Captain Valor is slightly shocked at this outburst.  The 
+	princess starts to cry and clings to him for support.</sd>
+         <sp spk="JUSTIN">
+		No-one is going to die, so stop acting 
+		like a child and start behaving like a 
+		queen.  What is this silly talk of love?  
+		You belong to the people of Townowi  and 
+		my job is to return you to them, nothing 
+		more.  Now straighten up and get into a 
+		lifepod.</sp>
+         <sd>She's deeply hurt by his callousness.  She breaks away from 
+	him and runs down a hallway into a lifepod.  He is tired 
+	and angry at the whole incident.</sd>
+      </scene>
+      <scene n="111">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>C-3 guides the starship toward the Ophuchi system.  The 
+	general watches the computer readout estimate the position 
+	of the royal hunter destroyers.</sd>
+         <sd>			 C-3
+		Hostile craft will intercept at 
+		thirty plus.</sd>
+      </scene>
+      <scene n="112">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Captain Valor rests in one of the lazercannon pod bays.  He 
+	is thinking about Zara.  Slowly, a smile creeps across his
+	face.  He makes a decision, jumps up  and hurries down a
+	hallway.  He taps on the lifepod bulkhead  and Oxus opens 
+	the door.  Valor is surprised.</sd>
+         <sp spk="OXUS">
+		What is it?</sp>
+         <sp spk="JUSTIN">
+		Where is Zara?</sp>
+         <sp spk="OXUS">
+		She went forward.  What's going 
+		on with you two?
+		
+				 JUSTIN
+		I love her.</sp>
+         <sp spk="OXUS">
+		You're asking for trouble.  She's a queen. 
+		Do you know what you're saying?</sp>
+         <sp spk="JUSTIN">
+		I don't care.  I've got to talk ...</sp>
+         <sd>Oxus just shakes his head, but before Valor can finish his 
+	sentence, the ship is rocked by a bombardment of proton 
+	torpedoes.  The intercom squawks to life.</sd>
+         <sp spk="SKYWALKER (over intercom)">
+		Get to those guns!</sp>
+         <sd>Captain Valor and Oxus rush to the lzercannons and jump into 
+	the protective suits and helmets.</sd>
+      </scene>
+      <scene n="113">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han enters the bridge and sits before a fire control center. 
+	The general sits in a chair  slightly behind and above C-3, 
+	directing the robot pilot.</sd>
+         <sp spk="SKYWALKER">
+		Turn around!  Let's face them.</sp>
+         <sd>A-2, sitting quietly in a corner, watches as C-3 punches 
+	new information into the computer and the giant starship 
+	swings around in a sharp circle.  Several torpedoes explode 
+	near the ship.  The general switches on the intercom.</sd>
+         <sp spk="SKYWALKER">
+		You boys ready?</sp>
+      </scene>
+      <scene n="114">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The captains adjust the lazercannon controls in front of 
+	them and check in with the general.</sd>
+         <sp spk="SKYWALKER">
+		They should be within range in 
+		twelve seconds...</sp>
+         <sd>Captain Valor adjusts his giant lazer ack-ack cannon, 
+	searching his electronic tracking screen for the hunter
+	destroyer.  Oxus is having a problem with one of the
+	rotating mechanisms on the huge gun.  He curses, climbs 
+	out of the chair, and attempts to fix it.</sd>
+         <sp spk="OXUS">
+		My vertical rotating circuits are 
+		out.</sp>
+         <sd>The princess straps herself into a small lifepod.  Only the 
+	slightest hint of concern or worry shows in her face.  She 
+	listens to her protectors relay instructions as the enemy 
+	approach.</sd>
+      </scene>
+      <scene n="115">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The starship shudders as the hunter destroyers open fire.
+	Han relays the ship's status to the general  as C-3 struggles 
+	to keep up with the barrage of orders.</sd>
+         <sp spk="HAN">
+		We're losing deflectors three 
+		thirty-one and ten forty-two.</sp>
+         <sp spk="SKYWALKER (to C-3)">
+		Cut hard to maridian nine zero 
+		six.  Level to three degrees.
+		<sd>into the intercom</sd>  We're 
+		coming under one.  Wait for my 
+		signal.</sp>
+      </scene>
+      <scene n="116">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The constant flashing of deflected lazer bolts reflect in 
+	the interior of the lazercannon bubble.  Captain Valor 
+	rechecks his firing swithces.  Oxus adjusts his headphones 
+	and lowers a glare reflector.  He raps on the power rotation 
+	circuits  and gives them a little test burst.  The pod 
+	instantly rotates a few degrees.  The large starship heads 
+	directly toward the three enemy ships and at the last moment 
+	dives under the attacking craft.  Valor watches the smaller 
+	crafts pass overhead, aching to open fire.  He calls Oxus on 
+	the intercom.</sd>
+         <sp spk="JUSTIN">
+		I've got no signal.  I'm on 
+		target.  What's wrong?  What 
+		is he waiting for?  I've got 
+		an open shield.</sp>
+         <sd>The three royal craft are firing incessantly at point blank 
+	range.</sd>
+         <sp spk="OXUS">
+		Wait for the signal.</sp>
+         <sd>But Captain Valor has a perfect shot and he can't wait.  He 
+	squeezes the trigger and the giant lazercannon, with a burst 
+	of smoke and electrical charge, opens up on the enemy craft. 
+	Moments later, the signal lights flash on and Oxus commences 
+	firing on the receding  hunter-destroyers.  Two of the royal 
+	craft break off, and prepare for another attack run.  The 
+	third is hit by a concentrated barrage from the two captains 
+	and begins spinning out of control until it finally explodes. 
+	Oxus gives the victory wave, which Justin gleefully returns. 
+	These moments of triumph are broken by the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, next run you wait for 
+		my signal.  We haven't much power to 
+		spare on your inaccurate grandstanding!</sp>
+         <sd>Justin's pride is wounded.  He resets his accelerators as 
+	the two remaining hunter-destroyers begin a second run.</sd>
+      </scene>
+      <scene n="117">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+		We have a weakened shield on the 
+		port turret...</sp>
+         <sp spk="SKYWALKER">
+		Warn Captain Valor.  Get him out of 
+		there.  <sd>to C-3</sd>  Change your 
+		heading by point five.</sp>
+      </scene>
+      <scene n="118">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Princess Zara listens to Han warn Valor.</sd>
+         <sp spk="HAN">
+		Your shield power is down.  Abandon 
+		that position and seal that section. 
+		Report!  Captain, do you hear me?  
+		Captain?!!!</sp>
+         <sd>Zara becomes worried that something has happened to Justin. 
+	The young captain switches off the intercom system and 
+	signals to Oxus that the system has gone dead.  Before Oxus 
+	can answer, the two hunter-destroyer spacecraft are upon 
+	them once again.  Lazer bolts flash all around them.  The 
+	general's signal flashes on, and the captain starts to 
+	return the fire.  One of the royal fighters concentrates 
+	its fire on Valor's weakened gunport.  A direct hit blows 
+	open a hole in the turret and everything that isn't bolted 
+	down is sucked into outer space, including Captain Valor. 
+	He bangs against the side of the starship, held only by a 
+	weakened lifeline.</sd>
+         <sd>The princess hears Oxus explain Valors predicament  and 
+	rushes back to help him.  She is stopped by a pressure 
+	locked door leading to the gun emplacement.</sd>
+      </scene>
+      <scene n="119">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The general orders C-3 to swing the spacecraft around and 
+	start a new attack.  He turns to A-2.</sd>
+         <sp spk="SKYWALKER">
+		Use the aft port.  See what you can 
+		do for Valor.</sp>
+         <sd>A-2 hurriedly waddles out of the bridge.  C-3 and Han 
+	simultaneously turn to the general.</sd>
+         <sd>			 C-3
+		More craft approaching!</sd>
+         <sp spk="HAN">
+		It looks like at least six or seven.</sp>
+         <sd>The general studies the radar scopes and then checks a
+	galactic map displayed on one of the monitors.</sd>
+         <sp spk="SKYWALKER">
+		Change course to three point one.</sp>
+         <sd>			 C-3
+		That will head us directly into 
+		the path of the Norton Asteroid 
+		Belt.</sd>
+         <sp spk="HAN">
+		That asteroid belt is too dense 
+		to pass through.  The ship won't 
+		make it!</sp>
+         <sp spk="SKYWALKER">
+		We'll never defeat them in combat. 
+		It's our only chance to lose them.</sp>
+         <sd>C-3 punches in new coordinates  and the starship veers away 
+	toward the treacherous asteroid belt.</sd>
+      </scene>
+      <scene n="120">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Oxus fires on one of the two hunter-destroyers which is
+	pacing the rebel starship.  Captain Valor unsuccessfully 
+	tries to pull himself back inside the spacecraft.  The enemy 
+	craft maneuvers wildly in an attempt to get into a better 
+	position to fire on Valor.  Oxus blasts away until the royal 
+	spacecraft spews forth equipment and personnel, careens off, 
+	and eventually explodes.</sd>
+         <sd>A-2 wobbles along the exterior of the ship until he reaches 
+	the stranded captain.  He attaches a new lifeline to the 
+	young Dai's spacesuit and makes his way back inside the 
+	wounded craft.  Valor is pulled to safety just as the star-
+	ship enters the asteroid belt.  A barrage of small and large 
+	asteroids begins to pelt the ship, causing a great deal of 
+	damage.</sd>
+         <sp spk="SKYWALKER (over intercom)">
+		Secure yourselves.  We may have to 
+		eject.  Abandon the turrets.</sp>
+         <sd>The princess rushes back to her lifepod and straps herself
+	in.  Oxus and A-2 help Valor make his way out of the lazer-
+	cannon turrets and through a series of locks, to the life-
+	pod area.</sd>
+      </scene>
+      <scene n="121">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The asteroids hit hard.  The ship is buffeted to and fro as 
+	the general, Han, and C-3 struggle into their spacesuit-
+	like lifepods.  The royal hunter-destroyer closest to the 
+	rebel ship explodes in the on-rush of deadly asteroids. 
+	The new reinforcement hunter-destroyers turn back and give 
+	up the pursuit.  They disappear from the tracking monitors. 
+	The asteroid bombardment becomes almost unbearable.  Warning 
+	lights begin to flash.  Extending foils, antennae, and arma-
+	ment pods are scraped away from the starship hull.  A base-
+	ball sized hole is punched through the midsection, and 
+	hundreds of objects are sucked into space.  A large locker 
+	eventually plugs the opening.  The starship and her passengers 
+	shudder and sway under the punishment of the asteroid storm.</sd>
+         <sd>			 C-3
+		The ship is breaking up.</sd>
+         <sp spk="HAN">
+		We're almost clear of the storm.</sp>
+         <sd>			 C-3
+		We'll never make it.  Eject.  We 
+		must eject.</sd>
+         <sd>The general watches the computer monitor as the starship
+	emerges from the far side of the asteroid belt.</sd>
+         <sp spk="HAN">
+		We're approaching one of the 
+		Forbidden Systems.</sp>
+         <sp spk="SKYWALKER">
+		We've got to achieve orbit.</sp>
+         <sd>			 C-3
+		We'll never make it.</sd>
+         <sd>The starship heads for a small blue-green planet in the
+	distance.</sd>
+      </scene>
+      <scene n="122">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Captain Valor was considerably shaken in the destruction of 
+	his lazerturret.  He is slightly dazed as Oxus straps him 
+	into a lifepod with A-2.</sd>
+         <sp spk="OXUS (to A-2)">
+		You watch him.  Make sure this 
+		pod gets off all right.</sp>
+         <sd>A-2 nods  and Oxus moves to the second lifepod and straps 
+	himself in next to the princess.</sd>
+         <sp spk="ZARA">
+		Will he be all right?</sp>
+         <sp spk="OXUS">
+		I think so.  His feelings for 
+		you are dangerous.  You should 
+		discourage him.</sp>
+         <sd>She is surprised that Valor has any feeling for her  but 
+	keeps her emotions to herself.</sd>
+      </scene>
+      <scene n="123">
+         <setting>BRIDGE - STARSHIP - YAVIN ORBIT</setting>
+         <sd>The general is strapped into the lifepod with the two 
+	micropacks containing the young princes.  Han and C-3 are 
+	in the second lifepod.</sd>
+         <sp spk="HAN">
+		We're in orbit.</sp>
+         <sd>			 C-3
+		We've got to eject now!  Those reactors 
+		won't hold much longer.  This ship's 
+		going to end up in a million little 
+		pieces  and I don't want to be one of 
+		them.</sd>
+         <sp spk="HAN">
+		All lifepod systems are operative.</sp>
+         <sp spk="SKYWALKER (into intercom)">
+		If you boys are ready back there, 
+		we'll get off this bucket.</sp>
+         <sp spk="OXUS">
+		All systems operative.  I 
+		have the signal.</sp>
+         <sd>			 A-2
+		All systems operative.  We 
+		have the signal.</sd>
+         <sd>Han salutes the general  and his lifepod jettisons away 
+	from the crippled starship.  He is quickly followed by 
+	the general.</sd>
+      </scene>
+      <scene n="124">
+         <setting>AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>A-2 pushes the jettison switch  but nothing happens.  Cap-
+	tain Valor slowly and with some difficulty  pushes the 
+	switch two or three times.  Nothing happens.  He begins to
+	look a little worried.</sd>
+         <sd>			 A-2 (into intercom)
+		We've got a problem.  Wait a 
+		second.</sd>
+         <sd>A-2 pushes the switch again  and the lifepod blasts off in 
+	a cloud of smoke and debris.  Oxus also seems to be having 
+	a problem.  Half the lights on his control panel have gone 
+	dead.  He struggles to reactivate them.</sd>
+         <sp spk="OXUS">
+		My power's out!</sp>
+         <sp spk="SKYWALKER (over intercom)">
+		Is it a faulty switch?</sp>
+         <sp spk="OXUS">
+		No.  The whole bank is out.</sp>
+         <sd>Oxus gives the princess a reassuring look, then punches some 
+	information into the computer.  The monitor flashes: "Income 
+	line main power."  He looks outside the lifepod and sees a 
+	damaged cable.</sd>
+         <sp spk="OXUS">
+		I've found it.</sp>
+         <sp spk="SKYWALKER">
+		You haven't much time.  The 
+		auxiliary units have already 
+		blown.</sp>
+         <sd>Oxus scrambles out of the lifepod and rushes over to the 
+	severed connector.  He works on it for a few moments, then 
+	stops with a rather defeated look.  The princess watches 
+	him as he tries to think of a solution.  A great explosion 
+	is heard in the forward part of the ship.</sd>
+      </scene>
+      <scene n="125">
+         <setting>LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods containing the general, Han and C-3 drift 
+	away from the disabled starship.</sd>
+         <sp spk="SKYWALKER">
+		Where's Captain Valor?</sp>
+         <sp spk="HAN">
+		I can't see him either.</sp>
+         <sd>Captain Valor uses the small rockets on his lifepod to 
+	maneuver back toward the burning starship.  He can hear the 
+	general over the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, where are you? 
+		Report in.</sp>
+         <sd>Valor reaches down and switches off the intercom.</sd>
+      </scene>
+      <scene n="126">
+         <setting>AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Oxus appears to have found a solution to his situation and 
+	rushes back to the princess.  He reaches in and locks on the 
+	power switch.</sd>
+         <sp spk="OXUS">
+		There is only one possible solution 
+		and we must use it.  Lock the hitch 
+		and make sure it is sealed.</sp>
+         <sp spk="PRINCESS">
+		But what of...?</sp>
+         <sd>Another explosion creates a large bulge in the wall of the 
+	aft section.</sd>
+         <sp spk="OXUS">
+		We've no time!</sp>
+         <sd>He slams the hatch shut and runs to the power connector.
+	Smoke begins to fill the chamber, as Oxus slams a large 
+	metallic dampening tool across the damaged connector ter-
+	minals, and the lifepod jettisons away.</sd>
+      </scene>
+      <scene n="127">
+         <setting>LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The princess jettisons free, as Captain Valor moves toward 
+	the crippled ship.  Zara calls the general on the intercom.</sd>
+         <sp spk="ZARA">
+		I'm all right, but Clieg is 
+		still on board.</sp>
+         <sp spk="SKYWALKER">
+		Captain Valor, stay out of 
+		there.</sp>
+         <sd>With a rumble, the starship disappears in a spectacular
+	explosion, sending debris in all directions.  Valor stops 
+	his lifepod and it starts to drift.  He is weeping.  Han 
+	and the general watch the remains of the explosion drift 
+	away.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, stay near Zara. 
+		Use your beacon.  Coordinate 
+		with us.</sp>
+         <sd>Valor's intercom is weak and there is a great deal of static. 
+	The lifepods drift toward the awesome blue-green Yavin 
+	surface.  The general loses sight of the other lifepods as 
+	they descend through the cloud cover.</sd>
+         <sp spk="SKYWALKER">
+		Captain, I'm losing your beacon. 
+		Send me a new signal.</sp>
+         <sd>All he gets is static.  The planet surface rushes toward the 
+	falling lifepods.  Retrorockets automatically kick in and 
+	slow the pods.  Two of the small craft break through the 
+	brown clouds and land in the dense, steaming jungles.  The
+	sky is a strange light brown color.</sd>
+      </scene>
+      <scene n="128">
+         <setting>VINE JUNGLE - YAVIN</setting>
+         <sd>The general's lifepod crashes through the foliage until it 
+	comes to rest in the middle of a large vine-covered tree. 
+	He grabs the two micropacks and climbs out of the lifepod 
+	and onto a large  moss-covered limb.  Han and C-3 run to the 
+	base of the huge tree.</sd>
+         <sp spk="HAN">
+		Are you all right?</sp>
+         <sp spk="SKYWALKER">
+		Fine.  Any signal from Captain
+		Valor?</sp>
+         <sp spk="HAN">
+		Nothing yet.  I think they landed 
+		further south.</sp>
+         <sd>The general attaches a thin cable from his utility belt to 
+	the tree trunk  and slides to the ground.  Han takes the 
+	micropacks from him. The general looks around at the jungle.</sd>
+         <sp spk="SKYWALKER">
+		This is dangerous country.  We'd better 
+		stay together.</sp>
+         <sd>			 C-3
+		The wildlife in the Forbidden System 
+		is extremely hostile.  Perhaps we 
+		should seek shelter?</sd>
+         <sd>Han inspects the power units of the micropacks.</sd>
+         <sp spk="HAN">
+		Puck's unit is very low.  I can't 
+		tell if the unit is still functioning.</sp>
+         <sp spk="SKYWALKER">
+		We have to find a place to revive 
+		them.  We'll start moving south.  We 
+		should find protection along that 
+		ridge.</sp>
+         <sd>The general grabs one of the micropacks and starts off into 
+	the murky jungle.  Han and C-3 quickly follow.  The jungle 
+	is a strange and eerie fog-laiden purgatory.  Gruesome and 
+	unnatural sounds permeate this ghostly wasteland.  Everyone 
+	is cautious and on the alert for an unseen danger.</sd>
+      </scene>
+      <scene n="129">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Captain Valor's lifepod is also caught in the limbs of a
+	gargantuan tree.  The lifepod has been ripped in half by the 
+	crash landing.  The unconscious Dai hangs half out of the 
+	damaged craft.  A two-foot high insect-like creature scoots 
+	down a branch and onto the back of the dormant warrior.  The 
+	insect lets out a chilling hissing sound and a slimy tube 
+	emerges from its hairy mouth, waking Valor.  He is immediately 
+	aware of the insect.  His eyes are open but he doesn't move.  
+	Suddenly with one quick blow he knocks the creature against 
+	the side of the spacecraft and it is squashed lifeless.</sd>
+         <sd>Captain Valor is a little groggy but he manages to climb 
+	out of the wreckage.  He looks around for A-2.</sd>
+         <sp spk="JUSTIN">
+		A-2!  A-2!</sp>
+         <sd>			 A-2
+		Help!</sd>
+         <sd>Valor turns and sees the little robot hanging upside down, one 
+	of his three feet caught in a vine.  He lifts A-2 out of his 
+	predicament and places him securely on a wide limb.</sd>
+         <sp spk="JUSTIN">
+		Did you see Zara?</sp>
+         <sd>			 A-2
+		She landed on the other side of those 
+		trees, approximately eight hundred 
+		meters.</sd>
+         <sp spk="JUSTIN">
+		Well, come on, old buddy.  Let's get 
+		ourselves out of this tree.</sp>
+      </scene>
+      <scene n="130">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general, Han, and C-3 reach a shallow cave near the top 
+	of a steep ridge.  They quickly pull off the micropacks and 
+	place them on a clear piece of ground at the mouth of the 
+	cave.</sd>
+         <sp spk="SKYWALKER (to Han)">
+		Check out the inside.  C-3, stand 
+		guard.  Keep you eye on the country-
+		side.</sp>
+         <sd>He looks at the power units on the micropacks and shakes his 
+	head with a worried look.  Han returns from a survey of the 
+	inside of the cave.</sd>
+         <sp spk="HAN">
+		It doesn't go very far.  There's 
+		nothing back there.</sp>
+         <sp spk="SKYWALKER">
+		Help me with this.</sp>
+         <sd>Han helps the general lift the top from the case containing 
+	Puck, the younger of the two princes.  The small boy appears 
+	lifeless as the general pulls him from his encasement and 
+	rests him on the cave floor.  Han pulls a small respirator 
+	out of the micropacks and places it over the boy's nose.  The 
+	general attaches two electrodes over his heart.</sd>
+         <sp spk="HAN">
+		He doesn't look good.</sp>
+         <sd>The little prince begins to turn blue.  The general grows
+	tense.  Puck starts to regain consciousness  but begins
+	coughing and choking, then goes limp again.  The general
+	quickly props Puck's mouth open with a small plastic rod and 
+	checks the reading on his powerpack.</sd>
+         <sp spk="SKYWALKER">
+		We need more power.  Tap off Oetas 
+		unit.  Quickly!</sp>
+         <sd>He then places Puck's arms behind his back and starts pressing 
+	on his chest with sharp, rhythmic movements.  Han attaches 
+	new electrodes to the boy's heart.  Puck again comes to, 
+	choking and coughing.  Finally, he begins to cry.  The general 
+	takes the plastic tube from Pucks mouth and tenderly pats 
+	him on the back.</sd>
+         <sp spk="SKYWALKER">
+		Let's get Oeta out of there.  He 
+		shouldn't be a problem.</sp>
+      </scene>
+      <scene n="131">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Valor slams closed the hatch of Princess Zara's lifepod. 
+	In the distance the subhuman cries of lonesome tree beasts 
+	cut through the forest murmur.</sd>
+         <sd>			 A-2
+		Perhaps she went in search of 
+		us.</sd>
+         <sd>Valor studies the ground around the capsule.  There are a 
+	great many footprints and much broken foliage.</sd>
+         <sp spk="JUSTIN">
+		Someone's got her.  She put up 
+		quite a fight.  It's an easy 
+		trail to follow.</sp>
+      </scene>
+      <scene n="132">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Both Oeta and Puck are sleeping restlessly on the floor of 
+	the cave.  Han watches over them as the general scans the 
+	valley below with a pair of electrobinoculars.</sd>
+         <sd>			 C-3
+		It's about fourteen degrees below 
+		the horizon...a little to the left.</sd>
+         <sd>The electrobinoculars sweep the rich green landscape until 
+	they come to rest on a bright reflection revealing some 
+	type of structure.</sd>
+         <sp spk="SKYWALKER">
+		It's too small to be a military 
+		base.  Could belong to a trapper.</sp>
+         <sd>			 C-3
+		Highly unusual.</sd>
+         <sp spk="SKYWALKER">
+		It's on the way.  Perhaps we 
+		should investigate.
+		
+	Little Oeta wakes up with a giant yawn.</sp>
+         <sp spk="OETA">
+		Hey!  Where are we?</sp>
+      </scene>
+      <scene n="133">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>The gargantuan trees are shrouded in mist, and the ominous 
+	sounds of unearthly creatures fill the air.  Captain Valor 
+	moves quietly and cautiously, followed by A-2, who 
+	inadvertently makes a loud clicking sound.  The young 
+	warrior stops and motions to the stubby little robot.</sd>
+         <sp spk="JUSTIN">
+		Wait here.  If I don't return by 
+		zero two hundred, come looking 
+		for me.</sp>
+         <sd>The mechanical dwarf acknowledges with his computer light.
+	Valor moves swiftly and silently forward, until he hears 
+	laughing and voices.  He climbs up the bankside of a huge 
+	tree and inches his way out onto one of the huge overhanging 
+	branches.  Below him he can see a group of scruffy alien 
+	trappers sitting around a nutron stove, joking and telling 
+	stories.  Parked on either side of the group are two large, 
+	tank-like jungle-crawlers.  Behind the crawlers, five Jawas 
+	(huge gray and furry beasts) hang upside down in a tree. 
+	Occasionally they thrash about in great anger and frustration.</sd>
+         <sd>The trappers speak in a strange language, and although they 
+	appear slightly human, they are slimy, deformed, hideous 
+	looking creatures.  Two of the trappers yell at each other 
+	in a friendly argument.  One shirtless creature goes into a 
+	crawler and the remaining eight laugh hysterically.  Captain 
+	Valor moves further out on the limb to get a better view.  A 
+	couple  of pieces of bark break loose, and float a hundred 
+	feet to the ground.  The trappers fail to notice.  Moments 
+	later, the shirtless trapper emerges from the crawler with 
+	the princess held unconscious and half naked over his head. 
+	Valor's rage knows no bounds.  With a terrifying Dai war cry, 
+	the young captain jumps from the tree, sails over a hundred 
+	feet, and with great agility, lands in the middle of the 
+	startled trappers.  In one continuous rapid motion, he ignites 
+	his lazersword and cuts down three of the vile creatures.  The 
+	shirtless trapper swings the princess over his shoulder  and	 
+	runs back into the huge jungle crawler.  Two other trappers 
+	reach for their pistols, but the Dai has killed them before 
+	their weapons can clear leather.  The three remaining 
+	creatures have their pistols out and start firing.  Explosions 
+	erupt all around Valor.  One blast hits the branch holding 
+	the Jawas  and they collapse with a loud screech in a heap. 
+	One of the trappers is caught in the crossfire and is blown 
+	apart.</sd>
+         <sd>When the smoke clears  Valor lies unconscious amid the 
+	burning rubble.  The jungle crawler begins to move out of the 
+	camp.  The last two trappers run after it.  One is able to 
+	jump on board, but the second trapper runs too close to the 
+	now freed Jawas.  Boma, one of the furry giants, grabs him 
+	and snaps him in two, like a stick of wood.  The jungle 
+	crawler disappears in the forest mist.  The eight foot Boma, 
+	who resembles a huge, gray bushbaby with fierce baboon-like 
+	fangs, struggles to free his companions.</sd>
+         <sd>Valor regains semi-consciousness, and attempts to get up, only 
+	to groan and collapse back into unconsciousness.  The Jawas 
+	gather around him and poke him a couple of times to see if 
+	he is still alive.  They squawk and jabber, apparently in 
+	some kind of argument.  Finally, Wann, the largest of the Jawas 
+	picks up Valor and puts him over his shoulder.  The group 
+	disappears into the jungle foliage.</sd>
+      </scene>
+      <scene n="134">
+         <setting>TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Han and C-3 carry the two little boys on their shoulders. 
+	The general stops on the edge of a clearing and motions for 
+	the others to be still.  Oeta turns around and signals his 
+	little brother to be quiet.  On the opposite side of the 
+	clearing, a small metal structure is attaached to one of the 
+	huge trees.  It is a small, weatherbeaten hut of futuristic 
+	design.  It appears deserted.  The general cautiously 
+	approaches the structure.</sd>
+         <sp spk="VOICE">
+		Howdy stranger.  What can I offer you?</sp>
+         <sd>The general spins around and sees Huu Tho, an aged and scruffy 
+	looking anthropologist.</sd>
+         <sp spk="THO (Cont.)">
+		I'm Huu Tho of Bastine.</sp>
+         <sd>The general takes the old man's extended hand.</sd>
+         <sp spk="SKYWALKER">
+		I'm Luke Skywalker of Townowi.</sp>
+         <sd>He signals for the others to join him in the clearing.</sd>
+      </scene>
+      <scene n="135">
+         <setting>WOOKEE CAMP - YAVIN</setting>
+         <sd>The small caravan of Jawas, led by Boma, enters a small 
+	clearing surrounded by many bark and mud hovels.  Young 
+	Jawas race ahead of the group, yelling and running in and 
+	out of the grubby little dwellings.  Giant, bushbaby-like 
+	Jawas of all ages and sizes make their way into the clearing. 
+	Many stand dumbfounded, but others let out a joyful scream 
+	and rush up to members of the group, hugging and kissing them.</sd>
+         <sd>Wann dumps the unconscious captain on a raised area in the 
+	middle of the clearing.  Armed Jawas immediately surround the 
+	helpless human.  Boma enters the largest of the lodges.  He 
+	is greeted by his father, Auzituck, chief of the Kaapauku 
+	tribe.  He is an old and feeble Jawa dressed in royal skins 
+	and headdress.</sd>
+      </scene>
+      <scene n="136">
+         <setting>INTERIOR - ANTHROPOLOGIST HUT - YAVIN</setting>
+         <sd>Anthropologist Tho, the general, Han and the children sit 
+	around a large table eating.  Tho yells into the kitchen.</sd>
+         <sp spk="THO">
+		Beru!  Where's the thanta sauce?</sp>
+         <sd>BERU THO, Kuu's warm plump wife, enters carrying a small 
+	pitcher.  She smiles at Kuu.</sd>
+         <sp spk="BERU">
+		I swan!  I put it right here in 
+		front so you'd see it.  <sd>to Han</sd>  
+		Here's some bum bum extract. 
+		It's very mild.</sp>
+         <sp spk="THO (to general)">
+		There are no settlers to the south 
+		since the Dau family was wiped out. 
+		I'm afraid I couldn't even get in 
+		there to bury them.  Those Jawas 
+		are the fiercest critters I've ever 
+		run across.  A new tribe moved in 
+		down there about a year ago  and 
+		it's been hell ever since.  Only 
+		Yourellian trappers venture in 
+		there now  and many of them don't 
+		even come back.</sp>
+         <sp spk="SKYWALKER">
+		Where's the nearest city?</sp>
+         <sp spk="THO">
+		No cities at all, only a few 
+		scattered settlers and -- one 
+		royal outpost.  But the troops 
+		are of no help.  They kill and 
+		plunder rather than protect.
+		Enough.  If your friends landed 
+		farther south, I'd fear for them.</sp>
+         <sp spk="HAN">
+		How far is the outpost from here?</sp>
+         <sp spk="THO">
+		Five leagues...an oppressive 
+		blight.</sp>
+         <sp spk="SKYWALKER">
+		What class is it?  How many 
+		support craft?</sp>
+         <sp spk="THO">
+		It's very small, a class two.  
+		Only ten or twelve starraiders, 
+		I think.</sp>
+         <sd>Beru fusses over the boys, who refuse to eat their vegetables. 
+	She makes up a game  which tricks them into eating.  The 
+	general ponders the situation.  Han eats like he hasn't eaten 
+	in years.</sd>
+      </scene>
+      <scene n="137">
+         <setting>JAWA CAMP - YAVIN</setting>
+         <sd>Captain Valor is surrounded by Jawas.  Young ones push through 
+	to get a better look, as the adults jabber and argue about the 
+	human.  Valor regains consciousness with a groan, and a sudden 
+	hush sweeps over the gathering.  Valor staggers to his feet, 
+	and the group of Jawas back away en masse.  The young dai 
+	surveys the situation for a few moments.  The Jawas appear 
+	to be frightened of this brave warrior.  He reaches for his 
+	weapons  but they are gone.  Three guards with long spears 
+	attempt to contain Valor.  With a loud shout, he lunges at 
+	them and they give him a little room.  Jommillia, a large	 
+	ferocious Jawa, steps forward.  He says something to the 
+	guards and they quickly move away.  He struts before Captain
+	Valor, boasting and taunting him with his spear and battle 
+	ax.  The captain studies the Jawa warrior as he paces back 
+	and forth, his helmet plumes dancing and chest armor jangling. 
+	Without warning, Valor lets out another loud yell, startling 
+	Jommillia into backing off.  Captain Valor continues his 
+	verbal assault, calling the uncomprehending Jawa all manner 
+	of vile and degrading things.  Jommillia continues to back 
+	into the surrounding crowd, momentarily confused by this odd 
+	behaviour.  Slowly, Jommillia begins to grin.  He takes a 
+	defensive stance, then begins to laugh hysterically.  This 
+	stops Valor.  The giant Jawa swings his deadly double-bladed 
+	battle ax over his head and expertly throws it directly at 
+	the young captain's head.  To the amazement of Jommillia and 
+	the other Jawas, Captain Valor, with Dai Nogas skill and 
+	concentration, catches the ax in mid-air, then charges his 
+	furry opponent.</sd>
+         <sd>Jommillia is caught off-guard, but manages to block Valor's 
+	attack with his spear.  The two warriors engage in a savage 
+	and fantastic duel.  Valor cuts the Jawas spear in half, but 
+	is hit along the side of the head by the shaft and is momentaril 
+	dazed.  The battle ax is knocked from his hands.  He grabs the 
+	spear shaft and rams the giant creature in the belly.  A loud 
+	command from outside the crowd stops the fight.  The Jawas 
+	part, revealing Boma and his father, who approach the two 
+	warriors.  Jommillia bows before his chief, and is commanded 
+	to move away.  Boma speaks to Valor.  The captain doesn't 
+	understand, but welcomes the chance to catch his breath. 
+	Boma then presents his father, who steps forward and bows 
+	before the mighty Dai.  Boma bows also as the crowd of Jawas 
+	chatter in disbelief.  When the chief and his son rise, Valor 
+	bows before them.  This pleases the Jawas and they screech 
+	and cheer.</sd>
+      </scene>
+      <scene n="138">
+         <setting>TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Mr. and Mrs. Tho stand on the balcony of their tree house 
+	with C-3 and the two little princes, Oeta and Puck.  Han and 
+	the general emerge with large survival backpacks and multi-
+	plelazer weapons.</sd>
+         <sp spk="SKYWALKER (to C-3)">
+		We'll call for you when we've found them.</sp>
+         <sd>			 C-3
+		Your orders are quite clear.  The 
+		boys will be quite safe.</sd>
+         <sp spk="THO">
+		Don't worry.  The patrols never 
+		come out this far.  We'll take good 
+		care of the boys.</sp>
+         <sp spk="SKYWALKER">
+		Your kindness will surely be 
+		rewarded.</sp>
+         <sp spk="THO">
+		Just be careful out there.</sp>
+         <sd>He pats Skywalker on the back as the old Dai and the ever 
+	faithful Han descend from the tree house.  At the base of 
+	the huge tree, the warriors climb aboard two small rocket 
+	powered platforms.</sd>
+         <sp spk="THO (yelling down to them)">
+		They're pretty old.  I hope they'll 
+		be all right!</sp>
+         <sp spk="SKYWALKER">
+		Out here they're a wonderment.</sp>
+         <sd>C-3 and the kids wave as the jelsticks start with a whine. 
+	They idle about five feet above the ground.</sd>
+         <sp spk="THO">
+		Good hunting!  May the force of 
+		others be with you.</sp>
+         <sd>Han and the general wave as they ride off into the foreboding 
+	Yavin sunset.</sd>
+      </scene>
+      <scene n="139">
+         <setting>JAWA CAMP - YAVIN - NIGHT</setting>
+         <sd>A beautiful but frenzied fire festival is underway.  Jawas 
+	perform the Waita Tar dance, and yodel in a barking fashion 
+	around a large fire.  The female Jawas arrive, carrying 
+	torches  and move in a circle around the males.  The giant 
+	creatures are too involved to notice little A-2 make his way 
+	around the dancers.  The stubby robot stops near one of the 
+	mud huts and looks around.   He then wobbles off toward the 
+	large chief's quarters and enters.</sd>
+         <sd>								  - Dissolve -</sd>
+      </scene>
+      <scene n="140">
+         <setting>JAWA CAMP - YAVIN - MORNING</setting>
+         <sd>A-2 exits the chief's hut and looks around.  It is a quiet 
+	gray morning.  A low mist hangs over the now deserted 
+	clearing.  He turns and signals back into the hut.  Captain 
+	Valor cautiously emerges from the mud house.  He wears a 
+	crude backpack and carries a large battle ax.  They start 
+	across the clearing.  Suddenly, out of nowhere, Boma is 
+	standing before them.  He says nothing, but scratches his 
+	head and then circles around Captain Valor.</sd>
+         <sp spk="JUSTIN">
+		We are leaving.  We must go. 
+		Stand away!</sp>
+         <sd>The huge Jawa kneels and bows down in front of the young Dai. 
+	Valor looks down and smiles.</sd>
+         <sp spk="JUSTIN">
+		Rise my friend.  We will meet 
+		again.</sp>
+         <sd>Valor walks toward the jungle and Boma scurries ahead of him 
+	and bows down once more.</sd>
+         <sd>			 A-2
+		What does he want?</sd>
+         <sd>Valor shakes his head and rubs his several days growth of 
+	beard.  He leans down toward Boma.</sd>
+         <sp spk="JUSTIN">
+		Stand up so we can talk properly.</sp>
+         <sd>Boma jabbers in a questioning fashion.</sd>
+         <sp spk="JUSTIN">
+		I am grateful to you and your 
+		people, but I must go.  I wish 
+		you understood me.  I would 
+		make things so much easier.  
+		Go!  Go!</sp>
+         <sd>Valor turns away, and begins to walk toward the jungle again. 
+	Boma gets to his feet and runs after the Dai, following a few 
+	paces behind.  Valor notices the Jawa following them  and 
+	shakes his head.</sd>
+      </scene>
+      <scene n="141">
+         <setting>FOREST OF THE GARGANTUANS - TRAPPER SIGHT - YAVIN</setting>
+         <sd>The bodies of the killed trappers are covered with rat-sized 
+	insects.  A lazer explosion erupts in the middle of the slimy 
+	creatures and they scatter into the underbush.  Han and the 
+	general turn over one of the dead trappers.</sd>
+         <sp spk="HAN">
+		They ran into something.</sp>
+         <sp spk="SKYWALKER">
+		It's strange they left their 
+		dead.  Something...</sp>
+         <sd>The constant cacophony of jungle creatures suddenly stops. 
+	The two warriors scan the jungle for possible danger.  Han 
+	draws his lazerpistol.  The cacophony starts again as the 
+	general ignites his lazersword.</sd>
+         <sp spk="HAN">
+		Two or three moving this way 
+		from the east.</sp>
+         <sd>He listens more closely for a few moments.</sd>
+         <sp spk="HAN (Cont.)">
+		It's A-2.</sp>
+         <sd>Captain Valor and A-2 break out of the dark foliage into the 
+	clearing.  He waves to Han and the general.  A-2 waddles a 
+	few paces behind.  Boma sees the humans and stops at the 
+	edge of the jungle.  He watches as Captain Valor and the 
+	general carry on an animated conversation.  Han sees the 
+	Jawa lurking in the shadows.</sd>
+         <sp spk="HAN">
+		You were followed.</sp>
+         <sp spk="JUSTIN">
+		He wouldn't stay.  He's the one I 
+		saved.</sp>
+         <sd>Han calls out to Boma in the Jawa's own language  and the 
+	huge lumbering creature approaches the group.  Han and the 
+	Jawa talk for a few moments, then embrace as if they were 
+	old friends.  Captain Valor is surprised.</sd>
+         <sp spk="HAN (to Valor)">
+		This is Boma, son of Auzituck, 
+		Prince of the Sawas - a very 
+		powerful tribe.  It seems they've 
+		made you a god.</sp>
+         <sd>The general smiles.  Captain Valor is embarrassed.</sd>
+      </scene>
+      <scene n="142">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Captain Valor joins the general on a ridge overlooking the
+	royal outpost of Mavassi.  All that can be seen of the
+	fortress is a lone guard standing on a small pedastal jutting 
+	out above the dense jungle.</sd>
+         <sp spk="SKYWALKER">
+		Their trail leads directly to the 
+		outpost.  Patrols are probably 
+		out looking for us by now.</sp>
+         <sp spk="JUSTIN">
+		Finding her in there isn't going 
+		to be easy.</sp>
+         <sp spk="SKYWALKER">
+		Getting in there is going to be 
+		impossible, but we could sure 
+		use those starships.</sp>
+         <sd>Captain Valor spots something moving in the jungle.  He scans 
+	the area with his electrobinoculars.</sd>
+         <sp spk="JUSTIN">
+		Something's going on down there.
+		Han!</sp>
+         <sd>Han moves up next to Valor, followed closely by Boma.</sd>
+         <sp spk="JUSTIN">
+		Your eyes are better than mine.
+		What do you make of that?</sp>
+         <sp spk="HAN">
+		They look like Jawas, hundreds 
+		of them.</sp>
+         <sd>Han turns and speaks to Boma, gesturing toward the movement 
+	far below in the jungle.</sd>
+         <sp spk="HAN">
+		Apparently it's a siege.  They've 
+		been harassing the outpost for 
+		almost two years.</sp>
+         <sp spk="SKYWALKER">
+		Have they ever tried to take the 
+		fortress?</sp>
+         <sd>Han relays this to Boma.</sd>
+         <sp spk="HAN">
+		He says they've made several 
+		assaults, but they are no match 
+		for the weapons.</sp>
+         <sp spk="SKYWALKER">
+		It's only a class three fortress.  
+		Maybe they just need a little 
+		help.</sp>
+         <sd>Captain Valor grins, and Han says something to Boma, who 
+	becomes excited and screeches loudly.</sd>
+      </scene>
+      <scene n="143">
+         <setting>INTERIOR - TREE HOUSE - YAVIN</setting>
+         <sd>The incoming signal alarm on the anthropologist's radio
+	system wails through the calm of the tree house.  Oeta,
+	dragging an eight-legged, furry rodent, rushes up to the 
+	old radio and flips the receiver.</sd>
+         <sp spk="OETA">
+		I'm reading yah.  Go ahead.</sp>
+         <sp spk="SKYWALKER">
+		Oeta, how are you getting along?</sp>
+         <sp spk="OETA">
+		Great!  I caught a thumper, a 
+		really big one.  Its name is 
+		Amber.</sp>
+         <sd>He yanks on the leash, and the furry beast lets out a
+	strained yelp.</sd>
+         <sp spk="SKYWALKER">
+		Good, Oeta.  How's your brother?  
+		Are you taking good care of him?</sp>
+         <sp spk="OETA">
+		Oh, sure.  He's out collecting 
+		"abas" with Huu and Beru.  I'm 
+		in charge here.  Did you find 
+		Zara?</sp>
+         <sp spk="SKYWALKER">
+		Not yet.  We'll be away for a 
+		while.  You mind Tho until we 
+		return.  May the force of others 
+		be with you.</sp>
+         <sp spk="OETA">
+		All right.  Take care.</sp>
+         <sd>C-3 enters the room carrying a plate of steaming food. Oeta 
+	turns the radio off and puts the receiver away.  A crashing 
+	sound and voices are heard in the clearing below.</sd>
+         <sd>			 C-3
+		Come and eat your dinner.</sd>
+         <sp spk="OETA">
+		They're back!  They're back!  Come Amber.</sp>
+         <sd>The furry rodent jumps up onto its eight stubby legs and
+	rushes over to the door, but stops short and begins to growl. 
+	Oeta stops behind the creature.</sd>
+         <sp spk="OETA">
+		What is it, Amber?</sp>
+         <sd>Oeta peeks out the window, and sees a patrol of six royal 
+	stormtroopers climbing out of an airtank.  He ducks back 
+	and tugs Amber away from the door.</sd>
+         <sp spk="OETA">
+		Quiet, Amber.  Come here.  Come on.</sp>
+         <sd>			 C-3
+		What's wrong?</sd>
+         <sp spk="OETA">
+		Troopers.  We must hide.  Stay quiet.</sp>
+         <sd>Oeta and the robot scramble for a trap door near a large 
+	shelf.  The troops begin to climb the ladder to the tree 
+	house.  The trap door is heavy, and the robot and the little 
+	boy struggle to get it open.  The troops break in the door 
+	just as C-3 closes the trap door.  The troopers are led by 
+	a rough looking sergeant.  They poke around, tearing every-
+	thing apart.  Oeta struggles to keep Amber quiet.  Suddenly, 
+	he realizes something.</sd>
+         <sp spk="OETA">
+		The food!</sp>
+         <sd>The sergeant takes the bowl of food from the table and
+	studies it.  He then takes a small chrome ball from his
+	pocket and tosses it into the air.  Antennae shoot from 
+	its surface as it floats around the room.  Eventually it 
+	hovers over the trap door.  A sinister grin sweeps across 
+	the sergeant's face as he moves over to the trap door and 
+	puts the chrome ball back into his pocket.</sd>
+         <sd>C-2 puts his arm around Oeta, who is desperately clutching 
+	the struggling thumper.  All the movement above them stops 
+	and Oeta looks to the robot.</sd>
+         <sd>			 C-3 (quietly)
+		They're still up there.  Stay 
+		still.</sd>
+         <sd>The silence continues, then suddenly the trap door swings 
+	open with a loud bang.  Amber breaks away from Oeta and 
+	attacks the sergeant.  One of the other troopers cuts the 
+	thumper in half with his lazersword.  The sergeant pulls 
+	Oeta out of his hiding place.  Oeta stares at the dead 
+	thumper.</sd>
+         <sp spk="SERGEANT">
+		Well, well!  Here's one of them, 
+		anyway.  Send seekers in all 
+		directions.  Find the others!</sp>
+      </scene>
+      <scene n="144">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general sits at the head of the large stone table
+	pushing small markers around.  Han explains what the general 
+	is doing to ten or fifteen Jawa chiefs gathered around the 
+	table.  Occasionally, Boma puts in a word of further explana-
+	tion or answers a question.  Captain Valor sits back silently 
+	watching the Jawa warriors and listens to the general's plan.</sd>
+         <sp spk="SKYWALKER">
+		... then they pull back to here.  
+		That's where the trap will be set.  
+		No-one must advance.  An assault 
+		on the perimeter is useless.  Our 
+		only hope is to use their weapons 
+		against them.</sp>
+         <sd>The general pauses while Han and Boma translate.</sd>
+         <sp spk="SKYWALKER ">
+		Once we acquire those tanks, our
+		prime object must be to secure the 
+		starship.  No-one must escape.</sp>
+      </scene>
+      <scene n="145">
+         <setting>IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three officers run along a row of giant airtanks to a perimeter 
+	bunker.  There, two stormtroopers are watching the jungle. 
+	When the officers arrive, the troopers let them look through 
+	the powerful mounted electrobinoculars.  One of the troopers 
+	points out several areas in the dense jungle.</sd>
+      </scene>
+      <scene n="146">
+         <setting>INTERIOR - CONTROL ROOM - ROYAL OUTPOST - YAVIN</setting>
+         <sd>A trooper sitting at an elaborate control panel turns to an 
+	officer watching a monitor system.</sd>
+         <sp spk="TROOPER">
+		A large concentration of trestuals 
+		at point E-2.</sp>
+         <sp spk="OFFICER">
+		Alert squads one through six.</sp>
+      </scene>
+      <scene n="147">
+         <setting>VINE JUNGLES - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands in a clearing surrounded by many armed 
+	Jawas carrying large shiny shields.  Han moves back and forth, 
+	barking orders to the assembled creatures.</sd>
+         <sp spk="SKYWALKER (to Han)">
+		We're ready.  Give them the signal.</sp>
+         <sd>Han motions to a young Jawa, who takes off, running through 
+	the jungle.</sd>
+      </scene>
+      <scene n="148">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three large airtanks slowly move toward the outpost perimeter. 
+	The tank pilots sit on the hatch rims of the ponderous weapons, 
+	studying the movements of the Jawas.  The tank personnel talk 
+	to one another on an intercom system.</sd>
+         <sp spk="TANK PILOT">
+		There is a large concentration,
+		red two by X-S.  Let's break 
+		them up.</sp>
+         <sd>The pilots slip into the tanks and close the hatches.  The 
+	tanks open up with a barrage of lazerbolts which create a 
+	wall of explosions.  The Jawas retreat, and the tanks follow. 
+	The tank crews track the fleeing creatures with various 
+	electronic scopes, and laugh at the fleeing creatures.</sd>
+      </scene>
+      <scene n="149">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands on a limb of a jungle tree, watching the 
+	advancing tanks.  Captain Valor is on another branch a few 
+	feet away.</sd>
+         <sp spk="SKYWALKER">
+		They've grown sloppy fighting 
+		Jawas.  The intrafazer systems 
+		aren't on.  They're in for a 
+		little surprise.</sp>
+         <sd>Captain Valor flashes a signal mirror, which is received by 
+	a Jawa near the tanks.  The Jawas are in pairs and they hold 
+	heavy stone wedges attached to woven vines, which, in turn, 
+	are fastened high in the trees.  When the tanks pass directly 
+	under the Jawas, they let loose with the heavy stone 
+	pendulums.  The wedges fly through the air, neatly clipping 
+	off the antenna groupings protruding from the tops of the 
+	airtanks.</sd>
+      </scene>
+      <scene n="150">
+         <setting>INTERIOR - AIRTANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Several of the lights and monitors go dark on the main control 
+	panel.  The pilot flips several switches in a panic.</sd>
+         <sp spk="PILOT">
+		All high phasing units are out.  
+		We've lost all contact.</sp>
+         <sp spk="SERGEANT">
+		Send out a ground signal!</sp>
+         <sd>Suddenly, all of the monitors go white, and static fills the 
+	crowded tank interior.  An alarm signal sounds.</sd>
+         <sp spk="SERGEANT">
+		What is it?!!!</sp>
+         <sp spk="PILOT">
+		All signals, sensers, everything, 
+		are coming right back to us.  Some 
+		kind of deflection screen.  It's a 
+		total blackout.</sp>
+         <sp spk="SERGEANT">
+		Get out there and see if you can 
+		see anything.</sp>
+         <sd>The pilot pushes a button and the main hatch slowly slides 
+	away.</sd>
+      </scene>
+      <scene n="151">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The pilot pops out of the hatch and sees two rows of Jawa 
+	warriors holding reflective shields.  They form a circle 
+	that totally encompasses the massive air tank.  Han shouts 
+	a signal to a group of Jawas in another tree, and they cut 
+	loose a bent limb which is attached to a noose around the 
+	tank's hatch.  The noose instantly tightens around the pilot 
+	and he is plucked from the tank and suspended fifty feet in 
+	the air.  In an equally swift move, Captain Valor drops a 
+	small gas grenade into the open hatch.  It explodes and 
+	engulfs the tank in a gray mist.</sd>
+         <sd>The Jawas let out a joyful yell, and charge the tank.  Han 
+	yells at them to stop, but several make it to the conquered 
+	craft before the gas cloud dissipates and they are felled by 
+	the fumes.  Valor waits until after the smoke clears  and
+	then jumps on the back of the immobile tank.</sd>
+         <sd>Several signal mirrors flash their messages to Han and the 
+	general.</sd>
+         <sp spk="HAN">
+		That makes four captured.</sp>
+         <sp spk="SKYWALKER">
+		Have them camouflaged.  I'm 
+		going with Captain Valor.</sp>
+      </scene>
+      <scene n="152">
+         <setting>INTERIOR - AIRTANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Jawas are removing the tank crew as Valor checks out the power 
+	controls.  The general slides through the main hatch.</sd>
+         <sp spk="SKYWALKER">
+		Any damage?</sp>
+         <sp spk="JUSTIN">
+		She's fine.  We're ready to 
+		move.</sp>
+         <sp spk="SKYWALKER">
+		Then let's go.
+		
+	The general yells for the Jawas to clear the tanks, and they 
+	scramble out of the hatch.</sp>
+      </scene>
+      <scene n="153">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The tank starts up with a loud roar, startling many Jawas 
+	resting on the mighty vehicle.  Boma yells at the warriors 
+	and they fall a few feet behind the tank, their shields 
+	forming a shiny protective wall.</sd>
+      </scene>
+      <scene n="154">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Several officers stand on a parked airtank trying to get a 
+	better view of the operation.  A light landspeeder pulls up 
+	next to the group and a general gets out.  The officers snap 
+	to attention.</sd>
+         <sp spk="GENERAL">
+		Can you see anything?</sp>
+         <sp spk="OFFICER">
+		No, sir, but they've stopped 
+		firing.</sp>
+         <sp spk="AIDE">
+		Communications still can't reach 
+		them, sir.</sp>
+         <sp spk="GENERAL">
+		Does anyone know what's going on?</sp>
+         <sp spk="OFFICER">
+		I'm sure they've got them on the 
+		run, sir.</sp>
+         <sd>A lazerbolt flashes out of the jungle and destroys a guard 
+	tower about a quarter of a mile from where the men are 
+	standing.  Seconds later, the airtank on which they are 
+	standing explodes into a million pieces.  Out of the jungle 
+	rumbles the captured airtank, driven by Captain Valor and 
+	followed by a column of Jawa warriors.</sd>
+         <sd>Alarms sound, troops rush from the low block-houses, and a 
+	battle rages inside the outpost.  Jawas with spears, axes, 
+	and arrows mange to hold their own against the lazer weapons 
+	of the stormtroopers.  Explosions erupt everywhere as the 
+	Jawas begin to use captured lazerrifles.  They are much 
+	fiercer fighters than the soft royal troops.</sd>
+      </scene>
+      <scene n="155">
+         <setting>INTERIOR - AIRTANK - OUTPOST - YAVIN</setting>
+         <sd>Captain Valor works the controls of the airtank as the general 
+	watches the monitors and works the lazerguns.</sd>
+         <sp spk="SKYWALKER">
+		Swing left.  They're trying to cut us 
+		off.</sp>
+      </scene>
+      <scene n="156">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Captain Valor maneuvers the airtank in front of a line of 
+	ten starships  cutting off a platoon of stormtroopers.  The 
+	troops open fire on the tank  but are cut down by a group of 
+	Jawas who have moved in behind them.  Han and A-2 run up to 
+	the tank as Valor and the general climb out of the hatch.</sd>
+         <sp spk="HAN">
+		We've taken the main control center.  
+		All power units have been shut 
+		down.  They're helpless.</sp>
+         <sp spk="JUSTIN">
+		Have they found Zara?</sp>
+         <sp spk="HAN">
+		They've taken her back to Townowi.  
+		The ship left nor more than ten 
+		hours ago.</sp>
+         <sp spk="SKYWALKER (to Han)">
+		Set up a perimeter around these 
+		starships.  Use as many men as 
+		you need.</sp>
+      </scene>
+      <scene n="157">
+         <setting>STAFF OFFICE - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Captain Valor and the general sit at a large table in the
+	deserted office of the Royal Chief of Staff.  The room is 
+	in a state of disarray;  papers are scattered everywhere. 
+	A-2 stands on a chair, projecting an image of the "death 
+	star" fortress orbiting Townowi, on the table top.</sd>
+         <sd>			 A-2
+		... and are connected to the 
+		central system by a series of 
+		crossing networks similar to 
+		section TB4 or F687.</sd>
+         <sd>The projection switches to a close-up view of the transformer. 
+	The general studies it carefully, then leans back in his chair. 
+	A-2 turns off the projector.</sd>
+         <sp spk="SKYWALKER">
+		I'm not going to stop you, but I 
+		think it's a reckless move. Even 
+		if you could get in, you'd never 
+		be able to get out.  Just be patient.  
+		We now have enough ships to attack 
+		in force.</sp>
+         <sp spk="JUSTIN">
+		But no pilots.</sp>
+         <sd>Han and Boma enter the office.</sd>
+         <sp spk="HAN">
+		Still no contact with Huu Tho 
+		or the kids.  I'm afraid some-
+		thing's happened.</sp>
+         <sp spk="SKYWALKER">
+		Have Boma send two of his best 
+		warriors out there to get them.</sp>
+         <sd>Han relates this to Boma.  The general turns back to
+	Captain Valor, who watches Boma leave the room.</sd>
+         <sp spk="JUSTIN (mocking)">
+		They're fierce warriors  but you'll 
+		never teach them to fly.</sp>
+         <sd>The general gives him a stern look.</sd>
+         <sp spk="SKYWALKER">
+		They'll fly  and Townowi will be 
+		free.</sp>
+         <sp spk="JUSTIN">
+		May the force of others be with 
+		you.</sp>
+         <sd>The general embraces the young Dai.</sd>
+         <sp spk="SKYWALKER">
+		Bring her back safely.</sp>
+      </scene>
+      <scene n="158">
+         <setting>OUTPOST RUNWAY - STARSHIP - YAVIN</setting>
+         <sd>Captain Valor, dressed as an royal skyraider, and A-2 climb 
+	aboard one of the giant four-man starships.  A crowd of 
+	Jawas lead by Boma give a rousing cheer for the departing 
+	Dai.  Valor breaks into a smile and waves to the joyous 
+	warriors.  The general watches the proceedings from a bunker 
+	turret.  He is lost in thought.</sd>
+      </scene>
+      <scene n="159">
+         <setting>SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Three royal space transports dock inside the huge artificial 
+	moon.  The smaller convoy starships circle the larger craft 
+	until the three ships are safely inside the vast fortress.</sd>
+      </scene>
+      <scene n="160">
+         <setting>CONFERENCE ROOM - INTERIOR SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader of the Royal Space Fleet, hurries down a hall-
+	way, followed by a group of officers.  They enter the large 
+	conference room where Zara is held under heavy guard.  She 
+	appears well, but saddened.  Vader approaches her and bows  
+	before her.</sd>
+         <sp spk="VADER">
+		I pray you have been treated honorably?  
+		I am your servant, Darth Vader.  It 
+		won't be long before we will be able to 
+		return you to your people.  <sd>to an aide</sd>  
+		Are the chambers ready?</sp>
+         <sp spk="AIDE">
+		They are working on it, sir.</sp>
+         <sd>Zara stares defiantly at him.  She starts to speak, but a 
+	powerful electric shock engulfs her body  and she whines 
+	in extreme pain.</sd>
+         <sp spk="VADER">
+		Just relax, and everything will be fine.  
+		<sd>to guards</sd>  Take her to section twenty-
+		five.</sp>
+         <sd>Zara is forcibly taken from the room.</sd>
+         <sp spk="VADER (to officer)">
+		What time do the doctors from Granicus 
+		arrive?</sp>
+         <sp spk="OFFICER">
+		Sixty-five hours, sir.</sp>
+         <sp spk="VADER">
+		Put all security stations on alert 
+		until they arrive.</sp>
+         <sd>The officer salutes smartly and exits.</sd>
+      </scene>
+      <scene n="161">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>A huge air tank rumbles along the approach to the royal 
+	outpost.  The pilot sits on the main hatch of the tank, 
+	talking to his crew by headphones.</sd>
+         <sp spk="PILOT">
+		Any contact yet?. It appears 
+		deserted.  I don't like it.</sp>
+         <sd>The tank enters the outpost perimeter and smoking rubble 
+	from the recent battle comes into view   The pilot becomes 
+	alarmed.</sd>
+         <sp spk="PILOT">
+		There has been an attack!  
+		Reverse direction.</sp>
+         <sd>The tank comes to a grinding halt  but before it can start 
+	up again  it is surrounded by the Jawa army.  From out of 
+	no-where a Jawa is on the back of the airtank and has the 
+	pilot in a powerful armlock.</sd>
+         <sd>A Jawa chieftan rushes from a bunker, followed by an excited 
+	jabbering warrior.  They reach the captured airtank just as 
+	the last crewman is hauled out  and little Oeta pokes his 
+	head out of the hatch.  He is frightened.  His younger 
+	brother Puck follows him out of the tank.  Below them, the 
+	Jawas bully the captured crewmen.</sd>
+         <sp spk="PUCK">
+		What will they do to us?</sp>
+         <sp spk="OETA">
+		I don't know  but it don't look 
+		good.</sp>
+         <sd>C-3 pulls himself out of the airtank, followed by Han Tho 
+	and his wife.  The Jawa chieftan climbs on board and starts 
+	to jabber at the group   The Jawa carries on for some time 
+	gesturing wildly and continually pointing at the sky.  The 
+	two boys are too scared to say anything.  Finally, the Jawa 
+	kneels before them.  C-3 politely returns a short bow.</sd>
+         <sp spk="OETA">
+		I don't get it.</sp>
+         <sd>The Jawa rises and again gestures skyward, just then a starship 
+	wildly buzzes the field, upside-down.  All the Jawas run for 
+	cover.  The chief Jawa points to the crafts, and jabbers 
+	incessantly.</sd>
+      </scene>
+      <scene n="162">
+         <setting>INTERIOR - ROYAL STARSHIP - SKY OVER YAVIN</setting>
+         <sd>Boma sits at the controls of a four-man starship.  His face 
+	is a twisted combination of complete panic and an awesome 
+	religious experience.  The general  sitting next to him 
+	calmly switches a few buttons on the control panel, as Han 
+	watches from the seat directly behind the Jawa.</sd>
+         <sp spk="SKYWALKER">
+		You'll get the hang of it.</sp>
+         <sd>Han also gives the Jawa a few words of encouragement.</sd>
+         <sp spk="SKYWALKER">
+		Now, let's see if we can get into 
+		orbit.  Push this, then ease her up.</sp>
+         <sd>Boma follows the instructions  but pulls back on the lever 
+	too fast and the ship being to vibrate and bounce violently. 
+	Boma thinks it's funny and begins to laugh hysterically.  Han 
+	becomes nervous and upset.</sd>
+         <sp spk="SKYWALKER">
+		Not so fast.  Back off!  Back off!</sp>
+         <sd>Han yells at the Jawa, who can't respond because he is 
+	laughing so hard.  The general pulls back on the lever.  Han 
+	shakes his head and gives the general a worried look.</sd>
+         <sp spk="SKYWALKER">
+		Don't worry.  Ignorance is on 
+		their side.</sp>
+         <sd>Han is beginning to look a little sick.  He gets up and 
+	rushes to the back of the ship.</sd>
+      </scene>
+      <scene n="163">
+         <setting>ROYAL SPACE FORTRESS - DOCKING AREA - TOWNOWI</setting>
+         <sd>The canopy on the starship pops open and A-2 and the young 
+	Dai  disguised as a starraider, climb out onto the docking 
+	platform.  An officer and two groundcrew approach him and 
+	salute.  Captain Valor hands him his papers.</sd>
+         <sp spk="JUSTIN">
+		I'm here to check the vent ports in 
+		the rim tracks.</sp>
+         <sp spk="OFFICER">
+		Your ship is from Yavin.  We've 
+		lost all contact with them.  What's 
+		going on out there?</sp>
+         <sp spk="JUSTIN">
+		There is a fierce invasion just east of 
+		Bull Pup station.  It's really a mess 
+		out there.</sp>
+         <sd>The officer smiles and the ground crew starts to check out 
+	the starship.  Valor heads for the main docking exit, followed 
+	by A-2.  He remembers something as he passes the control 
+	station and calls out to the officer.</sd>
+         <sp spk="JUSTIN">
+		Do you mind if I use your com-link?</sp>
+         <sp spk="OFFICER">
+		No.  Go ahead.</sp>
+         <sd>Valor walks into the small control area and pretends to talk 
+	on an intercom system.</sd>
+         <sp spk="JUSTIN (to A-2)">
+		Find the highest security area.</sp>
+         <sd>A-2 punches his claw arm into a computer socket and the brain 
+	comes to life, feeding information to the little robot.</sd>
+         <sd>Captain Valor watches the officer as he directs the crewmen 
+	in the securing of the starship.  A-2 removes his arm from 
+	the computer and the duo leave the control station.</sd>
+         <sd>			 A-2
+		Station 325 is the highest security 
+		area on board.  It's a detention area.</sd>
+         <sd>They disappear into a chamber lock hallway.</sd>
+      </scene>
+      <scene n="164">
+         <setting>ELEVATOR TUBE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor, trying to look inconspicuous, waits for a horizontal 
+	elevator.  Troops and fortress personnel come and go, but 
+	no-one seems to pay any attention to the pair.  Finally  a 
+	small car arrives  and Valor follows A-2 into the podlike 
+	vehicle  and it takes off through a vacuum tunnel.</sd>
+      </scene>
+      <scene n="165">
+         <setting>DETENTION AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor and A-2 enter a security station.  Guards and electronic 
+	cutters are everywhere.  An officer approaches Valor and checks 
+	his papers.</sd>
+         <sp spk="OFFICER">
+		The B-23 can't enter this station.</sp>
+         <sp spk="JUSTIN">
+		But I need him.</sp>
+         <sp spk="OFFICER">
+		Sorry.  No mechanical personnel. 
+		It's restricted.</sp>
+         <sd>Valor watches helplessly as A-2 is led into a waiting area.</sd>
+         <sp spk="OFFICER">
+		You may proceed  but you'll have 
+		to be escorted.</sp>
+         <sd>A trooper joins Valor and leads him through a series of 
+	hallways.  Valor carefully surveys the area as he follows 
+	the guard.</sd>
+         <sp spk="TROOPER">
+		Mathusians just beat the PDRs again.  
+		They should be in another league.  Do 
+		you follow the ecometrics?</sp>
+         <sd>The guard turns to discover that Captain Valor has dis-
+	appeared.  He is stunned, then manages to pull out a small 
+	ring radio.</sd>
+         <sp spk="TROOPER">
+		Code six - alert.</sp>
+      </scene>
+      <scene n="166">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Six Jawas sit before Han and the general, listening to Han 
+	explain something about space fighting.  Tho approaches the 
+	general.</sd>
+         <sp spk="THO">
+		We've made contact with the under-
+		ground on Townowi.  Things are 
+		tighter.  They can only get one 
+		man out.  Datos is on his way.</sp>
+         <sp spk="SKYWALKER">
+		We should be ready by the time he 
+		arrives.</sp>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+		They're ready to go up.</sp>
+         <sd>The general makes a short statement to the Jawas in their 
+	own language.  They let out a loud cheer and run for the row 
+	of starships.</sd>
+      </scene>
+      <scene n="167">
+         <setting>STARSHIP - SPACE - YAVIN</setting>
+         <sd>The general sits next to Boma as he leads two other Jawa- 
+	piloted starships in a tight formation.  They head for a 
+	small cluster of asteroids orbiting near the planet's surface. 
+	The general quietly gives Boma some reassuring instructions. 
+	Han leads a second formation of three ships, following Bomas 
+	group.  The two formations of starships make an attack run on 
+	the asteroids.  The general watches as Boma lines up and fires 
+	at an asteroid blowing it into a million pieces.  The general 
+	smiles and slaps Boma on the back.  The Jawas excitedly 
+	chatter among themselves over the intercom system.</sd>
+      </scene>
+      <scene n="168">
+         <setting>DETENTION AREA HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>A patrol of ten men marches through one of the long hallways 
+	in the detention area.  They stop at an intersection.  The 
+	officer in charge reports on the intercom.</sd>
+         <sp spk="OFFICER">
+		Ben Five to Boma.  All clear.</sp>
+         <sd>The troops relax; some stand in groups, others wander a
+	distance away, poking into the various small alleyways 
+	running off the main hallway.  One trooper notices a small 
+	reflected light in one of the narrow corridors  and carefully 
+	moves down the dark passageway to check it out.  Out of no-
+	where, a fist knocks the trooper unconscious and drags him 
+	into a small alcove.</sd>
+         <sd>The officer finishes his report on the intercom and yells 
+	for the troops to fall-in.  Men scurry in all directions 
+	and out of a narrow corridor emerges Captain Valor, dressed 
+	in the uniform of a royal startrooper.  He joins the platoon 
+	and they march away.</sd>
+      </scene>
+      <scene n="169">
+         <setting>GENERAL'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader and several officers watch the progress of the 
+	search on TV monitors.  The general speaks into an intercom.</sd>
+         <sp spk="VADER">
+		Have them clear the area.  Bring 
+		in the seekers.
+		
+	On the monitors the troops are assembled in the main entry-
+	way and several small chrome balls are thrown into the hall-
+	way.  Small antennae pop from the chrome surface  and the 
+	small balls float down the hallways.  Dodona, once a proud 
+	legionnaire, enters wearing the uniform of a stormtrooper. 
+	He snaps to attention before the general and hands him a 
+	report.  Vader gives Dodona a sly grin.</sp>
+         <sp spk="DODONA">
+		Contact has been lost with the ship 
+		carrying the doctors from Granicus.  
+		The princess' treatment will have to 
+		be delayed.</sp>
+         <sp spk="VADER">
+		We've just trapped your old friend 
+		Captain Valor.  Watch us accomplish 
+		what you found to be impossible.</sp>
+         <sd>Dodona is humiliated but stays at attention.  Vader gets an 
+	emergency call on the intercom.</sd>
+         <sp spk="VADER">
+		Yes. Yes.  Put it on the view screen.</sp>
+         <sd>One of the TV monitors switches to an image of the unconscious 
+	trooper Captain Valor stripped.</sd>
+         <sp spk="VADER">
+		Get me the Captain of the Guard.</sp>
+      </scene>
+      <scene n="170">170  DETENTION AREA - MAIN ENTRY - SPACE FORTRESS - TOWNOWI
+
+	<sd>Three squads of troops, including Captain Valor, stand at
+	attention in the main entrance to the detention area, while 
+	the Captain of the Guard gets new orders over his head-
+	phones.  Valor studies the situation carefully, looking for 
+	a way out of his predicament.  The Captain of the Guard calls 
+	up the platoon sergeants and gives them a series of orders. 
+	They return to their squads and begin to inspect the troops. 
+	Valor begins to get worried.</sd>
+         <sd>The sergeant works his way down the line until he gets to 
+	the trooper next to Valor.  He sees no chance of escape, but 
+	surprise.  Suddenly, he bolts from the ranks and races down 
+	the hallway.</sd>
+         <sp spk="CAPTAIN OF THE GUARD">
+		Squad leaders!</sp>
+         <sd>Ten troopers break out of the ranks and take up the chase. 
+	Captain Valor runs down a corridor and rounds a corner, 
+	reaching a dead end.  The troops round the corner and 
+	confront the trapped Dai.  The sound of igniting lazer-
+	swords fills the hallway.  Valor takes a defensive stance, 
+	his huge lazersword buzzing loudly.  The troops attack. 
+	They fight with skill and bravery  but are eventually all 
+	cut down by the invincible Dai warrior.</sd>
+         <sd>Captain Valor breaks away from the troops and runs down a 
+	long hallway.  A safety door slides shut, closing off his 
+	escape.  He turns around in time to see another door seal 
+	off the opposite end of the hallway.  Before he can make 
+	any attempt to pry open the door, gas fills the sealed 
+	corridor.  Valor collapses in a heap on the floor.</sd>
+      </scene>
+      <scene n="171">
+         <setting>GENERAL'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Vader laughs as he watches the unconscious Valor on the TV 
+	monitors.  All of the other officers in the room are laughing 
+	and joking, except Dodona, who remains grimly at attention.</sd>
+         <sp spk="VADER (to Dodona)">
+		Take him to the special section.</sp>
+         <sd>Dodona salutes, and exits the offices.  Vader laughs again.</sd>
+      </scene>
+      <scene n="172">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - TOWNOWI</setting>
+         <sd>Nine gleaming starships sit in a row along the edge of the 
+	vast jungle runway.  Bizarre and colorful Jawa designs have 
+	been painted across the large deflector fins of the space-
+	craft.  Some designs transform the ships into huge and 
+	grotesque animals, while others create unique mosaic patterns.  
+	The four-man Jawa crews stand proudly at attention in front 
+	of their ships.  The general, along with Han and the under-
+	ground leader, Datos, review the assembled Jawas.   In one of 
+	the Jawa crews, a pilot is picking fleas off the back of his 
+	tail gunner.  When the general passes  he snaps to attention.  
+	There is a gleam in the general's eye as he shows off his 
+	strike force to the crusty old underground leader.  When 
+	they've inspected the last starship, Datos turns to the 
+	general.</sd>
+         <sp spk="DATOS">
+		I'm speechless.  It's amazing.  A 
+		most impressive display.  For the 
+		first time since the take-over, I 
+		feel real hope.</sp>
+         <sp spk="SKYWALKER">
+		Will your people be ready?</sp>
+         <sp spk="DATOS">
+		Our forces have already started 
+		sabotaging their com-link set 
+		ups.  A refugee camp on Mananyo 
+		has been conducting raids on 
+		shipping from Granicus.  That's 
+		how we intercepted those doctors.</sp>
+         <sp spk="SKYWALKER (to Han)">
+		Get them in the ships.  We're on 
+		our way.  <sd>to Datos</sd>  Send the 
+		code signal.</sp>
+      </scene>
+      <scene n="173">
+         <setting>DETENTION CELL - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader and Dodona watch as a medic revives Valor, 
+	who has been strapped to an upright slab protected by 
+	cutter-rays.</sd>
+         <sp spk="MEDIC">
+		He's coming round.</sp>
+         <sd>The medic backs away and throws the switch which activates 
+	the cutters.  A blue glow surrounds Valor as he wakes up 
+	and sees Vader and Dodona.</sd>
+         <sp spk="VADER">
+		For all the myths and the trouble 
+		you don't seem like much.</sp>
+         <sd>He laughs and leaves Dodona alone in the room with the young 
+	Dai.  Dodona appears sad and frustrated at the capture of the 
+	noble warrior.  They stare at one another for a few moments.</sd>
+         <sp spk="DODONA">
+		You were insane to come here.  The 
+		security on this...this thing is 
+		impossible.  Why?  For her?  I can't 
+		believe your loyalty is that strong. 
+		You're a great warrior, but you're a 
+		greater fool.  This is a place for 
+		androids - no codes, no honor.  Our 
+		ways are useless here.  Why couldn't 
+		you have stayed away?
+		
+	He storms out of the cell.  Captain Valor struggles to free
+	himself.</sp>
+      </scene>
+      <scene n="174">
+         <setting>SLUM DWELLING - GORDON SPACEPORT - TOWNOWI</setting>
+         <sd>The young partisan, Occo, listens to a small transmitter in 
+	a secret closet behind the main room in a slum dwelling.  He 
+	jumps up and runs  into the main room  where Quist and 
+	several other men are sitting around a table covered with 
+	maps and plans.</sd>
+         <sp spk="OCCO">
+		It's Datos.  We've got the go 
+		ahead.</sp>
+         <sd>The men cheer and starts hugging and slapping each other on 
+	the back.  Finally  they settle down.</sd>
+         <sp spk="QUIST">
+		Go to your organizations. <sd>to Occo</sd>  
+		What's the code time?</sp>
+         <sp spk="OCCO">
+		Zero three thirty.</sp>
+         <sp spk="QUIST">
+		May the force of others be with you.</sp>
+         <sd>The men solemnly shake hands and leave the room.</sd>
+      </scene>
+      <scene n="175">
+         <setting>GOVERNOR'S OFFICE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor stands on a small platform before Governor
+	Horus and the High Consul.  His hands are held behind his 
+	back by electric bonds.</sd>
+         <sp spk="HORUS">
+		... and I'm sure the King will 
+		enjoy your execution.  I only 
+		regret I won't be there myself. 
+		This should end the Dai Nogas 
+		myth once and for all.  Take 
+		him to Granicus.</sp>
+         <sd>Dodona steps forward with a squad of stormtroopers and
+	escorts the prisoner away.  Vader and the governor seem 
+	very pleased with themselves.  Dodona looks back in disgust.</sd>
+      </scene>
+      <scene n="176">
+         <setting>CONTROL CENTER - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>In the large central control room, two officers sit above 
+	a row of monitors and giant readouts.</sd>
+         <sp spk="FIRST OFFICER">
+		Look!  That whole sector just 
+		went dead.  We're losing contact 
+		with the surface.  Use the IF 
+		link and find out what's going 
+		on.</sp>
+      </scene>
+      <scene n="177">
+         <setting>DOCKING AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Dodona halts the squad guarding Captain Valor on an 
+	observation deck overlooking a starship docking port. 
+	Dodona reports to the officer in charge.</sd>
+         <sp spk="DODONA">
+		Where is the ship?</sp>
+         <sp spk="OFFICER">
+		It's on its way in.  It will just 
+		be a few minutes.</sp>
+         <sd>Dodona returns to his squad and watches the large starship 
+	slowly move into the docking area.  He glances at Valor, 
+	who stands defiant, ready to meet his fate.</sd>
+         <sd>Dodona continues to study Valor.  The young Dai returns his 
+	gaze.  Slowly  the spacecraft locks onto the docking port 
+	with a loud jolt.  The troops snap to attention  but Dodona 
+	grabs two lazerswords and in one swift move  switches off 
+	Valors bonds and tosses him one of the lazerswords.  Valor 
+	assumes a defensive stance, as the troops realize what has 
+	happened and draw their swords.</sd>
+         <sp spk="DODONA">
+		This way!</sp>
+         <sd>The two warriors fight their way through a side exit.  The 
+	door slides closed behind them, and Dodona throws the lock, 
+	trapping the troops on the observation platform.  They race 
+	down the hallway and stop at an intersection.</sd>
+         <sp spk="DODONA">
+		This way!   We can get a starship 
+		and be out of here before they've 
+		discovered...</sp>
+         <sp spk="JUSTIN">
+		I'm not leaving without the princess.</sp>
+         <sp spk="DODONA">
+		It's impossible;  there are traps 
+		everywhere.  You're mad!</sp>
+         <sd>Valor just grins and runs down the passageway leading to the 
+	detention area.  Dodona rushes and catches up.  An alarm 
+	signal wails through the hallways.</sd>
+      </scene>
+      <scene n="178">
+         <setting>JAWA STARSHIPS - SPACE</setting>
+         <sd>The general leads three squads of starships toward the glowing 
+	planet of Townowi.</sd>
+         <sp spk="SKYWALKER">
+		There she is.  Activate your deflection 
+		 shields.</sp>
+      </scene>
+      <scene n="179">
+         <setting>DETENTION AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Dodona talks with the Captain of the Guard.  He gestures wildly 
+	like something important had happened.  Four troops run into 
+	the central detention area leading the bound princess.  The 
+	captain salutes Dodona and the legionnaire, followed by the 
+	four troops and Zara, leave the main area.</sd>
+      </scene>
+      <scene n="180">
+         <setting>DETENTION HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor appears boldly at the end of the hallway facing Dodona 
+	and the troops.</sd>
+         <sp spk="DODONA">
+		Get him!</sp>
+         <sd>The troops rush for Valor, swords drawn.  They are no match 
+	for the skilled Dai.  He makes short work of them,  as Dodona 
+	frees the princess.  The trio then run into another hallway. 
+	The princess embraces Valor.</sd>
+         <sp spk="DODONA">
+		We have only a few seconds before they 
+		find us.  All of these hallways are 
+		sealable.</sp>
+         <sd>Valor spots a small garbage chute on the corridor wall.  He 
+	goes and looks into it.</sd>
+         <sp spk="JUSTIN">
+		Is this pressurized?</sp>
+         <sp spk="DODONA">
+		They're power sealed. We'll have to 
+		find another way, or some way to shut 
+		the power off.</sp>
+         <sd>They search the smooth-walled room for another exit.</sd>
+      </scene>
+      <scene n="182">
+         <setting>GOVERNOR'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Governor Horus watches General Vader as he supervises the 
+	hunt for Valor and Dodona.  They watch troops move through 
+	the detention area via TV monitors.  Seekers buzz through 
+	the hallways.  The general gets a report from an officer 
+	on another monitor.</sd>
+         <sp spk="OFFICER">
+		We've lost contact with the surface.  
+		There is a good probability of an 
+		uprising.  Even the IF links are out.</sp>
+         <sp spk="VADER">
+		Use a substandard relay and put all 
+		units on alert.</sp>
+         <sd>The officer disappears from the monitor and is replaced with 
+	the Captain of the Guard.</sd>
+         <sp spk="CAPTAIN">
+		All sections D through P-12 are clear.  
+		We have reason to suspect they escaped 
+		through the disposal system.  We are
+		checking.  (he is interrupted by an 
+		excited trooper who tells him something) 
+		We've found them in Receptacle B-29. 
+		You should...</sp>
+         <sd>A red light flashes on one of the other monitors.</sd>
+         <sp spk="VADER">
+		Hold on.</sp>
+         <sd>A controller appears on the second monitor.</sd>
+         <sp spk="CONTROLLER">
+		Starships approaching, three squads 
+		of royal design, but no clearance.</sp>
+         <sp spk="GENERAL">
+		Full alert.  Battle stations...</sp>
+         <sd>The general turns back to the Captain of the Guards.</sd>
+         <sp spk="CAPTAIN">
+		You should have them on your 
+		screen.</sp>
+         <sd>Alarms sound throughout the fortress.  Lights flash a
+	warning.</sd>
+      </scene>
+      <scene n="182">
+         <setting>GARBAGE RECEPTACLE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>A floodlight switches on  revealing Dodona and Valor 
+	attempting to cut open the door.  The princess stands up 
+	and stares into the floodlight.  Vader's voice comes over 
+	an intercom.</sd>
+         <sp spk="VADER">
+		I'm afraid I have no more time to 
+		deal with you.  A senseless and 
+		futile attack by your friends has 
+		forced me to take a rather un-
+		pleasant course of action.  Your 
+		execution will have to be expedited.</sp>
+         <sd>The intercom clicks off and a loud rumbling begins to shake 
+	the room.  With a loud shriek, the princess points to the 
+	far wall;  it has started to move toward the trio.  The 
+	situation looks desperate.</sd>
+      </scene>
+      <scene n="183">
+         <setting>SPACE - JAWA STARSHIPS - TOWNOWI</setting>
+         <sd>Lazerfire from the space fortress creates a wall of death, 
+	which the three squadron of Jawa starships miraculously 
+	emerge through undamaged.  The general barks orders to the 
+	Jawa craft and Boma and his squadron break off and start an 
+	attack dive.  Lazerfire from Bomas brightly colored ship 
+	hits one of the prime power terminals on the fortress sur-
+	face.  It explodes, creating weird electric arcs as it goes.</sd>
+         <sd>Han and the general also concentrate fire on the distinctive 
+	black power terminals.  Two more are destroyed in an arcing 
+	spectacle.  A chain reaction is set off, creating a series of 
+	explosions leaping across the surface of the fortress from 
+	power terminal to power terminal.</sd>
+      </scene>
+      <scene n="184">
+         <setting>GARBAGE RECEPTACLE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>The shock of the explosion can be felt over the rumbling of 
+	the trash masher.  The wall has moved within a few yards of 
+	squashing Dodona, Valor and the princess.  They are still 
+	frantically trying to somehow stop the relentless wall, to 
+	no avail.  The lights blink off, then on again  and the 
+	moving wall rumbles to a halt.  Zara breathes a sigh of 
+	relief.</sd>
+         <sp spk="VALOR">
+		They must have knocked the power 
+		out.</sp>
+         <sd>Dodona runs over to the door  and kicks it open.  They rush 
+	out of the would-be death trap.</sd>
+      </scene>
+      <scene n="185">
+         <setting>SPACE - JAWA STARSHIPS - TOWNOWI</setting>
+         <sd>One of the Jawa starships is caught in a crossfire and dis-
+	appears in a cloud of smoke.  Another ship for some unknown 
+	reason dives headlong into the surface of the fortress, 
+	creating a huge explosion.</sd>
+      </scene>
+      <scene n="186">
+         <setting>MAIN HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor, Dodona and the princess are thrown to a hallway 
+	floor by the explosion.  They get up and start down the hall-
+	way again.  A voice calls out from a connecting corridor.</sd>
+         <sd>			 A-2
+		Hey!  Over there.
+		
+	The trio turn and see little A-2 standing at the other end of 
+	the corridor.  He waves his claw arm at them and wobbles over
+	to them.</sd>
+         <sd>			 A-2
+		The power core has exceeded the 
+		normal stress quotient by point 
+		eight.  The magnetic fusion pods 
+		have evaporated.  There appears 
+		to be an immediate danger.</sd>
+         <sp spk="DODONA">
+		There is a lifepod station at the 
+		other end of this section.  Hurry.</sp>
+         <sd>The group followed by A-2, make a dash for the lifepod, 
+	but are knocked to the ground by another explosion which 
+	rocks the hallway.  A hole is ripped in one wall, sucking 
+	debris into space.  Everyone holds on to wall fixtures for 
+	dear life.</sd>
+      </scene>
+      <scene n="187">
+         <setting>GOVERNOR'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Aides and officers rush through the office, as Vader tries 
+	to keep things under control.  Governor Horus remains calm, 
+	watching the progress of the battle.  Vader turns to the 
+	governor.</sd>
+         <sp spk="VADER">
+		They've pinpointed every terminal.
+		It's impossible.  What are they?  
+		Where did they come from?  An 
+		electromagnetic transfer has started.
+		There's no stopping it.</sp>
+         <sp spk="GOVERNOR">
+		Continue the fight.</sp>
+         <sp spk="VADER">
+		We've already lost control of the 
+		planet.  We must abandon ship while 
+		there is still time.  Conditions are 
+		much worse than...</sp>
+         <sp spk="GOVERNOR">
+		Continue the fight.  This fortress 
+		is invincible.  I will not give up.</sp>
+         <sd>A giant explosion sweeps through the office.</sd>
+      </scene>
+      <scene n="188">
+         <setting>SPACE - JAWA STARSHIPS</setting>
+         <sd>The tiny starships race the chain reaction explosions across 
+	the surface of the fortress.  Lazerfire is everywhere.  One 
+	of the starships skimming across the surface lags behind and 
+	is caught in an explosion and disappears.</sd>
+         <sp spk="SKYWALKER">
+		Han!  Get everyone out of here. 
+		The whole thing's going to go.
+		Return to Gordon.  Get them out.</sp>
+         <sd>Han relays the order to the Jawas, and then starships pull 
+	away from the crippled fortress.</sd>
+      </scene>
+      <scene n="189">
+         <setting>MAIN HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>The group has made their way past the hole in the wall and 
+	are climbing into the lifepods.  Captain Valor helps the 
+	princess into one, while Dodona and A-2 get into the other. 
+	Warning sirens scream throughout the hallways.  Three troops 
+	run toward the lifepods, firing lazerpistols.  dodona returns 
+	the fire, stopping the oncoming troops.  Hatches are closed 
+	and the lifepods eject into space.</sd>
+      </scene>
+      <scene n="190">
+         <setting>LIFEPODS - SPACE - TOWNOWI ORBIT</setting>
+         <sd>The two lifepods drift toward the calm of the planet's
+	surface.  Captain Valor and the princess embrace  and he 
+	kisses her tenderly.  They watch the ominous fortress grow 
+	smaller and smaller as they drift away.  Suddenly, a great 
+	flash replaces the fortress and rubble streaks past the 
+	lifepods.  Several giant explosions follow, then there is 
+	only a smoke cloud where the mighty fortress once orbited 
+	Townowi.</sd>
+      </scene>
+      <scene n="191">
+         <setting>THRONE ROOM - PALACE OF LITE - TOWNOWI</setting>
+         <sd>Queen Zara, in all her grandeur, sits on the magnificent
+	throne of Townowi.  Captain Valor and the general stand to 
+	her right.  Several old advisors stand to her left.  Han 
+	presents Boma and a delegation of Jawas with a treaty, 
+	gifts, and a medal of honor.  They bow and exit.  Han moves 
+	to one side of the crowded court.  Dodona stands next to 
+	him.  They watch as the two robots, A-2 and C-3 approach 
+	the Queen and bow.</sd>
+         <sp spk="ZARA">
+		Your service to Townowi is greatly 
+		appreciated.  You are designated 
+		class A-4, and will serve Justin 
+		Valor, the new Lord Protector of 
+		Townowi.  Rise!</sp>
+         <sd>The robots rise and exit through the long entrance hall to 
+	\he throne.  The Queen turns and smiles at Valor and the 
+	general.  The general and Valor salute their new Queen.</sd>
+         <sd>									FADE OUT</sd>
+         <sd>			 END CREDITS</sd>
+      </scene>
+   </body>
+</xml>

--- a/scripts/ANHDraftsXML/XMLtransformed/ANHroughDraft.xml
+++ b/scripts/ANHDraftsXML/XMLtransformed/ANHroughDraft.xml
@@ -1,0 +1,5281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>The Star Wars</title>
+      <author>George Lucas</author>
+      <draft>Rough Draft [First of four major screenplay drafts]
+Lucasfilm Ltd.</draft>
+      <date>5/74</date>
+   </metadata>
+   <body>
+      <sd>  FADE IN:</sd>
+      <scene n="1">
+         <setting>SPACE</setting>
+         <sd>A sea of stars is broken by the vast blue surface of the planet, Utapau.  Five
+small moons slowly drift into view from the far side of the planet.  The main
+titles are followed by a roll-up:</sd>
+         <sd>Until the recent Great Rebellion, the Jedi Bendu were the most feared warriors
+in the universe.  For one hundred thousand years, generations of Jedi
+perfected their art as the personal bodyguards of the emperor.  They were the
+chief architects of the invincible Imperial Space Force which expanded the
+Empire across the galaxy, from the celestial equator to the farthest reaches
+of the Great Rift.</sd>
+         <sd>Now these legendary warriors are all but extinct.  One by one they have been
+hunted down and destroyed as enemies of the New Empire by a ferocious and
+sinister rival warrior sect, the Knights of Sith.</sd>
+         <sd>A small silver spacecraft emerges from behind one of the Utapau moons.  The
+deadly little fightercraft speeds past several of the moons, until it finally
+goes into orbit around the fourth moon.</sd>
+      </scene>
+      <scene n="2">
+         <setting>  WASTELAND - FOURTH MOON - UTAPAU</setting>
+         <sd>A harsh gale blows across the bleak grey surface of the Fourth Moon.  The
+leaden sky presses down on a lone figure, Annikin Starkiller, a tall, heavy-
+set boy of eighteen.  He slowly makes his way across the canyon floor.  The
+heavy winds whip at him and make the going extremely difficult.  His face is
+covered by a breath mask and goggles.  He stops for a second to adjust the
+shoulder strap on his chrome multiplelaser rifle.  Something in the sky
+catches his eye, and he instinctively grabs a pair of electrobinoculars from
+his belt.  He stands transfixed for a few moments, studying the heavens, then
+turns and rushes back in the direction from which he came.</sd>
+      </scene>
+      <scene n="3">
+         <setting>  SUPPLY HUT - FOURTH MOON - UTAPAU</setting>
+         <sd>A spacecraft, half buried in the dust, rests next to the remains of an
+abandoned supply shack.  Annikin makes his way across the colorless landscape
+and rushes into the crumbling building.  The interior of the hut is shabby,
+but manages to abate the howling winds.  Seated in front of a thermoheater are
+Annikin's father, Kane, and his young brother, Deak.  Kane is a large, burly
+man, wearing the distinctive robes of a Jedi.  Deak is ten years old, with
+dusty blond hair and a large scratch on his cheek.  Annikin slams the door and
+removes his gear.  His ruggedly handsome face is caked with many layers of
+dust.</sd>
+         <sp spk="ANNIKIN">
+
+Dad!  Dad!...They've found us!</sp>
+         <sd>Deak looks up from a small cube he has been studying.  His father whacks him
+across the shoulder with a braided wire connector.</sd>
+         <sp spk="KANE">
+
+Continue with the problem.  Your concentration is worse than your brother's.
+<sd>to Annikin</sd> How many?</sp>
+         <sp spk="ANNIKIN">
+
+Only one this time.  A Banta Four.</sp>
+         <sp spk="KANE">
+
+Good.  We may not have to repair this old bucket after all.  Prepare yourself.</sp>
+         <sp spk="DEAK">
+
+Me too!</sp>
+         <sp spk="KANE">
+
+Do you have the answer?</sp>
+         <sp spk="DEAK">
+
+I think it's the Corbet dictum:  "What is, is without."</sp>
+         <sd>Kane smiles.  This is the correct answer.  Annikin is strapping on a utility
+belt with chrome laserpistols and lasersword.  Kane rises and starts for his
+equipment.</sd>
+         <sp spk="DEAK (Con't)">
+
+Ahhh, Pop...</sp>
+         <sp spk="KANE">
+
+Deak, do you feel you're ready?</sp>
+         <sp spk="DEAK">
+
+Yes, sir.  I've outmarked Annikin in twelve disciplines.  I'm as good...</sp>
+         <sp spk="KANE">
+
+All right, son, get your gear.</sp>
+         <sd>Deak jumps up with the enthusiasm available only to a ten-year-old and grabs
+his gear.  His father frowns and shakes his head.</sd>
+      </scene>
+      <scene n="4">
+         <setting>  WASTELAND BLUFF - FOURTH MOON - UTAPAU</setting>
+         <sd>Kane Starkiller and his two sons carefully make their way up a rock bluff
+overlooking the parked silver Sith spacecraft.  Kane inspects the craft with
+his electrobinoculars.</sd>
+         <sp spk="KANE">
+
+No tracks.  Bi-lock hasn't been opened....Interior systems are still on....</sp>
+         <sp spk="ANNIKIN">
+
+Are we going to wait for him to come out?</sp>
+         <sp spk="KANE">
+
+He's not in there....He's baiting us.  I'm surprised they only sent one this
+time.  We must be wearing them down, or they must think this knight is
+something special....Stay on guard, and keep hidden.  I'm going to work my way
+across the ridge and call his bluff.  Better we meet in open combat than wait
+for him to ambush us....Keep your guard!</sp>
+         <sd>Kane leaves his two sons and  moves off along the obscured ridge.  Annikin and
+Deak watch him intently.  Annikin throws down his multiplelaser rifle in
+disgust.</sd>
+         <sp spk="ANNIKIN">
+
+He should have let me go with him....He's getting too old to make an open
+challenge.</sp>
+         <sp spk="DEAK">
+
+He's not too old to realize you'd just get in the way.</sp>
+         <sd>Annikin ignores his little brother's remark and sneaks a look over the ridge
+at the Sith spacecraft.  Kane moves out of the rocks some distance away and
+starts toward the starship.  Deak moves to the ridge next to his brother, his
+chrome laserrifle sparkling in the reflected light of Utapau.</sd>
+         <sp spk="DEAK">
+
+He's making his move....</sp>
+         <sp spk="ANNIKIN">
+
+Watch your guard...and cover that weapon.  It shines like a beacon.</sp>
+         <sd>Deak reluctantly move away and watches the other direction.  Kane has almost
+reached the Sith spacecraft and still there is no sign of its occupant.</sd>
+         <sp spk="DEAK">
+
+What's happening?</sp>
+         <sp spk="ANNIKIN">
+
+Nothing.  I don't like it.</sp>
+         <sd>Kane carefully moves to the main hatch of the starship.  He kicks a valve and
+the hatch drops open with a loud clank and rushing gas.  Annikin becomes more
+tense as his father carefully moves inside the spacecraft.  Everything is
+still.  Even the continual winds seem to have died down.  Moments pass with no
+sign of activity inside the enemy starship.  Annikin watches the craft with
+his electrobinoculars.  The waiting becomes unbearable.</sd>
+         <sp spk="ANNIKIN">
+
+Something's happened!  He's been in there too long.</sp>
+         <sp spk="DEAK">
+
+Let me look!  Stand my guard.</sp>
+         <sd>Deak takes the electrobinoculars from his brother and studies the silent
+spacecraft.  Annikin impatiently scans the opposite horizon.</sd>
+         <sp spk="DEAK">
+
+I think the power just went off.  We'd better wait here until someone comes
+out.</sp>
+         <sp spk="ANNIKIN">
+
+What if he needs help?</sp>
+         <sp spk="DEAK">
+
+The power went back on again....</sp>
+         <sd>With the aid of the electrobinoculars, Deak watches the running lights of the
+starship flash on and off.  Suddenly, something huge moves in front of his
+field of view.  Before either of the two young boys can react, a large,
+sinister Sith warrior in black robes and a face mask looms over them.  He
+carries a long lasersword which cuts young Deak down before he or his brother
+are able to raise their weapons.  The startled Annikin backs away in horror,
+then settles down and ignites his lasersword, which creates an eerie red glow.</sd>
+         <sd>He stumbles over rocks as he attempts to avoid the charging Sith knight.  The
+evil warrior swings his mighty lasersword, but Annikin manages to deflect the
+intended deathblow.</sd>
+         <sd>Finally, Annikin is able to assume a defensive stance, and the two warriors
+stand, sizing up each other.  The black knight is at least seven feet tall,
+and dwarfs the young Jedi.  They stand for a few moments, almost frozen, then
+in a flurry of blows, laserswords clash with the sound of electric snapping
+and popping.  Annikin is barely able to hold his own against the experienced
+knight.  Many blows are exchanged before the Sith warrior is able to back
+Annikin up against a deep crevasse.  Annikin stumbles and almost falls over
+the cliff to his death.</sd>
+         <sd>The black knight suddenly senses something behind him and whirls around to
+face Annikin's father, Kane Starkiller, a Jedi Bendu master.  The Sith warrior
+raises his lasersword, but is cut in two before he can bring it down again.
+Kane moves to the fallen black knight, and studies him carefully.  Annikin,
+still a little wobbly from the whole experience, attempts to stand.  Kane sees
+his dead son Deak, and goes to him.  He lifts him into his arms and begins to
+weep.  Annikin stands bewildered, watching his father cradle his dead brother.</sd>
+      </scene>
+      <scene n="5">
+         <setting>  INTERIOR SITH STARSHIP - WASTELAND CANYON - UTAPAU</setting>
+         <sd>Kane Starkiller slides into one of the four seats of the small Sith starship.
+Through the front viewing canopy, he watches Annikin drag his younger
+brother's body to a small crevasse.  Annikin places a small locket around his
+brother's neck, makes a complicated sign with his hand, and dumps the body
+into the shallow depression.  The giant engines of the spacecraft begin to
+whine, kicking up large clouds of dust.</sd>
+         <sd>Annikin climbs into the seat beside his father and removes his breath mask and
+goggles.  There are tears in his eyes.  Father and son look out across the
+wasteland towards Deak's grave.  The thunderous clap of an explosion is
+followed by a small mushroom cloud rising out of the depression.  Annikin
+throws a container down in a fit of rage.</sd>
+         <sp spk="ANNIKIN">
+
+How many more of them are there?  I want to finish it, once and for all!  I'm
+sick of running...when will it stop?</sp>
+         <sd>Annikin's father waits silently until his son's tirade is finished.  Annikin
+sits silently for a few moments.</sd>
+         <sp spk="ANNIKIN (con't)">
+
+I'm sorry.</sp>
+         <sp spk="KANE">
+
+Son, plot a course for Aquilae.</sp>
+         <sd>Annikin lights up like a Bantha at feeding time.</sd>
+         <sp spk="ANNIKIN">
+
+Aquilae!!  You mean we're going home?</sp>
+         <sp spk="KANE">
+
+We both need a rest.</sp>
+         <sd>Kane pulls back on the throttle, and the powerful spaceship lifts off the
+surface of the Fourth Moon of Utapau.</sd>
+      </scene>
+      <scene n="6">
+         <setting>  CLOUD SEA - ALDERAAN</setting>
+         <sd>A title card appears over a sea of billowing clouds on the gaseous planet of
+Alderaan:</sd>
+         <sd>Alderaan:  Capital of the New Galactic Empire.</sd>
+         <sd>The towering white oxide clouds pass, revealing the Imperial city of Alderaan.</sd>
+         <sd>The magnificent domed and gleaming city is perched, mushroom-like, on a tall
+spire, which disappears deep into the misty surface of the planet.  The
+peacefulness of this nebulous idyll is broken by the increasing wail of ion
+engines.   Four sleek stardestroyers, from the Imperial Third Fleet, burst
+from one of the huge cumulus range.  The craft are flying in a tight formation
+as they bank steeply, and head toward the Imperial capital of the galaxy.</sd>
+      </scene>
+      <scene n="7">
+         <setting>  INTERIOR OF STARDESTROYER - ALDERAAN</setting>
+         <sd>Stardestroyers are two-man spacecraft crammed with sophisticated electronic
+weaponry.  The pilot and gunnery officers sit side-by-side, surrounded by
+lighted readouts and switches.  They wear the gleaming black uniforms of the
+Empire.</sd>
+         <sp spk="PILOT">
+
+Tok-One to chicks:  Shape it up.  Let's make it good.</sp>
+         <sp spk="CHICK-ONE">
+
+Does that glare bother you?</sp>
+         <sp spk="PILOT">
+
+Use your face shield, Chick-One.</sp>
+         <sd>The pilot is cold and professional as he maneuvers his craft closer to the
+others.  The positions of the ships are displayed on a readout, along with a
+graphic representation of the city.  The pilot gives the gunner a quick look
+before he flips his sunshield over his eyes.</sd>
+         <sp spk="PILOT">
+
+Here we go.  Count:  three, two, one, now!</sp>
+      </scene>
+      <scene n="8">
+         <setting>  REVIEW STAND - PLAZA OF THE DADERS - ALDERAAN</setting>
+         <sd>On a huge, austere platform stands the dark Cos Dashit, Lord of Alderaan,
+Consul to the Supreme Tribunal, and ruler of the Galactic Empire.  He is a
+thin, grey-looking man, with an evil mustache which hangs limply over his
+insipid lip.  Standing at rigid attention on his right are several generals,
+dressed in the black and grey uniform of the realm.  Five members of the
+Supreme Tribunal sit off to the side.  On the emperor's left stands Crispin
+Hoedaack, newly appointed Governor of the Aquilaean Systems, a young,
+treacherous man with stone-cut, angular features and piercing grey eyes.</sd>
+         <sd>They all gaze skyward, as the four gleaming stardestroyers scream low overhead
+in an impressive barrel-roll formation.  As the sound of the spacecraft
+resonates throughout the glass canyon of the Plaza, the group of dignitaries
+return their attention to the parade of Imperial shock troops, and giant air
+tanks (which ride magically two to three feet above the ground).</sd>
+         <sd>The Plaza of the Daders is filled with a hundred rows of troops as the last
+brigade marches into position.  The sound of a thousand men snapping to
+attention is followed by a strange silence.  A light wind blows the great red
+banner of the Empire, creating a subtle flapping sound.  The emperor's
+amplified voice startles many of the troops as it cuts through the quiet.</sd>
+         <sp spk="EMPEROR">
+
+Upon this battle depends the survival of the Galactic Empire.  Upon this
+battle depends the life and long continuity of our civilization.  Not since
+the great Jedi Rebellion has our destiny been placed in such a balance.  This
+is to be the most magnificent campaign of all!  You have never been called
+without doing something to be remembered, something notable and striking.  The
+conquering of the Aquilaean System, the last of the independent Systems, and
+the last refuge of the outlawed, vile sect of the Jedi, will have such
+important and lasting consequences, that I can't but consider it as an epoch
+in history.</sp>
+         <sd>To the rear of the Plaza, watching the spectacle over the shoulder of a
+curious bureaucrat, stands Clieg Whitsun, a tall, blond young man about twenty
+years old.  He seems interested in what the emperor has to say, but keeps
+looking around nervously as if someone were after him.  His arm rests across
+his head, as he carefully but coolly adjusts a glowing blue ring on his index
+finger.  The emperor nears the end of his speech.
+        Crispin Hoedaack has moved up to stand next to the sinister monarch.
+The troops shout an Imperial salute in response to a particularly partisan
+statement.</sd>
+         <sp spk="EMPEROR (con't)">
+
+...I have personally asked the Aquilaeans to accept this Treaty of Alliance.
+During the long period of negotiation, they have only decided to be undecided.</sp>
+         <sd>We will barter no longer.  Governor Hoedaack has been appointed the First Lord
+of the Aquilaean System and Surrounding Territories.  This is the last
+frontier and the final stone in the great wall of the Galactic Empire.</sd>
+         <sd>The troops cheer, ad the emperor escorts Hoedaack inside.  Whitsun moves
+quickly away from the Plaza, passing through several check stations, where he
+is forced to show his identification.</sd>
+      </scene>
+      <scene n="9">
+         <setting>  NIGHT CLUB - ALDERAAN</setting>
+         <sd>Whitsun walks into the glass and chrome splendor of one of the famous
+nightclubs of Alderaan.  He moves to the long mirrored bar, and sits next to a
+rough-looking man, Bail Antilles, dressed in the distinctive gold and furs of
+the Galactic traders.</sd>
+         <sp spk="WHITSUN">
+
+Your glass is empty.</sp>
+         <sd>Whitsun speaks into a small intercom on the bar front.</sd>
+         <sp spk="WHITSUN (con't)">
+
+A dantic and...</sp>
+         <sd>He looks in Antilles' glass.</sd>
+         <sp spk="ANTILLES">
+
+No thanks, Whitsun.  I've had enough.</sp>
+         <sp spk="WHITSUN">
+
+Just a dantic then.  Bail, it's not like you to refuse a drink.  You're going
+to give Galactic traders a bad name.</sp>
+         <sd>A drink appears magically from a small elevator in the bar.  Whitsun takes it,
+and then places a pen-like transmitter he has taken from his pocket next to
+the intercom.  It creates a low electronic buzz.</sd>
+      </scene>
+      <scene n="10">
+         <setting>  BAR OBSERVATION CENTER - ALDERAAN</setting>
+         <sd>A controller sitting in front of a row of monitors taps his headphones, then
+flips a switch back and forth a couple of times.  He is obviously annoyed.</sd>
+         <sp spk="CONTROLLER">
+
+Number eighteen is out again.  Give me a maintenance check.</sp>
+         <sd>The controller yawns and puts his feet up on the control panel.</sd>
+      </scene>
+      <scene n="11">
+         <setting>  NIGHTCLUB - ALDERAAN</setting>
+         <sd>Whitsun leans in close to Antilles.  He is suddenly very serious.</sd>
+         <sp spk="ANTILLES">
+
+Whitsun, we've got problems.  They've just grounded all spacecraft, including
+trade frigates.  Even the ships under Imperial registry can't move.  Something
+big is up.</sp>
+         <sp spk="WHITSUN">
+
+I'm afraid they're not waiting for the Alliance Treaty.  They're already
+moving against the System.  I've got to get word back.</sp>
+         <sp spk="ANTILLES">
+
+The chrome companies are protesting the embargo, but it's going to take some
+time.</sp>
+         <sp spk="WHITSUN">
+
+Isn't anything moving?</sp>
+         <sp spk="ANTILLES">
+
+Military ships, but...</sp>
+         <sd>They are interrupted by an Imperial officer, and several stormtroopers.   The
+officer shouts over the P.A. system, as the troops rush to block the exits.
+Whitsun and the Galactic trader are tense, but remain cool.</sd>
+         <sp spk="OFFICER">
+
+Attention:  all Captains and First Officers of Guild Trade frigates will
+accompany me to the Ministry of Transport immediately.</sp>
+         <sd>Antilles gives Whitsun a hopeless look as the troops check their papers, and
+then take Antilles away.   A small fight breaks out in the back of the
+nightclub as one of the trader captains expresses his dislike of the Empire.
+Whitsun slams his glass to the bar in a gesture of hate and frustration.</sd>
+      </scene>
+      <scene n="12">
+         <setting>  GOVERNOR HOEDAACK'S QUARTERS - ALDERAAN</setting>
+         <sd>The large, white-on-white executive quarters resound with the high-pitched
+laugh of the evil Governor Hoedaack.  He slaps Darth Vader, a tall, grim-
+looking general, on the back, and the general's mouth makes the slightest
+gesture at a smile.</sd>
+         <sp spk="HOEDAACK">
+
+Success, I told you.  We are no longer under the control of the Great
+Families....We've gained a true advantage.</sp>
+         <sd>Vantos Coll, a member of the Supreme Tribunal, and a man of the grossest
+dimensions, appears to be a little worried.</sd>
+         <sp spk="COLL">
+
+A rather dangerous advantage.  You still have a System to conquer.</sp>
+         <sp spk="HOEDAACK">
+
+But this System will bring us more scientific wealth than that of any other
+House in the Tribunal.  We will easily gain control of the directorship.</sp>
+         <sp spk="COLL">
+
+Don't underestimate the armies of Aquilae.  They're lead by a Jedi.</sp>
+         <sp spk="HOEDAACK">
+
+I've told you about Commissioner Lars, General.  He worries a lot.</sp>
+         <sp spk="VADER">
+
+It's a myth that any Jedi still exist.</sp>
+         <sp spk="COLL">
+
+General Skywalker is no myth.  When I first arrived at court, he was the First
+Bodyguard to the emperor...He lead the Jedi Rebellion.</sp>
+         <sp spk="VADER">
+
+Seig Darklighter lead the Rebellion.</sp>
+         <sp spk="COLL">
+
+So the emperor would have you think, but I was there.</sp>
+         <sp spk="VADER">
+
+Then why wasn't he hunted down like the others?</sp>
+         <sp spk="COLL">
+
+Because he is too dangerous, too clever.  Besides, his presence on Aquilae is
+still only a rumor.</sp>
+         <sp spk="HOEDAACK">
+
+Then why do you believe it?</sp>
+         <sp spk="COLL">
+
+Because I knew him.  He's there, alright.  I can sense it.  Mark my words:
+Aquilae will not be easily conquered.</sp>
+      </scene>
+      <scene n="13">
+         <setting>  COURTYARD - PALACE OF LITE - AQUILAE</setting>
+         <sd>A low, sleek "landspeeder," (an auto-like transport which travels a few feet
+above the ground on a magnetic field), glides into the courtyard of the palace
+of Aquilae.  The planet is desert wilderness, but the palace is a sparkling
+oasis, with low concrete walls and great turrets spilling over with foliage
+from rooftop gardens.  The speeder stops before an enormous shaded corridor.
+Fountains line the beautiful and highly polished, tiled walkway.  Two young
+boys, Biggs (7) and Windom (5) are helped out of the speeder by Amber, a one-
+armed bodyguard dressed in the flowing white robes of the Aquilaean military.
+The two boys run through the long corridors, yelling and screaming, their
+little footsteps echoing throughout the palace.</sd>
+      </scene>
+      <scene n="14">
+         <setting>  The palace library is a dim, cool room projecting an aura of time-worn
+comfort and security.  In the distance, the children can be heard screaming
+through the corridors.  King Kayos, silver-haired but amazingly youthful under
+a tanned and leathery face, motions for one of his aides to shut the partially
+closed door.  He is in the middle of an emergency meeting of the Aquilaean
+High Senate.  The twelve men sit in overstuffed chairs, placed in a large
+circle.  A large, sallow-eyed Galactic trader named Aay Zavos fiddles
+nervously with a small scrap of leather as he speaks.</setting>
+         <sp spk="ZAVOS">
+
+My Lord, the chrome companies are with you in spirit, but you must understand,
+they can't openly support you.  Imperial trade restrictions are very
+unfavorable, and we, of course, favor your independence.</sp>
+         <sp spk="KAYOS">
+
+If there were to be war, would your frigates still supply us?</sp>
+         <sp spk="ZAVOS">
+
+Your bluntness is to be commended.  It could be arranged.</sp>
+         <sd>Count Sandage, a corrupt noble of the Senate, jumps to his feet in a rage.</sd>
+         <sp spk="SANDAGE">
+
+This is nonsense!  We have no choice but to approve the Treaty.  If there is
+war, the Empire will destroy our entire System with a snap of the finger.
+General Skywalker is a dreamer if he thinks he can mount any meaningful
+resistance....And you're dreamers if you believe him.  So much trust in one
+aged man.  You must see...</sp>
+         <sd>At that moment, all heads turn as someone enters the room.  It is General Luke
+Skywalker, Commander of the Aquilaean Starforce.  He is a large man,
+apparently in his early sixties, but actually much older.  Everyone senses the
+aura of power that radiates from this great warrior.  Here is a leader:  a
+Jedi general.  He looks weary, but is still a magnificent-looking warrior.
+His face, cracked and weathered by exotic climates, is set off by a close
+silver beard, and dark, penetrating eyes.  Sandage is somewhat embarrassed and
+quietly sits down.</sd>
+         <sp spk="GENERAL">
+
+Is there anyone here so naive he believes the Empire would even bother
+negotiating if they were contemplating destruction of this System?  Your
+Excellencies, this is more than a simple raid on your resources.  You must
+reach a decision.</sp>
+         <sd>Mir Nash, a thin, birdlike senator, turns to the general.</sd>
+         <sp spk="NASH">
+
+General Skywalker, war is a serious business...a deadly business.</sp>
+         <sp spk="GENERAL">
+
+Procrastination is a deadly business, Senator.  War is my business.  Have you
+approved my defense measures?</sp>
+         <sd>The Grande Mouff Tarkin wears the long, black robes of the Aquilaean religion.</sd>
+         <sd>He speaks with a high, cracking voice.</sd>
+         <sp spk="TARKIN">
+
+An actual war with the Empire is still only a remote possibility.  As a
+military treatise, your proposal has certain merits, but in the harsh light of
+reality, an attack against the Empire appears to be a somewhat extreme
+defense.</sp>
+         <sp spk="NASH">
+
+You must understand, General, we are interested in avoiding a war, not
+starting one.</sp>
+         <sp spk="GENERAL">
+
+There are times when offense makes the best defense.  If that Alliance Treaty
+isn't signed, we will need all of the advantage we can get.</sp>
+         <sp spk="KAYOS">
+
+Count Sandage, I want you to head the delegation to Alderaan.  You will leave
+tomorrow with our answer regarding the Treaty.  My decision will be
+forthcoming.</sp>
+         <sd>The senators whisper among themselves.</sd>
+         <sp spk="KAYOS (con't)">
+
+All right, then.  May the force of others be with you all.</sp>
+         <sd>The senators leave in a flurry of hushed conversation.  The general is lost in
+thought, and remains in his chair.  Biggs and Windom (Windy), the king's two
+young sons, storm through the existing senators and rush on to Kayos' lap.
+The king is obviously very proud of the two young princes.  He throws Biggs
+into the air, and then catches him again.</sd>
+         <sp spk="WINDY">
+
+Me too!  Me too!</sp>
+         <sp spk="BIGGS">
+
+Leia's leaving!  Leia's leaving and you gotta say good-bye.</sp>
+         <sd>The king picks up Windy and swings him around, then puts him down.</sd>
+         <sp spk="KAYOS">
+
+Okay, whippersnapper, go tell your mother and your sister that I'm on my way.</sp>
+         <sd>The two boys run out of the room and are heard yelling and screaming down the
+hallway.  The king starts out, but stops in front of the general.</sd>
+         <sp spk="KAYOS">
+
+Luke, my daughter is leaving for the academy at Chathos.  Won't you come and
+wish her well?  It would mean a lot to her.  She truly idolizes you, you know.</sp>
+         <sd>Come on, the war will wait.</sd>
+         <sp spk="GENERAL">
+
+Of course.  I'm sorry, My Lord.  Politics always seem to distress me.</sp>
+         <sd>The general rises, and as they head for the door, Kayos pats him on the back.</sd>
+         <sp spk="KAYOS">
+
+I know, Luke.  I feel the Force also.</sp>
+      </scene>
+      <scene n="15">
+         <setting>  COURTYARD - PALACE OF LITE - AQUILAE</setting>
+         <sd>A large, four-seat speeder sits gleaming in the sun-soaked courtyard.  The
+Princess Leia, about fourteen years old, possessing a soft beauty and iron
+will, is embracing her mother, Queen Breha, a warm, silver-haired matron.
+There are tears in the princess' blue eyes.  Biggs and Windy jump around
+inside the speeder, disrupting the efforts of the one-armed Amber to pack
+several plaxiform cases.</sd>
+         <sd>Leia embraces the king as he approaches with the general.</sd>
+         <sp spk="LEIA">
+
+Oh, Daddy, I'll miss you so.</sp>
+         <sp spk="KAYOS">
+
+The semester will be over before you know it.  You'll have a grand time.
+There are so many new things to learn.  I wish I were going.</sp>
+         <sd>He gives her a fatherly smile, and she hugs him again.  The general stands
+rather formally to one side.  The princess, her long auburn hair tied in
+braids, moves to the general and he bows before her.</sd>
+         <sp spk="GENERAL">
+
+May your studies do you honor.</sp>
+         <sd>Leia is somewhat embarrassed by the general's formality and can only manage an
+awkward smile before returning to her parents at the speeder.</sd>
+         <sp spk="BREHA">
+
+Hurry Leia.  You must make it to Yuell before nightfall.</sp>
+         <sd>The princess' maids-in-waiting, Alana, a short, stocky girl, and Mina, more
+comely (somewhat the same stature as Leia) with long dark hair, giggle and
+straighten Leia's dress before she enters the speeder.  The princess and Mina
+hug Alana, whose giggles have turned to tears.  The two boys scramble out of
+the speeder as Amber helps the princess and her maid into the back seat.  The
+speeder is piloted by a trooper of the First Order.  Amber jumps into the seat
+beside him, and the speeder starts with a low buzzing sound.  The princess
+waves to her family, and Mina waves to Alana as the speeder slowly glides out
+of the courtyard.</sd>
+      </scene>
+      <scene n="16">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The war room is a mass of glass enclosures, electronic wall displays,
+monitors, and computer stations.  General Skywalker enters a control station,
+followed by a covey of military aides of various ranks.  As the group hurry
+through the crowded room, men rise and salute the new arrivals.  The general
+stops before a giant display of the galaxy.  Small symbols flash on and off
+over various portions of the big board.  The general studies it intently.</sd>
+         <sp spk="GENERAL">
+
+Montross!</sp>
+         <sd>Captain Montross, one of the general's aides, snaps to attention.</sd>
+         <sp spk="MONTROSS">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+What's the TQ on this?</sp>
+         <sp spk="MONTROSS">
+
+The last frigate to leave the Imperial capital was at twenty-three forty, Sir.</sp>
+         <sp spk="GENERAL">
+
+Have any ships at all left the planet?  <sd>to another aide</sd>  Check with the
+Guild on Horton three.</sp>
+         <sp spk="MONTROSS">
+
+At twenty four hundred, a full battalion of stardestroyers left for what is
+projected to be Anchorhead, or a nearby System.</sp>
+         <sp spk="GENERAL">
+
+And no word from Whitsun.  He should have reported by now.  Captain Prue!</sp>
+         <sd>An older, academic looking aide, steps forward.</sd>
+         <sp spk="PRUE">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+What do you make of this?</sp>
+         <sp spk="PRUE">
+
+A battalion is invasion force...but the Empire controls that entire part of
+the galaxy....A revolution, maybe.  At any rate, they're going in the wrong
+direction to be any trouble for us.</sp>
+         <sd>The general ponders this for a few moments, then speaks almost to himself.</sd>
+         <sp spk="GENERAL">
+
+I don't know... It doesn't feel good.</sp>
+         <sp spk="MONTROSS">
+
+Sir?</sp>
+         <sp spk="GENERAL">
+
+Put 'em on alert.</sp>
+         <sd>A loud uproar is heard on the far side of the war room.  Everyone turns to see
+a foreign dressed warrior pushing his way past several guards and war-room
+bureaucrats.  The warrior, with his long hair tied in an odd bun on the top of
+his head, is Kane Starkiller.  He is followed by his son, Annikin, who rudely
+pushes the pesky bureaucrats out of the way.</sd>
+         <sp spk="BUREAUCRATS">
+
+It's restricted.  You'll have to wait...<sd>etc.</sd>
+         </sp>
+         <sp spk="KANE">
+
+Get out of my way, boy, before I grind you into the surface...<sd>etc.</sd>
+         </sp>
+         <sd>As the dauntless Starkiller approaches the general, the guards stop in
+bewilderment as General Skywalker rushes up to the warrior and embraces him.
+The two Jedi warriors laugh jubilantly and slap one another, as the aides and
+bureaucrats look on in amazement.</sd>
+         <sp spk="GENERAL">
+
+Kane Starkiller - you old muscle-rat!  What a sight!  We heard that you had
+been executed.</sp>
+         <sp spk="KANE">
+
+So the Empire would like to believe.  I've been in the Kessil System.  You
+remember little Annikin.</sp>
+         <sd>Kane puts his arms around his son, who has been making eyes at one of the cute
+young female aides.  He bows before the General.</sd>
+         <sp spk="GENERAL">
+
+He takes after his mother!  <sd>They laugh</sd>  It's so good to see you.</sp>
+         <sp spk="KANE">
+
+It's wonderful to be with another Jedi again.  There are so few of us left.</sp>
+         <sd>The cute aide goes back to her duties, flirting with Annikin as she passes.
+The young warrior pinches her on the ass, which startles her, but she goes on
+like nothing happened.</sd>
+         <sp spk="GENERAL">
+
+What a sight!</sp>
+         <sd>The two Jedi stand looking at one another, hardly believing the other is real.</sd>
+         <sd>Finally, the general realizes his aides are standing around, gawking at the
+duo.</sd>
+         <sp spk="GENERAL (to the aids)">
+
+Wake up, gentlemen.  You're on alert.  Keep me posted on that battalion.</sp>
+      </scene>
+      <scene n="17">
+         <setting>  CONTROL STATION - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general, Starkiller, and his son enter a small glass enclosed control
+office.  They sit, and an awkward silence passes as each man waits for the
+other to speak.</sd>
+         <sp spk="KANE">
+
+I've come for your help.</sp>
+         <sp spk="GENERAL">
+
+Anything you ask.  You're a Jedi brother.  We're one.</sp>
+         <sp spk="KANE">
+
+My friend, we've been through much together...I've been through much since we
+parted.  I've lost much... The Empire has chased us half way across the
+galaxy... There is no refuge.  One day they will come here... Take my son as
+your Padawan Learner.  He would be a Jedi.  I've trained him from birth.  He's
+reached the fifth stage.  He fought in the Kessilian civil wars and commanded
+a Hubble expedition to the Cone Systems.  He's a good boy, Luke, and one hell
+of a fighter.</sp>
+         <sd>The general looks down, somewhat embarrassed.  He scratches his head, then
+smiles.</sd>
+         <sp spk="GENERAL">
+
+Old friend, you do me too much honor.  I was never a match for you.  Why don't
+you finish his training yourself?</sp>
+         <sp spk="KANE">
+
+I'm too old, Luke.  I can't go on... You must finish it.</sp>
+         <sp spk="GENERAL">
+
+What kind of talk is this?  You're not the old Starkiller I remember.  Too
+old?!?</sp>
+         <sd>Starkiller suddenly ignites in a rage and swings his left forearm down with a
+mighty blow across the solid chrome desk the general is sitting on.  The old
+Jedi warrior's forearm cracks in two, spewing forth wires, and many fine
+multicolored electronic components.  The artificial limb flops lifelessly to
+Starkiller's side.  The warrior rips open his tunic, revealing a plastic chest
+stuffed with flashing electric parts.</sd>
+         <sp spk="KANE (angrily)">
+
+I'm not the same.  There is nothing left but my head and right arm... I've
+lost too much, Luke...I'm dying.</sp>
+         <sd>The general bows his head in sorrow for one of the greatest warriors in the
+galaxy and a dear friend.</sd>
+         <sp spk="GENERAL">
+
+I'm sorry...</sp>
+         <sp spk="KANE">
+
+I'm sorry.  I keep losing control.  I'm very tired...Take my son!  The Jedi-
+Bendu must survive.  We must pass it on.  Only a Jedi can stop the Empire.
+We're very old, Luke.  A new generation of Jedi must be started.  Take him;
+teach him the way of the Jedi-Bendu...</sp>
+         <sd>Captain Montross bursts into the office and somewhat excitedly salutes the
+general.</sd>
+         <sp spk="MONTROSS">
+
+Sir, we have picked up something!  An asteroid, or solid comet moving away
+from the Anchorhead System.</sp>
+      </scene>
+      <scene n="18">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general rushes out of the control station and back to the giant Galactic
+display.  He is followed by Montross, Starkiller and his son.</sd>
+         <sp spk="GENERAL">
+
+Are you sure it's not the battalion?</sp>
+         <sp spk="MONTROSS">
+
+A solid object.  It's as big as our Third Moon.</sp>
+         <sp spk="PRUE">
+
+It's too large to be man-made, and it's too slow to be a comet.</sp>
+         <sp spk="GENERAL">
+
+Analysis?</sp>
+         <sp spk="MONTROSS">
+
+It's too far out.</sp>
+         <sp spk="GENERAL">
+
+I'll be with the king.  Report as soon as you can get a reading on it.
+<sd>turning to Kane's son</sd>  Captain Starkiller, from now on you stick close to
+me.</sp>
+         <sd>The older Starkiller smiles, and puts his good arm around his old friend.</sd>
+      </scene>
+      <scene n="19">
+         <setting>  DINING CHAMBER - PALACE OF LITE - AQUILAE</setting>
+         <sd>King Kayos moves his arm around Breha's waist as they stand on a balcony
+watching the giant twin suns of Aquilae disappear behind a distant dune range.</sd>
+         <sd>The general enters, rather in a rush, followed by the young Starkiller, who is
+now dressed in the white uniform of the Aquilaean starforce.  (He still wears
+the distinctive Kessilian hair knot.)  They bow before the king.</sd>
+         <sp spk="KAYOS (pointing to the suns)">
+
+Aren't they beautiful, General?  "Always and never the same."  You're just in
+time for dinner.</sp>
+         <sp spk="GENERAL">
+
+I have come for other reasons.  Could....</sp>
+         <sp spk="KAYOS">
+
+Relax, General.  We will discuss it, but over dinner.  There are times, Luke,
+when I find you a bit too rigid.  Is this your new disciple?</sp>
+         <sd>Starkiller is ill at ease and bows again.</sd>
+         <sp spk="STARKILLER">
+
+Annikin Starkiller, Sir.</sp>
+         <sp spk="KAYOS">
+
+Where's Kane?</sp>
+         <sp spk="GENERAL">
+
+He left for the spaceport at Gordon to visit an old friend, Han Solo, the
+Ureallian.</sp>
+         <sp spk="KAYOS">
+
+We are becoming quite a refuge.</sp>
+         <sd>The group sits at a large table, and food is brought in by servants.  They
+eat.  Starkiller is nervous and watches the general, to make sure he is being
+proper.</sd>
+         <sp spk="GENERAL">
+
+My Lord, several events have occurred which lead me to believe we are in
+imminent danger of attack.  There is no longer time for discussion and
+debate...</sp>
+         <sp spk="KAYOS">
+
+What events?</sp>
+         <sp spk="GENERAL">
+
+Whitsun, our best agent, has disappeared in the Imperial capital.  There is
+unusual military traffic in the S-4 sectors...</sp>
+         <sp spk="KAYOS">
+
+Unless you have direct, concrete proof of a pending attack, there is nothing I
+can do.</sp>
+         <sp spk="GENERAL">
+
+By the time we have proof, it may be too late.</sp>
+         <sp spk="KAYOS">
+
+Luke, I'm leaving tonight for Amsel.  I'm meeting with the full assembly first
+thing in the morning.  I am not going to approve the Alliance Treaty, and I
+will get your defense measure approved.  Just be patient.  You will have the
+war code.</sp>
+         <sp spk="GENERAL">
+
+Tomorrow may be too late.  My Lord, I need the war code now.  We must get our
+forces into space.</sp>
+         <sp spk="KAYOS">
+
+But it must be done legally, with everyone's approval.  Tomorrow you will have
+that.  I doubt the Empire would attack before receiving our answer.  The
+separation of war powers is the one condition upon which you assumed command
+of our forces.  You're a friend, Luke, and  I trust you.  But you're also an
+outlander who controls a great deal of power.  I can't forsake my oath any
+more than you can.  Just be patient.  You will have the code tomorrow.</sp>
+         <sd>Captain Montross enters the large chamber and bows before the king.</sd>
+         <sp spk="MONTROSS">
+
+I bring a report to General Skywalker, My Lord.</sp>
+         <sp spk="KAYOS">
+
+You may deliver it.</sp>
+         <sp spk="MONTROSS">
+
+Sir, the asteroid has disappeared from our scopes.  There is no trace of it.</sp>
+         <sp spk="GENERAL">
+
+Were they able to analyze it?</sp>
+         <sp spk="MONTROSS">
+
+It never came within range, Sir.</sp>
+         <sd>The general rises, quickly followed by Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Excuse us, My Lord.  We'd better get back.  I will wait patiently for the
+approval.</sp>
+         <sd>The general and Montross exit the chamber.  Starkiller takes one last bite of
+his dinner, then dashes after his mentor.</sd>
+      </scene>
+      <scene n="20">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general sits rigidly, facing the big Galactic display board.  Several
+aides and bureaucrats rush to and fro, ignoring the general.  he is asleep.
+Captain Prue approaches the general and snaps to attention.  The general's
+eyes open.</sd>
+         <sp spk="GENERAL">
+
+What are the results?</sp>
+         <sp spk="PRUE">
+
+Negative, Sir.</sp>
+         <sp spk="GENERAL">
+
+Are you sure?</sp>
+         <sp spk="PRUE">
+
+Absolutely.</sp>
+         <sp spk="GENERAL">
+
+It's just not possible.  Something that size can't just disappear without a
+trace...Check it again.</sp>
+         <sp spk="PRUE">
+
+That's the tenth negative, Sir.</sp>
+         <sp spk="GENERAL">
+
+I said check it again.</sp>
+         <sd>Captain Prue retreats to a computer station.  The general looks around for
+Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Starkiller!</sp>
+         <sd>Everyone near the general turns, but Starkiller doesn't show.</sd>
+         <sp spk="GENERAL">
+
+Where is that boy?  Montross!</sp>
+         <sd>Montross rushes to the general and snaps to attention.</sd>
+         <sp spk="GENERAL">
+
+Page Starkiller.</sp>
+         <sd>Montross goes back to his station and a few moments later, Starkiller is paged
+over the P.A. system.  The general waits, watching the big board.  Eventually,
+Starkiller stumbles out of an enclosed computer closet, fastening his pants
+and tucking in his tunic.  A moment later, the cute female aide rather
+sheepishly exits the computer closet.  She is also in the process of putting
+her uniform back together.  Starkiller rushes up to the general and snaps to
+attention.</sd>
+         <sd>The general lets him stand there for a moment, not acknowledging his presence;
+then, suddenly, without warning and in one masterful flash motion, the general
+stands, grabs a small baton attached to his belt (which immediately ignites
+into a four-foot glowing lasersword,) and swings at the young warrior's head.
+In an equally quick movement, Starkiller ignites his lasersword and blocks the
+general's blow.  Everyone in the war room is surprised and startled.  After a
+moment, they rush to the general.  Starkiller and the general stand motionless
+for a few moments, with laserswords locked in mid-air, creating a low buzzing
+sound.  Finally, the general grins, and Starkiller hesitantly relaxes.  They
+lower their swords and turn them off.</sd>
+         <sp spk="GENERAL">
+
+You are trained well, but remember, a Jedi must be single-minded, a discipline
+your father obviously never learned, hence your existence.  Clean yourself up.</sp>
+         <sd>Discipline is essential.  Your mind must follow the way of the Bendu.</sd>
+         <sp spk="STARKILLER">
+
+It won't happen again, Sir.  There are many new....</sp>
+         <sd>P.A.
+General Skywalker, white com.</sd>
+         <sd>The general moves to a control station and picks up a phone.</sd>
+         <sp spk="PHONE VOICE">
+
+Sir, Captain Whitsun has just been admitted to Med Vac.</sp>
+         <sp spk="GENERAL">
+
+What's his condition?</sp>
+         <sp spk="PHONE VOICE">
+
+No data, Sir.</sp>
+         <sp spk="GENERAL">
+
+I'm on my way.</sp>
+      </scene>
+      <scene n="21">
+         <setting>  MED VAC EMERGENCY ROOM - UNDERGROUND FORTRESS</setting>
+         <sd>Captain Starkiller waits in an outer chamber as General Skywalker rushes into
+the Med Vac emergency room where several doctors are working on the prostrate
+Whitsun.</sd>
+         <sp spk="GENERAL">
+
+What's his condition?  Is he conscious?</sp>
+         <sp spk="DOCTOR">
+
+Partially.  He's be all right - a few bruises, primary exhaustion....</sp>
+         <sd>Whitsun thrashes around in a semi-conscious state.  He sees the general.</sd>
+         <sp spk="GENERAL">
+
+What happened, boy?  What's going on?</sp>
+         <sp spk="WHITSUN (with difficulty)">
+
+The Imperial Starforce is already on its way, not far behind me... They're
+going to attack.</sp>
+         <sp spk="GENERAL">
+
+Are you sure?</sp>
+         <sp spk="WHITSUN">
+
+I have tapes...A giant space fortress....</sp>
+         <sd>He struggles to give General Skywalker his ring.</sd>
+         <sp spk="GENERAL">
+
+As big as our Third Moon?</sp>
+         <sp spk="WHITSUN">
+
+Bigger.  It's unlike anything I've ever seen.  Sophisticated deflection
+systems.... work in opposition to the suns.</sp>
+         <sp spk="GENERAL">
+
+They will show up on our screens at sunrise.  They'll attack before that.</sp>
+         <sd>The general rushes into the outer chamber where Captain Starkiller is waiting
+for him.</sd>
+         <sp spk="GENERAL">
+
+Take the fastest landspeeder to Chathos.  Pick up Princess Leia... and only
+Princess Leia.  Return by way of the Great Reef.  Most speed.</sp>
+         <sd>Starkiller exits and the general goes to an intercom and pushes several
+buttons.</sd>
+         <sp spk="GENERAL">
+
+Montross.</sp>
+         <sp spk="MONTROSS">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+Full alert....everything!  Get the Royal Family back here.</sp>
+         <sp spk="MONTROSS">
+
+The princess is at Chathos.  There are no transports....</sp>
+         <sp spk="GENERAL">
+
+I've already sent Captain Starkiller for her!  Contact the king, first
+priority.  He's probably still en route to Amsel.  Use the scan com.  I'm on
+my way.</sp>
+      </scene>
+      <scene n="22">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The war room is on full alert.  Everyone is at attention, waiting for the
+command that will put them into action.  The general enters a communication
+center, followed by many aides.  Captain Montross and the com aide salute.</sd>
+         <sp spk="MONTROSS">
+
+We're having a problem getting through, Sir.  There is a great deal of
+interference.</sp>
+         <sp spk="PRUE">
+
+It could be jamming.</sp>
+         <sp spk="GENERAL">
+
+Try a surface link through Amsel.</sp>
+         <sd>The aides go back to the com-link system to try to get a line through to the
+king.</sd>
+         <sp spk="PRUE">
+
+We should be able to spot them at sunrise....That's not too far off.</sp>
+         <sp spk="GENERAL">
+
+They'll attack with sunrise.  Until the king gives us that code to start the
+war computers, we'll just have to sit tight.</sp>
+         <sp spk="PRUE">
+
+All units are on alert, Sir.</sp>
+         <sp spk="GENERAL (to Montross)">
+
+Have you made contact yet?  <sd>to himself</sd>  This is one hell of a way to run a
+war.</sp>
+         <sp spk="PRUE">
+
+Sir?</sp>
+      </scene>
+      <scene n="23">
+         <setting>  COURTYARD - ACADEMY OF CHATHOS - AQUILAE</setting>
+         <sd>A landspeeder roars into a courtyard of the Academy at Chathos.  Starkiller
+jumps out, and runs up to the large, heavy doors of the academy.  They are
+locked.  He bangs madly on the carved metallic door, until finally an old
+woman manages to swing it open.  Starkiller rushes past her into the main
+courtyard where Princess Leia and her hand-maiden, Mina, struggle with two
+large cases.  They are followed by two very old matrons, dragging several more
+cases.</sd>
+         <sp spk="STARKILLER">
+
+Forget the cases - we've no time.</sp>
+         <sp spk="LEIA">
+
+These are my things.  They must...</sp>
+         <sp spk="STARKILLER">
+
+I said forget them, and hurry...</sp>
+         <sp spk="LEIA">
+
+Just who do you think you are?</sp>
+         <sd>Starkiller grabs the princess by the arm, and hauls her to the speeder.  Mina
+and the old women run after them.</sd>
+         <sp spk="LEIA">
+
+I will not be treated like this!   You bring my things.... My father will have
+your head... <sd>etc.</sd>
+         </sp>
+         <sd>Leia struggles to break away from the young warrior's grasp as he opens the
+door of the speeder.</sd>
+         <sp spk="STARKILLER">
+
+Settle down!</sp>
+         <sd>When the door to the speeder is opened, Mina starts in, and Starkiller stops
+her.</sd>
+         <sp spk="STARKILLER">
+
+You must stay.  Here, take the Crest.</sp>
+         <sd>Starkiller rips the royal crest from the princess' neck, and hands it to the
+startled handmaiden.  The old women gasp in horror.  The princess starts
+hitting Starkiller with little result.</sd>
+         <sp spk="PRINCESS">
+
+Mina's not staying...I'm not leaving her.  You can't....</sp>
+         <sd>Starkiller punches her square on the jaw and knocks her cold.  Mina is panic
+stricken, one of the old women faints, and another starts for Starkiller with
+a large staff.</sd>
+         <sp spk="STARKILLER">
+
+She'll be all right.  I'm taking her to safety...as ordered.  You will wear
+the crest and continue as before.</sp>
+         <sd>The authority of Starkiller's voice stops the old lady.  He places the
+princess into the speeder, and maneuvers it out of the courtyard.  Mina puts
+on the crest as the speeder races away from the academy.</sd>
+      </scene>
+      <scene n="24">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>Queen Breha, Biggs and Windy are escorted into a rest area of the war room.
+General Skywalker sits rigidly in a chair in the communications area,
+apparently asleep.</sd>
+         <sp spk="MONTROSS">
+
+Sir, we've made contact!</sp>
+         <sd>The general opens his eyes and takes the intercom mike.</sd>
+         <sp spk="KAYOS">
+
+What is it, General?</sp>
+         <sp spk="GENERAL">
+
+The Empire will attack on the rising of the sun.  My agent made it back.  I
+now have proof.  I need the war code...</sp>
+         <sp spk="KAYOS">
+
+I'll relay it directly to the computer.  Is Breha...?</sp>
+         <sp spk="GENERAL">
+
+The Royal Family is safe.  Starkiller has gone after Princess Leia...</sp>
+         <sp spk="KAYOS">
+
+I'm on my way back.</sp>
+      </scene>
+      <scene n="25">
+         <setting>  RED PLAINS - AQUILAE</setting>
+         <sd>The small caravan of four speeders sits motionless on the vast red plains of
+Aquilae.  The king returns the intercom to the pilot and takes a small
+metallic card from around his neck and gives it to the co-pilot.</sd>
+         <sp spk="KAYOS">
+
+Send this sub-land, priority one.  <sd>to the pilot</sd>  Get us back to Calvas
+immediately!</sp>
+         <sd>The four speeders turn around and scream away in the direction they had come.
+They pass a huge ultrasleek powerplow, planting green fungus in endless
+furrows.  Two clay-covered farmers, riding atop the ponderous machine, watch
+the speeders disappear over the horizon, and into the rising twin suns.  A
+bright object, twinkling in early morning heavens, catches the eye of the
+older of the two farmers, and he brings the machine to a lumbering halt.  The
+younger farmer also notices the object, and stares skyward, shading his eyes
+to get a better view.</sd>
+         <sd>Suddenly there is a huge, bright atomic flash on the horizon.  A few moments
+later, a thunderous shaking, followed by high winds, tumbles the older farmer
+from his perch.  A second flash on the opposite horizon brings another jolting
+earthquake, and the younger farmer collapses, terror frozen on his face.</sd>
+      </scene>
+      <scene n="26">
+         <setting>  READYROOM - SPACEPORT OUTPOST - AQUILAE</setting>
+         <sd>Chaos.  Red scramble lights are flashing.  Alert horns and attack buzzers
+create an unbelievable cacophony.  Air warriors, with the distinctive circle
+and cross medallion on their white space suits, scramble out of the low,
+concrete readyroom, grabbing helmets and spacepacks as they race out of the
+door.</sd>
+      </scene>
+      <scene n="27">
+         <setting>  ATTACK RUNWAY - SPACEPORT OUTPOST - AQUILAE</setting>
+         <sd>Twelve pilots and navigators dash in unison to a line of waiting two-man
+starships of the destroyer class.  Ground crews scurry back and forth, loading
+last-minute armament, and unlocking power couplings.  Pilot Leader, a rugged,
+handsome boy of twenty, gives his ground crew a signal that his is okay.  He
+has a winning smile and a distinctive scar along the side of his face.  His
+crew chief pats him on the back.</sd>
+         <sp spk="CHIEF">
+
+Knock them all the way back to Alderaan.</sp>
+         <sd>The canopy is closed and the powerful starship moves onto the runway.  Other
+crewmen say good-bye to their pilots, some grin, some kidding - all with a
+great deal of hidden emotion.  The din of two dozen retrorockets cuts through
+the uproar, and six silver spacecraft leave the runway, and disappear into the
+morning cloud cover.</sd>
+      </scene>
+      <scene n="28">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general stands before a giant display of the Aquilaean solar system.
+Montross signals the general.</sd>
+         <sp spk="MONTROSS">
+
+They're away, Sir.  Six from Gordon.  All other spaceports were hit.  The king
+hasn't arrived yet.</sp>
+         <sp spk="GENERAL">
+
+Keep checking.  Put those fighters' intercom over the P.A.</sp>
+         <sd>The general sits at one of the intercom panels, and puts on a headphone.  A
+row of monitors is before him.  He turns to Montross.</sd>
+         <sp spk="GENERAL">
+
+Where are they?</sp>
+      </scene>
+      <scene n="29">
+         <setting>  SPACE - AQUILAE IN ECLIPSE</setting>
+         <sd>The eerie, reddish-yellow planet of Aquilae slowly drifts into view from total
+eclipse.  A small, bright speck, orbiting the planet, sparkles in the light of
+the twin suns.  The six deadly Aquilaean starships settle ominously into the
+foreground, moving swiftly toward the orbiting speck.  As the sleek starships
+move closer, the orbiting speck is revealed to be a gargantuan space fortress.</sd>
+         <sd>The moon-sized satellite fortress dwarfs the approaching fighters.  Every few
+moments, explosions create blinding flash on the planet's surface, as the
+fortress bombards the planet with a fusillade of laser bolts.</sd>
+      </scene>
+      <scene n="30">
+         <setting>  AQUILAEAN STARSHIP - INTERIOR</setting>
+         <sd>Pilot Leader, in the first ship, signals to his navigator who sits in a small,
+isolated glass bubble to the rear of the craft.  General Skywalker is seen on
+one of many monitors.  A view of the space fortress is on another.  The rest
+are filled with various computer readouts and displays.  One of the other
+starships reports to Pilot Leader.</sd>
+         <sp spk="DEVIL SIX (intercom)">
+
+Look at the size of that thing!  Hey, Bowman, I hope you remembered to bring
+your pop gun, 'cause I think we caught us a big one this time....</sp>
+         <sp spk="PILOT LEADER">
+
+Cut off, Devil Six....Stand by.</sp>
+         <sp spk="GENERAL (monitor)">
+
+It looks like they're still using the basic quad-tristation configuration.
+Use a "ranger defense."  Concentrate on breath ports and lock areas.</sp>
+         <sp spk="PILOT LEADER">
+
+Affirmative base...Copy and transmit....Devil Two, check your rotation plates.</sp>
+         <sp spk="DEVIL TWO">
+
+Roger, Boss.  We're getting a threshold disturbance on gyro-three.</sp>
+         <sp spk="GENERAL (monitor)">
+
+Switch over, Five, cover it! ...Devil pack, generate a spread six
+formation...May the force of others protect you.</sp>
+         <sp spk="PILOT">
+
+Settle in...Devil pack, stand by.  Mark five...break off.  Here we go.  God
+save us all.</sp>
+      </scene>
+      <scene n="31">
+         <setting>  SPACE - AQUILAEAN STARSHIP</setting>
+         <sd>Fuel pods are jettisoned.  The half-dozen fighters break off into a powerline
+attack on the huge fortress.  Multiple laserbolts streak from the starships,
+creating small explosions on the complex surface of the fort.</sd>
+      </scene>
+      <scene n="32">
+         <setting>  INTERIOR MAIN CORRIDOR - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The chaos of battle echoes through the vast corridors of the fortress.  Walls
+buckle and cave in, sucking debris and personnel into the vacuum of outer
+space.  Alarm sirens scream as soldiers scramble to large turbo-powered laser
+gun emplacements.  Sergeants yell orders through the smoke and confusion.  Men
+and robots of various shapes and sizes run to their battle stations.</sd>
+      </scene>
+      <scene n="33">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The monitors with pictures from the starships suddenly go blank.  Technicians
+check channels as others in the war room silently listen to the action over
+the intercom.  The general remains calm, but concerned.</sd>
+         <sp spk="PILOT LEADER (intercom)">
+
+Tighten it up... Devil Two, tighten it up.  Watch those towers....</sp>
+         <sp spk="DEVIL TWO (CHEWIE)">
+
+Heavy fire, Boss.  Twenty-three degrees.</sp>
+         <sp spk="PILOT LEADER">
+
+I see it.  Pull in... we're picking up some interference.</sp>
+         <sp spk="DEVIL SIX">
+
+Wow, I've never seen such fire power.</sp>
+         <sp spk="PILOT LEADER">
+
+Pull in, Devil Two...Pull in!  Chewie???!!</sp>
+         <sp spk="DEVIL TWO (CHEWIE)">
+
+I'm all right, Boss.  I've got a target.</sp>
+         <sp spk="DEVIL SIX">
+
+There is too much action, Chewie.  Get out!</sp>
+         <sp spk="PILOT LEADER">
+
+Break off, Chewie....Acknowledge.  Devil Six, can you see Devil Two?</sp>
+         <sp spk="DEVIL SIX">
+
+I've lost him.  There's a very heavy fire zone on this side.  My radar's
+jammed.</sp>
+         <sp spk="DEVIL FIVE">
+
+He's gone....no, wait.  There he is...Fin damage, but he's all right.</sp>
+         <sd>A sigh of relief sweeps across the war room.  The monitors flash on, then off
+again.</sd>
+         <sp spk="DEVIL FOUR (intercom)">
+
+Watch your back, Boss!  Watch your back!!</sp>
+      </scene>
+      <scene n="34">
+         <setting>  AQUILAEAN STARSHIP</setting>
+         <sd>The speedy little fighters dart back and forth across the soft underbelly of
+the fortress, leaving a trail of destruction behind them.</sd>
+         <sp spk="PILOT LEADER">
+
+Converge on south axis point, point three nine four.  It appears accessible.
+I'm going to map the surface.  Devil Four, cover me!</sp>
+         <sd>Pilot Leader and Devil Four dive in unison through a forest of radar domes,
+antennae, and gun towers.  Devil Four fires into the protrusions as the two
+starships criss-cross the surface of the fortress.  Suddenly, a dense barrage
+of laserfire erupts from a tower, catching Devil Four broadside.  The
+spacecraft bursts into a million flaming pieces.  Pilot Leader reacts to the
+loss of his wing man, but continues on his mission.</sd>
+      </scene>
+      <scene n="35">
+         <setting>  SUB-HALLWAY - IMPERIAL SPACE FORTRESS</setting>
+         <sd>Constant explosions rock the interior of the fortress.  Civilians, including
+women and children, scurry for safety in the panic-ridden hallways.  Two
+construction robots, Artwo Detwo (R2D2) and See Threepio (C3P0), are blown,
+slipping and sliding across the hallway floor into some freight canisters.
+Both robots are rather old and battered.  Artwo is a short, (three feet) claw-
+armed tri-pod.  His face is a mass of computer lights, surrounding a radar
+eye.  Threepio is a tall, gleaming android of human proportions.  He is thin,
+with a totally metallic surface of an Art Deco design.  The robots attempt to
+get out from under the canisters, but rushing gas from a broken pipe keeps
+knocking them over.</sd>
+         <sp spk="THREEPIO">
+
+This is madness; we're going to be destroyed.  I'm still not accustomed to
+space travel.</sp>
+         <sp spk="ARTWO">
+
+The external bombardment does appear to be concentrated in this area.  The
+structure has exceeded the normal stress quotient by point four, although
+there appears to be no immediate danger.</sp>
+         <sp spk="THREEPIO">
+
+No immediate danger!  You're faulty.  This is madness!</sp>
+         <sd>Artwo gives Threepio a sheepish look and clings to a siderail for dear life,
+as debris flies through the hallway.</sd>
+      </scene>
+      <scene n="36">
+         <setting>  AQUILAEAN STARSHIP</setting>
+         <sd>Devil Two (Chewie), a young hotshot of about sixteen years, miraculously dives
+his ship through a virtual wall of laser fire, and blasts a huge radar disc
+into dust.  Chewie signals his navigator, who lets out a whooping cheer, as
+the craft veers into a victory roll.</sd>
+         <sp spk="PILOT LEADER">
+
+Great moves, Chewie.  Regroup at point two, zero one.  Coincide, Devil Six.</sp>
+         <sp spk="GENERAL">
+
+Mace, your map projection shows a weak point at south portal:  niner point
+six.  Concentrate the attack on that point.  Coordinate.</sp>
+         <sp spk="PILOT LEADER">
+
+I see it... It looks good.</sp>
+         <sd>Devil Five and Devil Three bob and weave in formation toward a giant
+transformer jutting from the fort's surface.</sd>
+         <sp spk="DEVIL THREE">
+
+I've got a... We're hit.  We're hit.</sp>
+         <sp spk="PILOT LEADER">
+
+Eject...Eject.  Babs, Babs, do you read?</sp>
+         <sp spk="DEVIL THREE">
+
+I'm okay.  I can hold it.  Clear me a little, Devil Five... Watch it!  Watch
+it!</sp>
+         <sd>Devil Three wobbles a little, then drops away sharply, plowing into a lasergun
+emplacement, causing a hideous series of chain reaction explosions.</sd>
+      </scene>
+      <scene n="37">
+         <setting>  SUB-HALLWAY - IMPERIAL SPACE FORTRESS</setting>
+         <sd>A huge explosion rips a large hole in the ceiling of a subhallway.  Artwo and
+Threepio are in a state of shock as they scramble through the rubble.  There
+is a constant sound of creaking and snapping as the sections of the hallway
+resettle in the fortress superstructure.</sd>
+         <sp spk="ARTWO">
+
+You're a mindless, useless philosopher... Come on!  Let's go back to work; the
+system is all right.</sp>
+         <sp spk="THREEPIO">
+
+You overweight glob of grease.  Quit following me.  Get away.  Get away.</sp>
+         <sd>Suddenly, the hallway lurches, and a dead trooper falls through a gaping hole
+in the ceiling.  The foot of the carcass is caught in the rubble and it hangs
+upside down, staring at the two robots.  Artwo grabs Threepio, and they cling
+to each other in terror.</sd>
+         <sp spk="ARTWO">
+
+We're lost.  We're destroyed.</sp>
+         <sd>Three sharp blasts from an airhorn send the two androids running for cover in
+a burned-out doorway.  Five grim-faced troopers riding small rocket platforms
+pass the two mechanical men.</sd>
+      </scene>
+      <scene n="38">
+         <setting>  GOVERNOR'S QUARTERS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The five troopers race through several hallways, and finally stop in front of
+an important looking office complex.  Two officers dismount and enter the
+complex.  They pass through several heavily guarded doorways until they reach
+the main chamber.  Seated behind a large, cluttered desk surrounded by
+generals and attaches is Governor Hoedaack.  General Vader paces in front of a
+row of blank monitors.  The two officers salute General Vader.</sd>
+         <sp spk="FIRST OFFICER">
+
+All com-link power is out.  Twenty-two transformer sections have been
+destroyed.  The situation is grave on all southern levels.  Com-link
+communication should be repaired shortly.</sp>
+         <sd>The officers salute, turn and leave the chamber.  The general turns to
+Governor Hoedaack, who looks a little worried.</sd>
+         <sp spk="VADER">
+
+Don't look so worried.  Not even a Jedi could penetrate this fortress...We've
+already wiped out most of their forces.</sp>
+         <sp spk="HOEDAACK">
+
+If it goes on too long, we'll run over budget.  When do the landings begin?</sp>
+         <sp spk="VADER">
+
+As soon as the attack has been broken:  not long.</sp>
+         <sd>A short, stocky attache salutes the general.</sd>
+         <sp spk="ATTACHE">
+
+Contamination has set in on quadrants B-5 and R-4.  All sections are sealed.
+We've lost two major power stations in the southern quadrants.  That puts
+section 5-1 in serious trouble.</sp>
+         <sd>The general turns away in controlled anger and embarrassment.</sd>
+      </scene>
+      <scene n="39">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general sits in a glass enclosed computer station, watching the battle
+progress on several monitors.  An officer enters and salutes the general.</sd>
+         <sp spk="OFFICER">
+
+Analysis reports those ZQ configurations are definitely power
+transformers...Everything in the southern sectors of the fortress is out.</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+I'm surprised they are still using external power units.  It's a definite weak
+point.  Concentrate on searching for the main crosslink transformer.</sp>
+         <sd>The officer exits as Montross rushes in.</sd>
+         <sp spk="MONTROSS">
+
+The senate has voted to end the war.</sp>
+         <sp spk="GENERAL">
+
+They can't do anything without the king's approval; which gives us a little
+time...Have you been able to regain contact with the king?</sp>
+         <sp spk="MONTROSS">
+
+No, Sir.  All ground communications are jammed.</sp>
+         <sp spk="GENERAL">
+
+Send four men..from third squad, to meet the king, and escort him back.  Let
+me know before he arrives.  Is Starkiller back with the princess?</sp>
+         <sp spk="MONTROSS">
+
+No, Sir.  They're long overdue.</sp>
+         <sd>Pilot Leader checks in over the intercom.</sd>
+         <sp spk="PILOT LEADER">
+
+All right, base one, we're in position.</sp>
+         <sd>An officer with headphones looks to the general.  He signals to attack.</sd>
+      </scene>
+      <scene n="40">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>All four starships dive in formation toward a main transformer area, flanked
+by several solar towers.</sd>
+         <sp spk="PILOT LEADER">
+
+Hold your fire until we're within point zero five four... Make it count.</sp>
+         <sd>Several ack-ack lasers begin to open fire on the approaching spacecraft.  The
+starships direct their fire at a large black transformer, which when hit,
+spurts bright blue and white electrical arcs.  One of the starships (Devil
+Five) explodes and careens out of formation, leaving an erratic trail of
+smoke, before eventually crashing into a solar panel.</sd>
+      </scene>
+      <scene n="41">
+         <setting>  SUB-HALLWAYS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The impact of the exploding starship can be felt throughout the giant
+fortress.  The tall, gleaming Threepio races through several corridors,
+yelling at Artwo, who struggles vainly to e keep pace with his stubby
+mechanical feet.</sd>
+         <sp spk="THREEPIO">
+
+....I don't care what you do, but I'm getting out.  All the power's out.
+Those explosions are coming from the reactor section.  This is the end.
+Abandon ship.</sp>
+         <sp spk="ARTWO">
+
+Our work - we can't leave!  It's desertion.  It's not possible.  It's not
+possible.</sp>
+         <sp spk="THREEPIO">
+
+Your programming is so limited.  My first order is preservation.  You stay.
+I'm going to eject before the whole thing goes up.</sp>
+         <sd>Threepio breaks open the seal on an emergency lifepod.  A red warning light
+begins to flash, and a low hum is heard.  The lanky chrome android works his
+way into the cramped four-man craft.</sd>
+         <sp spk="ARTWO">
+
+These lifepods aren't for us!  It's not right!</sp>
+         <sd>A new explosion, this time very close, sends dust and debris through the
+narrow passageway.  Flames lick at the two robots.  The runt-sized Artwo jumps
+into the lifepod.</sd>
+         <sp spk="ARTWO">
+
+It's the end.  Eject.  Eject.</sp>
+         <sd>The safety door snaps shut, and the pod ejects from the fortress.</sd>
+      </scene>
+      <scene n="42">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>The terrified androids in the lifepod speed away from the fortress, and pass
+the attacking starships.</sd>
+         <sp spk="DEVIL TWO">
+
+Object approaching.  Attack bearing...</sp>
+         <sp spk="DEVIL FOUR">
+
+It's a lifepod.  Forget it.  We've got...</sp>
+         <sd>Devil Four is hit by laser fire, and disintegrates, leaving a trail of flaming
+particles.  The two remaining craft continue the assault.  Chewie and Pilot
+Leader watch the remains of Devil Four disappear.  The general appears over
+one of the monitors.</sd>
+         <sp spk="GENERAL">
+
+Analysis indicates transformer code zero three is the main relay.  Hit it, and
+the whole thing goes dead.</sp>
+         <sp spk="PILOT LEADER">
+
+We're on our way.</sp>
+      </scene>
+      <scene n="43">
+         <setting>  GOVERNOR'S QUARTERS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>A row of monitors and the main overhead lights go on, and a trooper appears on
+one of the screens.</sd>
+         <sp spk="TROOPER">
+
+Internal relays operative.  All power restored.  All contaminated areas
+sealed.</sp>
+         <sd>An officer appears on another monitor.</sd>
+         <sp spk="OFFICER">
+
+Only two enemy craft remain operative.  We calculate victory by zero three
+hundred.</sp>
+         <sd>General Vader switches to another monitor.</sd>
+         <sp spk="VADER">
+
+Alert the invasion forces.  <sd>turning to the governor</sd>.  The planet is ours.  A
+three hour war.  You expected longer.  Jedi or not, we've beaten him, and the
+culture is intact.</sp>
+         <sp spk="HOEDAACK">
+
+A truly great prize for the Empire.  They have a treasure of biotic science.
+Genetics, cloning - they've added two-hundred years to a lifespan.  Remember,
+you must capture at least one member of the Royal Family alive.  The Aquilae
+family has ruled this system for ten thousand years.  The people will follow
+no other.  If the royal line is broken, there is a good chance the entire
+population will destroy themselves and their knowledge before submitting to
+our rule.</sp>
+         <sd>The general is interrupted by a call on one of the monitors.</sd>
+         <sp spk="OFFICER (on monitor)">
+We've received a message from the planet....</sp>
+      </scene>
+      <scene n="44">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker watches a giant computer display of the space fortress
+mapped by the starships.  An aide approaches.</sd>
+         <sp spk="AIDE">
+
+Sir!  The king's convoy has destroyed at Caldin.  All the bodies were
+contaminated.</sp>
+         <sp spk="GENERAL">
+
+I will audience with the queen.... Who knows of this?</sp>
+         <sp spk="AIDE">
+
+Many.  It came through civilian sources.</sp>
+         <sp spk="GENERAL">
+
+Confine Senator Sandage to his quarters.  Use any pretext.  Where is the
+senator now?</sp>
+         <sd>Sandage and several other senators enter the computer station.</sd>
+         <sp spk="SANDAGE">
+
+Right here, General...It's over.  We've already relayed peace terms to the
+Empire, and they've been accepted.  Your war has ended.</sp>
+         <sd>The general is angry and stands pointing at the senators.  They jump back, as
+if the general were pointing a gun at them.</sd>
+         <sp spk="GENERAL">
+
+Senator, this war isn't over.  It's just begun.  I take my commands from the
+Royal Family.</sp>
+         <sp spk="SANDAGE">
+
+The queen concurs.  I have her written decree.  It is to be implemented
+immediately..... I order you to cease the attack.</sp>
+         <sp spk="GENERAL">
+
+Not likely...</sp>
+         <sp spk="SANDAGE">
+
+Treason?  Revolution?  The people won't follow you, General...nor will your
+troops.  I suggest you follow your orders.</sp>
+         <sd>General Skywalker stands angrily pondering the situation.  Sandage and the
+other senators are tense, a little afraid that he might cut them down on the
+spot.</sd>
+         <sp spk="SANDAGE">
+
+Well, General?</sp>
+      </scene>
+      <scene n="45">
+         <setting>  LIFEPOD - SKY OVER AQUILAE</setting>
+         <sd>The reddish-yellow mass of Aquilae seems to engulf the tiny lifepod containing
+the two fleeing androids.</sd>
+         <sp spk="ARTWO">
+
+It's desertion.  They'll destroy us.  How could this happen?</sp>
+         <sp spk="THREEPIO">
+
+That's funny.  The damage doesn't look as bad from out here.</sp>
+      </scene>
+      <scene n="46">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>Pilot Leader and Devil Two make a second dive on the now smoldering
+transformer area.  All firing from the fortress suddenly stops.  Pilot Leader
+looks back to his navigator, who is equally puzzled.  The two fighters
+continue to attack the now silent fortress.</sd>
+         <sp spk="CHEWIE (DEVIL TWO)">
+
+I don't get it.  What do you think, Boss?</sp>
+         <sd>General Skywalker appears on the monitors.</sd>
+         <sp spk="GENERAL (with difficulty)">
+
+Base one to Devil Leader...Scramble code niner.  Break your attack, and return
+to base.  Repeat, break your attack.  Confirm.</sp>
+         <sp spk="PILOT LEADER">
+
+They're hurt, Sir, but they still have power.  We should finish....</sp>
+         <sp spk="GENERAL">
+
+Break off.  The war is over.  Run on white lights.  Get back here, Mace.
+We're going to need you.</sp>
+         <sp spk="PILOT LEADER">
+
+Confirmed, base one.  We're on our way.  Did you copy, Chewie?</sp>
+         <sp spk="DEVIL TWO">
+
+Roger, Boss.</sp>
+         <sd>The two starfighters break off the attack and start back toward the planet.
+Without warning, the fort directs concentrated fire at the two starfighters.
+Devil Two instantly bursts into flames, then disintegrates.  Pilot Leader's
+tail section is hit, and the ship pinwheels toward the planet.  Blood covers
+Pilot Leader's immobile face.</sd>
+         <sp spk="PILOT LEADER'S NAVIGATOR">
+
+We're under fire...They're still shooting.  I thought it was over.  We're hit!</sp>
+         <sd>We're hit!  Pilot is dead....Ejecting.</sd>
+         <sd>The dead "Pilot Leader" is jettisoned free of the craft, but the navigator's
+eject panel is dead.  He struggles with it, then bangs on the canopy to no
+avail.  The navigator is still trapped in the craft when it explodes, leaving
+only a puff of pink smoke reflected in the rim light of the planet.</sd>
+      </scene>
+      <scene n="47">
+         <setting>  DESERT NEAR OUTPOST - AQUILAE</setting>
+         <sd>Pilot Leader's dead body drifts toward his arid mother-planet.  Automatic
+rockets kick-in occasionally, to direct and soften the landing.  Two grey-clad
+troopers stand next to a military "landspeeder;" watching the descending
+airwarrior through electrobinoculars.  Mace's corpse hits the ground rather
+hard, creating a whirlwind of dust, and the two troopers rush over to the
+pilot.  The younger of the two troopers, a young boy in his teens, cradles the
+dead starpilot in his arms and begins to cry.</sd>
+      </scene>
+      <scene n="48">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker sits alone, meditating in the deserted war room.  Montross
+approaches the contemplative general.</sd>
+         <sp spk="MONTROSS">
+
+No sign of Starkiller or the princess.  There was much damage in that
+area...The queen will see you at ten hundred.</sp>
+         <sd>The general doesn't reply.</sd>
+      </scene>
+      <scene n="49">
+         <setting>  ASSEMBLY - DEPARTURE AREA - IMPERIAL SPACE FORTRESS</setting>
+         <sd>General Vader stands behind a row of men at computer control panels.  A
+commander reports to the general.</sd>
+         <sp spk="COMMANDER">
+
+All enemy craft destroyed.  First and fifth division, troops and equipment
+standing by.</sp>
+         <sd>The general gives a sly smile of approval and takes a microphone from one of
+the computer technicians.  He speaks to the troops and pilots waiting in their
+huge war machines for the invasion order.</sd>
+         <sp spk="VADER">
+
+The war is won.  With the conquering of this System we have ushered in a new
+millenium for the Empire; which will echo throughout the universe.  Our reward
+is the knowledge this system possesses.  This planet must be controlled with a
+minimum of force, but you must not think lightly of this enemy.  They have
+exacted a heavy toll.  Today you will make the Empire complete.  Do so with
+pride and care.</sp>
+         <sd>Vader puts down the mike, and turns to his commander.</sd>
+         <sp spk="GENERAL">
+
+Let the invasion begin.</sp>
+      </scene>
+      <scene n="50">
+         <setting>  EDGE OF THE DUNE SEA - AQUILAE</setting>
+         <sd>Jundland, or "no man's land," where the rugged desert mesas meet the
+foreboding dune sea.  The two helpless astro robots kick up clouds of dust as
+they clumsily work their way across the desert coastline.  The short Artwo
+struggles desperately to keep up with the long-legged Threepio.</sd>
+         <sp spk="ARTWO">
+
+It's not possible.  We're not built for this.  You're nothing more than a dim-
+witted, emotion-brained intellectual.  Why you were created is beyond my logic
+systems.  Thanks to you, we're deserters, and will probably be destroyed on
+sight.  And on top of that, you're going the wrong way!  All this filth is
+getting....</sp>
+         <sd>The towering Threepio stops short and turns on the blabbering mechanical runt.</sd>
+         <sp spk="THREEPIO">
+
+I've had enough of you, you pragmatic, nearsighted scrap pile.  You go your
+own way.</sp>
+         <sd>He picks up the tiny robot and tosses him several feet into a large sand dune.</sd>
+         <sd>Threepio starts off in the direction of the dune sea.  Artwo struggles to his
+feet, and shakes a metallic claw arm at his disappearing ex-partner.</sd>
+         <sp spk="ARTWO">
+
+You'll be malfunctioning within a day.  You're going the wrong way, but your
+way is always the wrong way.</sp>
+         <sd>Threepio stops and yells to the smaller android.</sd>
+         <sp spk="THREEPIO">
+
+And don't let me catch you following me, begging for help, because you won't
+get it from me.</sp>
+         <sd>Artwo's reply is a rather rude sound, which only an electronic person could
+make.  He turns and trudges off in the opposite direction into the rocky
+desert mesas.</sd>
+      </scene>
+      <scene n="51">
+         <setting>  DUNE SEA - AQUILAE</setting>
+         <sd>Threepio, hot and tired, struggles up over the ridge of a dune, only to find
+more dunes, which seem to go on for endless miles.  He looks back in the
+direction he came.</sd>
+         <sp spk="THREEPIO">
+
+You little malfunctioning twerp.  This is all your fault.  You tricked me into
+going this way, but you'll do no better!</sp>
+         <sd>He sits in a huff of anger and frustration, knocking the sand from his joints.</sd>
+      </scene>
+      <scene n="52">
+         <setting>  DESERT MESA - AQUILAE</setting>
+         <sd>Artwo stumbles through a narrow canyon until he climbs over a small boulder
+and sees before him a sight he first thinks is a mirage.  Nestled in a rock
+formation is a deserted landspeeder.  Once the little robot is convinced that
+he is alone, he approaches the battered speeder and begins to analyze it.  He
+climbs into the pilot's seat, and attempts to start the unfamiliar transport.
+He hears a sound, and stops for a moment.  He sees nothing, so he continues to
+fiddle with the control panel until the speeder lurches forward with a start,
+banging into a large rock.  The stubby android is shaken, but neither he, nor
+the speeder, seems to be damaged.</sd>
+         <sd>Shivers run down Artwo's metal spine, and again he has an eerie feeling that
+he is being watched.  He slowly looks around, and sees a large man, Captain
+Starkiller, standing directly behind him.  He is startled, then terrified.</sd>
+         <sp spk="STARKILLER">
+
+Where is your master?</sp>
+         <sd>The little robot clicks and rattles, but doesn't speak.</sd>
+         <sp spk="STARKILLER (Con't)">
+
+Can't you speak?  How do you relate your data?  You're of Karollian
+manufacture...You should be able to talk.  Are you damaged?</sp>
+         <sd>Starkiller pokes at the machine, but doesn't see any damage.  Artwo eyes him
+suspiciously.  The robot turns with a start and discovers a young girl,
+Princess Leia, has been standing next to him for some time.</sd>
+         <sp spk="PRINCESS (sarcastic)">
+
+Well, General, who's your friend?</sp>
+         <sp spk="STARKILLER">
+
+I don't know.  He doesn't seem to be able to talk.  Damaged,
+probably....Jettisoned from a damaged ship...</sp>
+         <sp spk="PRINCESS">
+
+What do you intend to do with it?</sp>
+         <sp spk="STARKILLER">
+
+We'll take it with us.  Could be a storehouse of valuable information.</sp>
+         <sd>Starkiller guides the android into the small luggage area behind the front
+seat, then hops into the driver's seat.</sd>
+         <sp spk="PRINCESS">
+
+I don't want to ride with that hing.  I order you to destroy it immediately.</sp>
+         <sp spk="STARKILLER">
+
+Get in!  We've got to hurry if we're going to get across the "dunehedge" by
+nightfall...You're coming, one way or the other.  Will you join us peaceably?</sp>
+         <sd>The princess reluctantly gets into the speeder, and it starts with a jolt.</sd>
+      </scene>
+      <scene n="53">
+         <setting>  LANDSPEEDER - DESERT MESAS - AQUILAE</setting>
+         <sd>The speeder flies along, a foot or so above the landscape.</sd>
+         <sp spk="PRINCESS">
+
+You are such a barbarian.  I'll have my father cut you into little pieces when
+we get back...and I'll take pleasure in feeding you to the Gonthas....a little
+bit each day.  I may save your eyes though.  I'll have them petrified and made
+into a necklace.</sp>
+         <sp spk="STARKILLER">
+
+Your sweetness is only surpassed by your beauty.  Just try to remember, I'm
+only following orders.</sp>
+         <sp spk="PRINCESS">
+
+... to beat me and abuse me?</sp>
+         <sp spk="STARKILLER">
+
+I'm afraid I've only learned one way to treat wild animals.</sp>
+         <sd>Artwo thrashes about, trying to relieve the pressure on his crumped legs.</sd>
+         <sp spk="PRINCESS">
+
+You stay out of this.</sp>
+      </scene>
+      <scene n="54">
+         <setting>  DUNE SEA</setting>
+         <sd>Threepio struggles to the top of a large dune.  He is dirty and hot.  His
+plight seems hopeless.  He searches the horizon for any sign of life.  A glint
+of reflected light in the distance reveals an object speeding toward him.  The
+chrome android waves frantically, and yells at the approaching speeder.  The
+sleek landspeeder races past him about a hundred yards away.  He runs after
+it, screaming in desperation, until he stumbles and falls head over heels down
+an enormous sand dune.  Silently, the speeder sweeps around in a circle and
+stops behind the immobile robot.  Starkiller jumps out of the landspeeder and
+is quickly followed by Artwo.</sd>
+         <sp spk="PRINCESS">
+
+We're in a hurry, remember!  If you're going to stop for everyone unfortunate
+along the way, we'll never get back.  We're lucky you got the speeder running
+as it is.</sp>
+         <sd>Artwo waddles up to his fallen partner and starts pulling on his leg, then
+runs up and starts pulling on his arm.</sd>
+         <sp spk="ARTWO">
+
+Function!  Function!  It's me.  Come on, function.</sp>
+         <sp spk="STARKILLER">
+
+Well, my little friend, you've found your tongue.</sp>
+         <sp spk="ARTWO">
+
+We must help him... We've been lost.</sp>
+         <sp spk="STARKILLER">
+
+Where did you come from?</sp>
+         <sd>The little robot runs around his fallen partner giving him small electric
+charges from his claw hand.  Threepio shudders from head to toe, then regains
+consciousness.</sd>
+         <sp spk="THREEPIO">
+
+What happened?</sp>
+         <sp spk="ARTWO">
+
+You're overheated.</sp>
+         <sp spk="STARKILLER">
+
+Where did you come from?</sp>
+         <sp spk="ARTWO">
+
+We were jettisoned from six twenty-nine, P.R. one.</sp>
+         <sp spk="STARKILLER">
+
+I'm unfamiliar with that ship.  What type is it?</sp>
+         <sp spk="THREEPIO">
+
+It's a class M station, not a conventional craft.</sp>
+         <sd>Threepio then stands and shakes the young Jedi's hand.</sd>
+         <sp spk="THREEPIO (Con't)">
+
+I'm Seethreepio, Human-Cyborg Relations.  Your kindness is greatly
+appreciated.</sp>
+         <sd>Starkiller and the two robots walk back to the speeder.</sd>
+      </scene>
+      <scene n="55">
+         <setting>  Both Artwo and Threepio are stuffed into the tiny luggage compartment.
+It is late in the day when the speeder rumbles to a stop in a small desert
+canyon surrounded by steep cliffs and broken boulders.</setting>
+         <sp spk="STARKILLER">
+
+We'll rest here.</sp>
+         <sp spk="THREEPIO">
+
+At last.  The transport is welcome but my joints are frozen.</sp>
+         <sd>Everyone climbs out of the low-slung speeder.  Starkiller watches the two
+androids as they stretch their mechanical limbs.</sd>
+         <sp spk="ARTWO">
+
+I've got a bad case of dust contamination.  I can barely move.</sp>
+         <sp spk="THREEPIO">
+
+What a foresaken place this is.  We seem to be made to suffer.  It's our lot
+in life.  Sir, could you tell....</sp>
+         <sd>Threepio turns and notices that Starkiller and the princess have disappeared.
+He looks all around.</sd>
+         <sp spk="THREEPIO">
+
+Where did they go?  They've disappeared.</sp>
+         <sp spk="ARTWO">
+
+Maybe they were attacked!  I sense danger!</sp>
+      </scene>
+      <scene n="56">
+         <setting>  HIDDEN FORTRESS ENTRANCE - DESERT CANYON - AQUILAE [scene number - sic]</setting>
+         <sd>Captain Starkiller and Princess Leia hurry through a maze of large boulders,
+until they reach a sheer rock face.  Starkiller looks around to see if they
+were followed.  Suddenly, a large section of the rock slides away, revealing a
+well-lit corridor carved out of the rock.  They enter, and are greeted by two
+jubilant guards.  Starkiller gives them some orders and points in the
+direction of the speeder.  The secret rock door silently slides closed.</sd>
+      </scene>
+      <scene n="57">
+         <setting>  MAIN HALLWAY - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>Starkiller and the princess are greeted by General Skywalker and Montross.
+They bow before the princess.</sd>
+         <sp spk="PRINCESS (angrily pointing at Starkiller)">
+
+General, I want you to do something with this..this barbarian.  Where's my
+father?</sp>
+         <sp spk="GENERAL">
+
+The king is dead, Your Highness.</sp>
+         <sd>All anger suddenly drains from the princess.  She almost timidly asks the next
+question.</sd>
+         <sp spk="PRINCESS">
+
+My mother?... and brothers?</sp>
+         <sp spk="GENERAL">
+
+She's here.  She's safe...so are your brothers.  They're in the main chamber.</sp>
+         <sd>Leia, now looking more like a frightened young girl than a vindictive
+princess, runs down the hallway toward the main chamber.  She vainly attempts
+to hold back the tears.</sd>
+      </scene>
+      <scene n="58">
+         <setting>  DESERT CANYON - AQUILAE</setting>
+         <sd>The two puzzled androids sit on the landspeeder, pondering the disappearance
+of their saviour.</sd>
+         <sp spk="THREEPIO">
+
+Do you suppose we're in danger?</sp>
+         <sp spk="ARTWO">
+
+The logic of this environment escapes me.</sp>
+         <sd>As night begins to fall, and the shadows begin to lengthen, the two robots
+begin to get a little edgy.  The sound of approaching feet startles Artwo, and
+he ducks behind his taller friend.  Two guards approach the robots.</sd>
+         <sp spk="GUARD">
+
+You will remain calm, and you will remain here.</sp>
+         <sp spk="THREEPIO">
+
+Certainly.  I'm Seethreepio, Human-Cyborg Relations.  Your kindness is
+gratefully appreciated.</sp>
+         <sd>Artwo sits rather suspiciously behind his extroverted friend.</sd>
+      </scene>
+      <scene n="59">
+         <setting>  ROYAL CHAMBER - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker bows low before Princess Leia.  She sits on a raised
+platform, dressed in the royal robes of a planetary ruler.  The queen sits off
+to one side on a smaller platform.  The princess waits for a few moments
+before she allows the general to rise.</sd>
+         <sp spk="QUEEN">
+
+The senate has been corrupted.</sp>
+         <sp spk="GENERAL">
+
+They cannot rule without your wish...</sp>
+         <sp spk="QUEEN">
+
+I rule by marriage.  With the king dead, I am not strong enough to stop
+them... Leia is now the true queen... She must be protected.  The line must be
+preserved.  I am placing the future of our people in your hands.  You must
+deliver Leia and her brothers to the Ophuchi System.  They will be safe there.</sp>
+         <sd>General, you must understand, I had no alternative but to condone an end to
+the hostilities.  I deeply believe your campaign could have been successful,
+but there are things that...</sd>
+         <sp spk="GENERAL">
+
+I understand, Your Highness...</sp>
+         <sp spk="QUEEN">
+
+The chrome companies on Ophuchi have offered to supply you with the men and
+ships necessary to return Leia to the throne.</sp>
+         <sp spk="GENERAL">
+
+Can the chrome companies be trusted?</sp>
+         <sp spk="QUEEN">
+
+The price for their cooperation is high.  It is waiting for you in Med Center
+blue.  Guard it as you would the princess herself.  No-one must know of this
+mission.  There are those among the trusted who would wish us ill.  Take only
+two of your best officers with you, the most loyal.  May the force of others
+be with you.</sp>
+         <sp spk="LEIA">
+
+Mother, you must not stay.</sp>
+         <sp spk="QUEEN">
+
+I am too old for such a journey.  The Empire already controls the spaceport
+cities.  You have a long way to travel.  It won't be easy.</sp>
+         <sp spk="GENERAL">
+
+We will have to travel in disguise.  I must have full command.  No-one can
+suspect wealth or royal training.  I fear the new queen will not stand for
+this.</sp>
+         <sp spk="LEIA (angry)">
+
+Do not put words into my mouth.  I will stand for what is necessary.</sp>
+         <sd>The general simply smiles.</sd>
+      </scene>
+      <scene n="60">
+         <setting>  SUB-HALLWAY - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general walks briskly through an isolated hallway, closely followed by
+Montross.</sd>
+         <sp spk="GENERAL">
+
+How is Captain Whitsun's recovery?</sp>
+         <sp spk="MONTROSS">
+
+Very good; he's up and around.</sp>
+         <sp spk="GENERAL">
+
+Fine!  Have Whitsun and...ah, Starkiller report at zero three hundred.  I want
+two converted transports:  agricultural type, two days' provisions, travel
+papers, weapons.  Contact Han Solo at the Gordon spaceport...I'll talk to
+him... with speed!</sp>
+         <sd>Montross turns and rushes down another hallway.</sd>
+      </scene>
+      <scene n="61">
+         <setting>  MEDICAL CENTER BLUE - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general enters a stark white waiting area filled with scholarly looking
+gentlemen.  An attendant greets General Skywalker and takes him into a small
+observation chamber overlooking a large operating theatre.  An elderly doctor
+greets him.</sd>
+         <sp spk="DOCTOR">
+
+Good to see you, General.  I'm afraid we're not quite ready yet.  Thank God
+you'll be the one taking them, though.</sp>
+         <sd>An attendant brings in one of the scholars from the waiting area and places
+him on a large operating table surrounded by strange looking equipment.  An
+ominous looking clamp is placed on the man's head.</sd>
+         <sp spk="GENERAL">
+
+How many are going?</sp>
+         <sp spk="DOCTOR">
+
+Thirty-three of the greatest scientific minds in our System...A high price for
+freedom.</sp>
+         <sp spk="GENERAL">
+
+Thirty-three scientists!  Transporting a group that size, undetected... I
+don't...</sp>
+         <sp spk="DOCTOR">
+
+Don't worry, General.  All you'll be taking are their minds.</sp>
+         <sd>The doctor moves over to a safe-like cabinet guarded by two attendants.  The
+doctor gingerly picks up a small clear vial filled with grey fluid.  It has a
+label which reads:  Faubun, Astro-dynamics...In the background the scholar on
+the operating table is undergoing a form of mechanized brain surgery.</sd>
+         <sp spk="GENERAL">
+
+"Bloodory's distillation?"</sp>
+         <sp spk="DOCTOR">
+
+Yes.  It has been greatly perfected.  The brain is condensed into five ounces
+of fluid.  Cloning cell samples are included so that a structural duplicate of
+the scientist can be reproduced.  When the duplicate child reaches the age of
+six, he or she begins a series of injections of the brain fluid.  By the age
+of ten years, they have received all the knowledge and memory of an
+experienced scientist:  an old mind in a young body.  We have prepared a
+special shock-belt to carry the vials.</sp>
+         <sd>In the background, the limp body of the scholar on the operating table is
+removed and another scientist is escorted into the operating threatre.  Dr.
+Bloodory, a portly doctor in his forties, enters the room and shakes hands
+with the general.</sd>
+         <sp spk="DOCTOR">
+
+General, this is Doctor Bloodory.  He'll be making the trip with you.</sp>
+         <sp spk="BLOODORY">
+
+It's an honor to meet you, General.  I'm sure I couldn't be in safer hands.</sp>
+         <sp spk="GENERAL">
+
+The chrome companies are exacting a high prince indeed.  Politics will be the
+ruin of us all.</sp>
+         <sp spk="BLOODORY">
+
+Careful.  If we could rid ourselves of the politicians, generals would no
+longer be necessary.</sp>
+         <sp spk="DOCTOR">
+
+We should be ready by zero three hundred.</sp>
+         <sd>The doctors exit, leaving the general alone to watch the huge machine extract
+another brain.</sd>
+      </scene>
+      <scene n="62">
+         <setting>  SPACEPORT - OBSERVATION DECK - AQUILAE</setting>
+         <sd>Governor Hoedaack, General Vader walk down a boarding ramp to an observation
+deck overlooking the conquered city of Gordon.  They are followed by a number
+of aides and officers from the Imperial fleet.  Below them air tanks and other
+military equipment and supplies are being unloaded.</sd>
+         <sp spk="VADER">
+
+Not much of a planet.</sp>
+         <sp spk="HOEDAACK">
+
+Darth, you've done well.  Do you think you will have the Royal Family by
+nightfall?</sp>
+         <sp spk="VADER">
+
+An advance expedition is already on its way to their underground hideaway.
+They should reach it by nightfall... but only if this Count Sandage can be
+trusted.</sp>
+         <sp spk="HOEDAACK">
+
+A man hungry for power can always be trusted... to betray those in power.  I'm
+sure his information is correct.</sp>
+      </scene>
+      <scene n="63">
+         <setting>  HIDDEN FORTRESS CANYON</setting>
+         <sd>The huge rock face of the canyon opens, and two shabby agricultural
+landspeeders are pushed into the late afternoon sun.  Artwo and Threepio stand
+on the far side of the canyon with their guards, watching in amazement.  The
+general and Captain Starkiller walk behind the men pushing the landspeeders.</sd>
+         <sp spk="GENERAL">
+
+We'll take them with us.  They know more about that fortress than any ten men.</sp>
+         <sd>They will be very useful.</sd>
+         <sp spk="STARKILLER">
+
+Can they be trusted?</sp>
+         <sp spk="GENERAL">
+
+Loyalty can't be programmed.  They can be trusted never to harm a living
+creature, and to always give accurate information...as they know it, to anyone
+who asks.  You just have to remember not to tell them anything that you don't
+want to fall into the wrong hands.</sp>
+         <sd>The general approaches the two robots.  Artwo shyly moves around his taller
+companion.</sd>
+         <sp spk="GENERAL">
+
+Greetings.  I'm Luke:  Agricultural Engineering.  We're going to be travelling
+together.  You're going with us to help set up a hortastation on Banth.</sp>
+         <sd>Threepio shakes hands with the general.</sd>
+         <sp spk="THREEPIO">
+
+I'm Seethreepio:  Human Cyborg relations.  Your kindness is greatly
+appreciated.</sp>
+         <sd>Threepio and the general both look down at Artwo.  Threepio gives the smaller
+android a little kick.</sd>
+         <sp spk="ARTWO">
+
+Artwo Detwo:  Fusion Repair.</sp>
+         <sp spk="GENERAL (to Starkiller)">
+
+Load them into one of the speeders.</sp>
+         <sd>Captain Whitsun, walking with a slight limp, emerges from the underground
+fortress with the Royal Family.  A small group of guards and aides are lined
+up, standing at attention.  The two young princes, Biggs and Windy, hug and
+kiss their mother good-bye, then jump into the back of the larger four-man
+speeder.  The princess bows before her mother, then embraces her.  Tears roll
+down her cheeks.  Her mother wipes them away.</sd>
+         <sp spk="QUEEN">
+
+You must learn strength.</sp>
+         <sd>The princess turns and moves to the larger speeder where she is helped aboard
+by Captain Starkiller.</sd>
+         <sp spk="PRINCESS (fuming)">
+
+I don't need your help, thank you.</sp>
+         <sd>She gives the general an angry look.</sd>
+         <sp spk="GENERAL">
+
+I'm afraid he's necessary.</sp>
+         <sd>A commotion erupts at the mouth of the underground fortress.  Count Sandage,
+several senators and ten to twelve troopers rush into the canyon and block the
+speeders.</sd>
+         <sp spk="SANDAGE">
+
+Where are you going?  What is this?</sp>
+         <sd>In one quick movement the general moves between Sandage and the queen.
+Whitsun and Starkiller assume defensive positions in front of the princess and
+her brothers.</sd>
+         <sp spk="QUEEN">
+
+Leia and the boys are being taken to safety.  It is my wish.</sp>
+         <sp spk="SANDAGE">
+
+The Empire has assured their safety.  They must stay.</sp>
+         <sp spk="QUEEN">
+
+It is not my wish....</sp>
+         <sp spk="SANDAGE">
+
+General, you've gone too far this time.  <sd>to the troops</sd> Arrest him.</sp>
+         <sd>Five troops start to move on the general, as Sandage draws his laserpistol.
+Before anyone can complete his action, the general ignites his lasersword and
+cuts the senator in two.  He drops to the ground in a heap, and the
+approaching troops stop in their tracks.</sd>
+         <sp spk="QUEEN">
+
+Stop this!</sp>
+         <sd>The general, Starkiller, and Whitsun replace their swords, and bow low to the
+queen.  All of the troops, senators, and aides do the same.  The formalness of
+the occasion is broken when the queen embraces the general.  She then turns
+and embraces each of the captains.  They are both flustered, and somewhat
+embarrassed.</sd>
+         <sp spk="QUEEN">
+
+May the force of others be with you.</sp>
+         <sd>The general and his captains head for the speeders, while the queen and all
+the others return to the underground fortress.</sd>
+      </scene>
+      <scene n="64">
+         <setting>  DESERT BLUFF - AQUILAE</setting>
+         <sd>The two speeders edge their way onto a bluff overlooking the hidden fortress
+canyon.  They stop for one last reflective moment.  Forced to leave their
+closest friends and relatives, the group is deeply moved.  The two robots, for
+the most part, are puzzled.  Suddenly, there is a huge atomic flash, followed
+by a loud rumble, and the entire canyon collapses into a large crater.  The
+group quietly watches the dust settle.  The hidden fortress and all its
+inhabitants have been destroyed.  The general watches the princess, who
+appears to take it well.</sd>
+         <sp spk="GENERAL">
+
+It was the only way we could be safe from treachery.</sp>
+      </scene>
+      <scene n="65">
+         <setting>  DUNE SEA - AQUILAE</setting>
+         <sd>The two sleek landspeeders glide effortlessly through the vast hills and
+valleys of the dune sea.  At the base of the towering dune ridge, the four-man
+speeder stops.  The smaller speeder, with Starkiller and the two robots, makes
+its way to the top of the ridge.  Captain Starkiller stops the speeder just
+short of the top of the ridge.  He gets out and continues the rest of the way
+on foot.  The young captain peeks over the dune ridge into the canyon below.
+Muted sounds and large dust clouds rise from the canyon floor.  Starkiller
+immediately ducks back behind the ridge with an amazed look on his face.  He
+quickly returns to the speeder, and picks up the intercom.</sd>
+         <sp spk="STARKILLER">
+
+Sir, you'd better take a look at this.  But come easy.</sp>
+         <sd>The four-man speeder starts with a crack, and slowly moves up the side of the
+imposing dune.  It stops next to the smaller speeder.  The general and Whitsun
+get out and make their way to the top of the ridge, where they join
+Starkiller.  Far in the distance, crossing the endless dune sea, is the
+Imperial invasion army.  It is immense.  A convoy of giant tanks, troop
+carriers, and supply ships stretch from horizon to horizon.  Cavalry, mounted
+on giant dune birds, ride the line from one end of the convoy to the other.
+Hundreds of troops ride one-man jet-sticks in precision formation.  Their
+lances form a giant pin-cushion.  It is an awesome sight.</sd>
+         <sp spk="GENERAL SKYWALKER">
+
+They're heading toward the fortress.</sp>
+         <sp spk="WHITSUN">
+
+What will they do when they find it destroyed?</sp>
+         <sp spk="GENERAL">
+
+They won't stop looking for us...They're coming from the spaceport at
+Anchorhead, which means they control everything between here and the spaceport
+at Gordon.</sp>
+         <sp spk="STARKILLER">
+
+Can we go around them?</sp>
+         <sp spk="GENERAL">
+
+No.  We'll have to wait for them to pass.  Starkiller, see if you can monitor
+any of their communications on the com-link in the big speeder.</sp>
+         <sd>Starkiller returns to the speeder.  He collapses in the large speeder next to
+the princess, and flips on the com-link radio, moving back and forth across
+the dial.</sd>
+         <sp spk="PRINCESS">
+
+Must you do that?</sp>
+         <sd>Starkiller smiles rather sarcastically.</sd>
+         <sp spk="STARKILLER">
+
+Orders...The invasion force has cut us off.  We'll probably be here for some
+time.  You ought to stretch a bit.</sp>
+         <sp spk="PRINCESS">
+
+Is that a command, General?  Maybe I feel like watching after my brothers.</sp>
+         <sd>Starkiller looks back at the two sleeping boys.</sd>
+         <sp spk="STARKILLER">
+
+They're not going anywhere.  They're asleep.</sp>
+         <sp spk="PRINCESS">
+
+I want to stay with them.</sp>
+         <sp spk="STARKILLER">
+
+What's the matter?  You afraid I might eat them?</sp>
+      </scene>
+      <scene n="66">
+         <setting>  LIBRARY - PALACE OF LITE - AQUILAE</setting>
+         <sd>The king's old library has been converted into an office for General Vader.
+He is sitting behind his desk as Prince Valorum, the black knight of Sith,
+enters and salutes.  The black knight is dressed in the fascist black and
+chrome uniform of the legendary Sith One Hundred.  The general returns his
+salute.</sd>
+         <sp spk="VADER">
+
+Welcome, Prince Valorum.  Your exploits are legendary.  I have long waited to
+meet a Knight of the Sith.  If there is any way I can assist you, my entire
+command is at your bidding.</sp>
+         <sp spk="VALORUM">
+
+I want a tie-in to your computer network, a control center, and communication
+access.</sp>
+         <sp spk="VADER">
+
+Right away!  I'll also transfer all information we have on the general.  His
+command post was self-destroyed, but we believe he is still alive.... Do you
+really believe he's a Jedi?</sp>
+         <sp spk="VALORUM">
+
+If he was not a Jedi, I wouldn't be here.</sp>
+      </scene>
+      <scene n="67">
+         <setting>  WASTELAND - AQUILAE</setting>
+         <sd>The speeders make their way across the grey desert.  It is dawn.  The twin
+suns have yet to rise over the distant hills.  The speeders are coated with
+dust and grime, indicating that they have travelled far.  The two captains
+drive through the night as everyone else sleeps.  Starkiller calls Whitsun on
+the intercom.</sd>
+         <sp spk="STARKILLER">
+
+How are your fuel packs?  I'm reading minus four.</sp>
+         <sp spk="WHITSUN">
+
+I'm too low to transfer any.</sp>
+         <sd>The general, who appeared to be asleep, opens his eyes, and takes the
+microphone from Whitsun.</sd>
+         <sp spk="GENERAL">
+
+There is a fuel station fourteen degrees by two meters.  The occupation force
+should have control of it by now, so hide your weapons...but keep them within
+reach.</sp>
+      </scene>
+      <scene n="68">
+         <setting>  FUEL STATION - AQUILAE</setting>
+         <sd>A series of low concrete structures rise out of the desert.  The speeders stop
+in front of an old weather-beaten block house.  The rusted hulk of a
+landspeeder lies half-buried to one side of the building.  Starkiller and
+Whitsun jump out of the speeder and go into the block house.</sd>
+      </scene>
+      <scene n="69">
+         <setting>  INTERIOR - FUEL STATION - AQUILAE</setting>
+         <sd>The two young captains, dressed as farmers, enter the dingy little fuel
+station.  It is quiet.  A few power packs line the walls and a dismantled
+speeder rests in the repair bay.  There is a sharp dripping sound coming from
+the speeder.  It appears that no-one is there.</sd>
+         <sp spk="STARKILLER">
+
+Greetings! ... Who's in charge here?</sp>
+         <sd>They look around the deserted station, but find no attendant.  An eerie quiet
+pervades the building.</sd>
+         <sp spk="WHITSUN">
+
+I don't get it...</sp>
+         <sp spk="STARKILLER">
+
+You don't have to.  It's abandoned.</sp>
+         <sd>Whitsun opens a door leading to a storage area, and stops short.</sd>
+         <sp spk="WHITSUN">
+
+Not quite abandoned...</sp>
+         <sd>Starkiller moves to the doorway and sees the attendant, his wife, and small
+daughter hanging upside down, tortured to death.  Whitsun cuts them down.</sd>
+         <sp spk="WHITSUN">
+
+They shouldn't have resisted.</sp>
+         <sd>Starkiller grabs two power packs from the shelf.</sd>
+         <sp spk="STARKILLER">
+
+Help me with these power packs.  We'd better move out of here.</sp>
+         <sd>Whitsun covers the family with an old work tarp.  He bows to the dead, then
+reluctantly grabs a couple of power packs and they start for the door.
+Whitsun stops for a moment.</sd>
+         <sp spk="WHITSUN">
+
+Hear that?  Someone's here.  <sd>yelling</sd>  We're friends.  Show yourself.</sp>
+         <sd>Silence.  Whitsun shrugs his shoulders and they start out the door, only to
+run straight into a burly stormtrooper.</sd>
+         <sp spk="STORMTROOPER">
+
+Get out of here!</sp>
+      </scene>
+      <scene n="70">
+         <setting>  FUEL STATION - AQUILAE</setting>
+         <sd>Whitsun and Starkiller are pulled out of the doorway and shoved into the
+center of a group of fifteen or twenty Imperial stormtroopers who have
+surrounded the two speeders.  Several troops have pulled General Skywalker out
+of the speeder.  He acts senile, like a man twice his age.</sd>
+         <sp spk="GENERAL SKYWALKER">
+
+I'm all right.  I can still move about by myself.</sp>
+         <sd>A rough looking sergeant grabs Whitsun.</sd>
+         <sp spk="SERGEANT">
+
+What are you doing here?</sp>
+         <sp spk="WHITSUN">
+
+We're out of power, sir.</sp>
+         <sp spk="SERGEANT">
+
+Let me see  your travel passes!</sp>
+         <sp spk="WHITSUN">
+
+I have it here, somewhere.  We've been relocated...to a Bantha hortastation,
+by Imperial order...</sp>
+         <sd>Whitsun fumbles to retrieve something from his pocket, and eventually pulls
+out a small, round disc.  The sergeant puts the disc in a small portable
+reader.  Various computer readouts are displayed on the monitor.  Starkiller
+starts to put a power pack into one of the speeders.</sd>
+         <sp spk="SERGEANT">
+
+What are you doing there?  All power has been restricted.</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+We've run out.  We must have power, or be forced to stay here....and become
+your responsibilities.</sp>
+         <sd>The sergeant thinks about this for a moment, as the old, wise general watches
+him.  Tension fills the air.  Starkiller shuffles around to a position where
+he can reach his weapon.  A trooper hands the sergeant a message.</sd>
+         <sp spk="SERGEANT (to Whitsun)">
+
+Take only two of those power packs, and then move out quickly.</sp>
+         <sd>The sergeant hurries to a military craft, where he takes a call on an
+intercom.  General Skywalker and his two young captains load the remaining
+power packs into the speeder, and roar away from the station.</sd>
+      </scene>
+      <scene n="71">
+         <setting>  WASTELAND - AQUILAE</setting>
+         <sd>The speeders race along through the rocky desert wasteland.  The general
+speaks into the intercom to Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Keep a close watch.  If that sergeant runs an analysis on those passes, we
+might be seeing him again...We should be safely inside Gordon within the day.</sp>
+         <sd>Everyone is in good spirits.  The princess and her young brothers sing an
+Aquilaean melody, which is transmitted to Starkiller in the smaller speeder.
+The general takes little Windy, and lets him sit on his lap in the forward
+compartment of the speeder.  Artwo flexes Threepio's arm back and forth,
+attempting to discover the cause of a loud squeak.</sd>
+         <sp spk="ARTWO">
+
+Z-2 doesn't seem to help at all.</sp>
+         <sp spk="THREEPIO">
+
+It's all this filth and dust.  This environment is murderous.</sp>
+         <sd>Starkiller notices a small speck on the horizon.</sd>
+         <sp spk="STARKILLER (into intercom)">
+
+Object approaching, bearing three point two.</sp>
+         <sd>The general looks through an electrotelescope mounted in the speeder.  He
+spots a distant row of troopers riding strange dune birds.</sd>
+         <sp spk="GENERAL (to Starkiller)">
+
+It's a patrol.  It could mean trouble.  We'd better split up.  You stay on a
+direct course.  We'll meet you at the western edge of ravine 23-64.  Stay in
+contact.</sp>
+         <sd>The larger speeder makes a sharp left turn, speeding off across a deep ravine.</sd>
+         <sd>Starkiller can begin to distinguish the approaching troopers.</sd>
+         <sp spk="STARKILLER">
+
+It looks like there's ten of them.  They're heading right for me.... Wait a
+second.  They've disappeared!  I've lost them.</sp>
+         <sp spk="GENERAL">
+
+Continue on.</sp>
+      </scene>
+      <scene n="73">
+         <setting>  WASTELAND LAKEBED - AQUILAE</setting>
+         <sd>Whitsun deftly maneuvers the bulky speeder through a narrow, boulder strewn
+ravine.  They eventually come out on a dry lake bed, where they stop.
+Standing not more than a hundred feet away, apparantly waiting for the
+speeder, are five Imperial troops on their dune birds.</sd>
+         <sp spk="GENERAL">
+
+We've found them, five of them, anyway...Watch yourself.</sp>
+         <sd>The troops slowly ride their huge birds over to the speeder, and dismount.
+The officer in charge is a vicious looking warrior, with a large scar across
+his face.</sd>
+         <sp spk="OFFICER">
+
+Let me see your passes.</sp>
+         <sd>Whitsun hands him the small pass disc, and he places it in his reader.  He
+studies the computer readout for a few moments, and then returns the disc to
+Whitsun.</sd>
+         <sp spk="OFFICER">
+
+Have you seen any other transports in this area?</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+We saw two heading south.  Goin' toward Ansel, look like to me.</sp>
+         <sp spk="OFFICER">
+
+All right.  Be on your way.</sp>
+         <sd>The officer mounts his dune bird, and the patrol moves away.  Whitsun winks at
+the princess, and smiles at the general, as the speeder starts off across the
+dry lake.  The general fiddles with the intercom.</sd>
+         <sp spk="GENERAL">
+
+S-2, are you clear?</sp>
+         <sp spk="STARKILLER">
+
+I have five troopers approaching.  Any problems on your end?</sp>
+         <sp spk="GENERAL">
+
+We came through all right.  You shouldn't have any trouble, but stay alert.</sp>
+         <sp spk="STARKILLER">
+
+Best wishes....Here they come.</sp>
+         <sd>Everyone rides along in silence, a little worried about Starkiller, especially
+the princess.</sd>
+         <sp spk="PRINCESS">
+
+..Do you think he'll be all right?</sp>
+         <sp spk="GENERAL">
+
+He can take care of himself.</sp>
+         <sd>Biggs is looking out the back window of the speeder.</sd>
+         <sp spk="BIGGS">
+
+Hey look!  They're coming back.</sp>
+         <sd>Everyone looks to see the patrol quickly gaining on them.</sd>
+         <sp spk="GENERAL">
+
+Stop!  They're faster.  Get your weapon.</sp>
+         <sd>The speeder screeches to a halt in a cloud of dust.  The general and his
+captain jump from the transport with laserpistols drawn.  The patrol bears
+down on them, swords drawn, at full charge.  Both the general and Whitsun
+fire.  Two of the troopers and their Dune birds explode in a cloud of smoke.
+The remaining three troopers are upon the duo in a matter of seconds.  The
+general ignites his lasersword and cuts down two of the troops as they pass.
+The last turns his bird around before reaching the speeder, and hightails it
+back toward the ravine.  The general jumps onto one of the riderless dune
+birds and takes off in pursuit.  Whitsun checks the dead troopers.</sd>
+      </scene>
+      <scene n="73">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The general rides at breakneck speed after the fleeing trooper.  His
+lasersword is raised high over his head, ready to deal a death blow.  The
+lumbering birds race through the winding ravine.</sd>
+      </scene>
+      <scene n="74">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The intercom warning buzzer begins to scream.  Whitsun rushes for it, but the
+princess gets there first.</sd>
+         <sp spk="PRINCESS">
+
+Are you all right?</sp>
+         <sp spk="STARKILLER">
+
+Two riders heading your way.  I got three, but two got away.  Watch
+yourselves!</sp>
+      </scene>
+      <scene n="75">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The general is riding neck and neck with the trooper.  He swiftly brings his
+sword down and the trooper drops from his saddle.  The momentum of his charge
+carries the general around a bend in the ravine, and right in the path of two
+more troops charging down on him.  The two troopers are taken by surprise.
+They stop their birds, and so does the general.  They stand there, about fifty
+yards apart, sizing up each other.  Suddenly, the two troopers start for the
+Jedi at full speed.  The general raises his sword, and starts for them.  The
+troopers are no match for the general, who kills them both before they are
+even able to swing their swords.</sd>
+      </scene>
+      <scene n="76">
+         <setting>  WASTELAND LAKEBED - AQUILAE</setting>
+         <sd>Starkiller stops near the larger landspeeder and gets out.  He is wounded.
+Blood streams from his left arm.  Whitsun rushes to help him.  The princess
+shows a great deal of concern.</sd>
+         <sp spk="WHITSUN">
+
+It looks worse than it is.  You'll be all right.</sp>
+         <sd>Whitsun motions to the princess, who looks a little relieved.</sd>
+         <sp spk="WHITSUN">
+
+Bring me the med aid pack.</sp>
+         <sp spk="PRINCESS">
+
+It he was clumsy enough to get hurt, maybe we ought to let him bleed to death.</sp>
+         <sd>She hands Whitsun the kit, as the general rides up and dismounts.  He moves to
+Starkiller.</sd>
+         <sp spk="GENERAL">
+
+You missed two.</sp>
+         <sp spk="STARKILLER">
+
+I know, I couldn't...</sp>
+         <sp spk="GENERAL">
+
+Don't let it happen again.  We'd better move out.  They might have reported
+in.</sp>
+      </scene>
+      <scene n="77">
+         <setting>  CONTROL ROOM - PALACE OF LITE - AQUILAE</setting>
+         <sd>The dark and sinister Valorum moves several markers on a large map readout to
+form a line from the destroyed underground fortress to the spaceport at
+Gordon.  An aide enters with General Vader.</sd>
+         <sp spk="AIDE">
+
+The patrol was lost, Sir.  All ten of them.</sp>
+         <sp spk="VALORUM">
+
+It's to be expected.</sp>
+         <sp spk="VADER">
+
+Have you found them?</sp>
+         <sp spk="VALORUM">
+
+They're heading for the spaceport at Gordon.  I'm going there.  Have all
+security doubled.  Make it an alert.</sp>
+      </scene>
+      <scene n="78">
+         <setting>  THE OUTSKIRTS OF GORDON - AQUILAE</setting>
+         <sd>The speeders stop on a bluff overlooking a small cantina on the outskirts of
+Gordon.  The spaceport can be seen in the distance.  The general and Captain
+Whitsun walk over to the smaller speeder.  Starkiller helps the two androids
+out of their cramped quarters.</sd>
+         <sp spk="THREEPIO">
+
+Your kindness is greatly appreciated.</sp>
+         <sp spk="STARKILLER (to general)">
+
+I'm fit enough to...</sp>
+         <sd>The general gives him a hard look and he shuts up.  Whitsun and the general
+climb into the speeder.</sd>
+         <sp spk="GENERAL">
+
+We'll make contact at zero four hundred.  If we're not back by fifty-five
+forty, get worried.</sp>
+         <sd>The speeder starts off toward the cantina.</sd>
+      </scene>
+      <scene n="79">
+         <setting>  SPACEPORT CANTINA - AQUILAE</setting>
+         <sd>The speeder pulls up in front of the low, blockhouse style cantina.  Various
+strange forms of transport are parked outside the bar.</sd>
+         <sp spk="GENERAL">
+
+Take care here.  If there is any trouble, get back to the others.</sp>
+         <sd>The general and Whitsun enter the shabby cantina.  The murky little den is
+filled with a startling array of weird and exotic alien creatures, laughing at
+the bar.  At first, the sight is horrifying.  One-eyed, thousand-eyed, slimy,
+furry, scaling arms, tentacles, and claws huddle over drinks.  The general
+looks over the patrons, but does not see the contact, Han Solo.  A large
+multiple eyed creature shoves the general.</sd>
+         <sp spk="CREATURE">
+
+Assha dughi wouldugga?</sp>
+         <sd>The general tries to ignore the creature, and turns back to his drink.  A
+short, grubby looking human, and an even smaller rodent-like creature join the
+first creature.</sd>
+         <sp spk="HUMAN">
+
+He doesn't like you.</sp>
+         <sp spk="GENERAL">
+
+I understood him.</sp>
+         <sp spk="HUMAN">
+
+I don't like you either.</sp>
+         <sp spk="GENERAL">
+
+I'm sorry.</sp>
+         <sd>The big creature is getting agitated, and yells at the general.</sd>
+         <sp spk="HUMAN">
+
+Don't insult us.  You just watch yourself.  We're wanted men.  I have the
+death sentence on twelve Systems.</sp>
+         <sp spk="GENERAL">
+
+I'll be careful then.</sp>
+         <sp spk="HUMAN">
+
+You'll be dead.</sp>
+         <sd>The short rodent yells something, and everything at the bar moves away.  The
+general assumes a defensive position.  His three adversaries ready their
+weapons.</sd>
+         <sp spk="GENERAL">
+
+You insist on a fight then.</sp>
+         <sp spk="HUMAN">
+
+Just try and kill us.</sp>
+         <sp spk="GENERAL">
+
+It will hurt a little.</sp>
+         <sp spk="HUMAN">
+
+We aren't cowards.</sp>
+         <sp spk="GENERAL">
+
+Then it can't be helped.</sp>
+         <sd>The general's lasersword sparks to life.  An arm lies on the floor.  The
+rodent is cut in two, and the large, multiple-eyed creature lies doubled, cut
+from chin to groin.  The general, with quiet dignity, replaces his sword in
+its sheath.  The entire fight has lasted only a matter of seconds.  A figure
+stands in the doorway watching the general.  As soon as the general notices
+him, he leaves.  The cantina goes back to normal, as if nothing had happened,
+although the general is given a respectable amount of room at the bar.  The
+Jedi finishes his drink, and then leaves.  Captain Whitsun follows.</sd>
+      </scene>
+      <scene n="80">
+         <setting>  SPACEPORT ALLEYWAY - GORDON - AQUILAE</setting>
+         <sd>General Skywalker embraces Han Solo, the underground contact.  Han is a huge,
+green skinned monster with no nose and large gills.</sd>
+         <sp spk="HAN">
+
+You old stardog.  Took a war to get you out here...</sp>
+         <sd>Whitsun arrives with Starkiller, the princess and her brothers, and the two
+puzzled androids.</sd>
+         <sp spk="GENERAL">
+
+It's been too long.  We've been through much together.  It will be good to
+have you out of retirement and back at my side.  How is Starkiller?  (putting
+his arm around the young Captain Starkiller)  This is his son.</sp>
+         <sp spk="HAN">
+
+You're all the old boy will talk about.  He's still holding up.  Come, let's
+get off the street.</sp>
+         <sd>The group enters a small doorway at the far end of the alleyway.  On the main
+street, within view of the doorway, giant Imperial air tanks and other
+military hardware rumble through the city.  Starving refugees sit in the
+gutters watching the immense display of force with a mixture of awe and
+terror.  The princess stops for a moment, and stares at her people, watching
+the might of the Empire.  The general escorts her through the doorway with the
+others.</sd>
+      </scene>
+      <scene n="81">
+         <setting>  SLUM DWELLING - LIVING AREA - AQUILAE</setting>
+         <sd>The seedy dwelling is dark and dingy.  The group is greeted by three
+underground leaders, and the old Jedi, Kane Starkiller.  Captain Starkiller
+embraces his father as the underground leaders bow before the princess.</sd>
+      </scene>
+      <scene n="82">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>The princess walks through the dining area followed by Whitsun and Starkiller,
+who carry the two sleeping princes.  The general sits at a large table
+finishing dinner with Han, Kane and the three underground leaders.  Whitsun
+returns from the bedroom.</sd>
+         <sp spk="GENERAL (to Whitsun)">
+
+Captain, why don't you take the androids into the other room for a game of
+chess? ... I'm sure they'd enjoy it.</sp>
+         <sp spk="THREEPIO">
+
+A wonderful idea.  Your kindness is greatly appreciated.</sp>
+         <sd>Whitsun escorts the two robots into the next room.  Datos, a thin, wizened old
+man, seems greatly relieved.</sd>
+         <sp spk="DATOS">
+
+You're taking a great risk travelling with them.  This whole operation sounds
+bad to me.  I don't trust the chrome companies.  Time is growing short.  The
+Empire's attempts at control have already caused a great deal of suffering to
+our people.</sp>
+         <sd>Occo, a brash young rebel, about the same age as Captain Starkiller, slams his
+fist on the table.</sd>
+         <sp spk="OCCO">
+
+It must happen now!  We are ready!  Each day the Imperial S.B.T. finds and
+destroys a few more in the organization.  We cannot wait any longer.</sp>
+         <sp spk="GENERAL">
+
+Any uprising without a coordinated attack on the death star is out of the
+question.</sp>
+         <sp spk="HAN">
+
+He's right.  As long as it's operational, any action down here would be
+meaningless.  We must proceed as planned.  Are the arrangements secure?</sp>
+         <sd>Quist, the third member of the underground, sparks to life, and places several
+discs and badges on the table.</sd>
+         <sp spk="QUIST">
+
+All passenger transport has been suspended, so we've arranged for you to
+travel as the crew of a Baltarian freighter.  The boys will have to be placed
+in suspended animation and hidden in shielded micro-packs.  It's the only way
+we will be able to get them past the scanners.</sp>
+         <sp spk="DATOS">
+
+Were you able to acquire the necessary power packs?</sp>
+         <sp spk="QUIST">
+
+It's become a serious problem.  All power supplies have been restricted.  S-4
+units are impossible to come by.</sp>
+         <sp spk="HAN">
+
+I know an agent who might be able to acquire them for us.  I'll check with
+him.  It will be risky, but we've no other choice.</sp>
+      </scene>
+      <scene n="83">
+         <setting>  SPACEPORT OBSERVATION DECK - AQUILAE</setting>
+         <sd>The dark figure of Valorum stands overlooking a group of Aquilaean partisans
+who are being tortured in the plaza below.  Two Imperial officers are
+finishing a report to the black knight.  They salute smartly, then leave the
+observation balcony, passing Kuro, one of General Vader's aides, who
+approaches Valorum, and bows low before him.  Kuro and the black knight carry
+on an animated conversation; it is inaudible over the screams of the tortured
+partisans.</sd>
+      </scene>
+      <scene n="84">
+         <setting>  SLUM DWELLING - ALLEYWAY - AQUILAE</setting>
+         <sd>Residents glance fearfully from their windows as six Imperial stormtroopers
+make their way through the crowded slum alleyway.  Han Solo and Captain
+Starkiller move cautiously past the Imperial patrol, and disappear into the
+shabby hideout of the partisan underground.</sd>
+      </scene>
+      <scene n="85">
+         <setting>  SLUM DWELLING - MAIN AREA - AQUILAE</setting>
+         <sd>The two men enter the dingy main room of the slum dwelling, and are
+immediately attacked by Biggs, wielding a toy sword.  Starkiller good-
+naturedly fends off the young prince, as Han in a more serious mood, goes into
+the other room.  Artwo and Threepio are helping Windy put together a block-
+like puzzle.  Princess Leia comes in to see what all the commotion is about,
+just as the young captain grabs Biggs by the foot and holds him upside-down.
+Starkiller and Biggs are laughing uproariously.  Leia gives the captain a
+stern, disapproving look, then returns to the other room.</sd>
+      </scene>
+      <scene n="86">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>General Skywalker, Captain Whitsun, and Datos are in the process of assembling
+two micro-packs on the kitchen table.  Han pulls a small silver powerpack from
+his pocket, and places it on the table.  The old Jedi, Kane Starkiller,
+reaches over with his one good arm and takes it.  He inspects it carefully.
+Princess Leia sits quietly behind the general.</sd>
+         <sp spk="HAN">
+
+We could only get one unit.  The Empire's methods are proving to be very
+effective.</sp>
+         <sd>Kane places the power-pack back on the table.  The pain from those simple
+movements shows on his face.</sd>
+         <sp spk="KANE">
+
+This will work fine.</sp>
+         <sp spk="HAN">
+
+One of the boys will have to stay.</sp>
+         <sp spk="DATOS">
+
+We can't hide him for very long....The risk is too great!  Whichever boy
+doesn't go must be destroyed.</sp>
+         <sd>The princess is alarmed, and looks to the general for support.  He gives her
+an understanding look.</sd>
+         <sp spk="GENERAL">
+
+Not while they're in my charge.  Find another way to get him through.</sp>
+         <sp spk="DATOS">
+
+There's no other way.  We've analyzed every possible alternative.  You can't
+jeopardize the enitre...</sp>
+         <sd>Captain Starkiller enters the room.</sd>
+         <sp spk="HAN">
+
+We have no time for discussion.  The freighters leave at zero three hundred.
+We must get started.</sp>
+         <sd>Through a break in the door, Whitsun watches Artwo and Threepio play with the
+two young princes.</sd>
+         <sp spk="WHITSUN">
+
+What about Artwo?  Could we lobotomize him, and use his energy pack?</sp>
+         <sp spk="GENERAL">
+
+They're not compatible.  We'd have to completely change the system...</sp>
+         <sp spk="HAN">
+
+It could work.</sp>
+         <sp spk="DATOS">
+
+There isn't enough time.  You can't do it...</sp>
+         <sp spk="KANE">
+
+You won't have to.  My power unit has more than half life.... Use it.</sp>
+         <sd>The withered Jedi opens his tunic revealing a metallic chest covered with
+electrodes.  With his one good arm, he grabs his chest and rips loose and
+miniature power unit similar to the one on the table.  Everyone is taken by
+surprise.  The general and the young Starkiller both rush to the side of the
+dying Jedi.  The old man turns to his son.</sd>
+         <sp spk="KANE">
+
+Trust my judgment, Son.  Serve your new teacher well.</sp>
+         <sd>The Jedi's breathing becomes more difficult as he turns to the general.</sd>
+         <sp spk="KANE (con't)">
+
+An honorable death, my friend.  May the force of others be with you....</sp>
+         <sd>Kane Starkiller passes on to the other world.  Everyone is stunned.  The
+general breaks the moment of silence.</sd>
+         <sp spk="GENERAL">
+
+May he be welcomed as a man above men.  Take him downstairs.</sp>
+         <sd>Starkiller takes his father in his arms and is followed out of the room by Han
+and Datos.</sd>
+         <sp spk="GENERAL">
+
+Prepare the boys!  We have little time.</sp>
+         <sd>Princess Leia and Captain Whitsun rush out of the room, as the general places
+the power units in the micro-packs.</sd>
+      </scene>
+      <scene n="87">
+         <setting>  SLUM DWELLING - MAIN AREA - AQUILAE</setting>
+         <sd>Biggs and Windy are not happy about being dragged away from their puzzle.
+Whitsun takes the robots into the sleep area.</sd>
+         <sp spk="LEIA">
+
+Now straighten up, Biggs.  Remember, father expects you to follow his ways.
+We are going on a trip.  There will be great danger.  You must go to sleep.
+When you wake, you will be in a strange land, so don't be alarmed.</sp>
+         <sp spk="BIGGS">
+
+Are you going to sleep too?</sp>
+         <sp spk="LEIA">
+
+I will be looking after you.  Now be good boys and stand still.  Lift your
+sleeve.</sp>
+         <sd>Windy lifts his sleeze and Leia injects him with a sleep serum.  Whitsun
+enters just as the little prince collapses into a deep sleep.  Quick as
+lightning, he catches the boy before he can hit the floor.  The princess
+injects her other brother, and he collapses into her arms.</sd>
+      </scene>
+      <scene n="88">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>The limp bodies of the two young princes are carried in by Leia and Captain
+Whitsun.  They are carefully squeezed into the hollowed out micro-cases.  Leia
+pensively watches as the general expertly attaches electrodes to her brother's
+skull.  Han and Datos return from the burial of Kane.  The general looks up
+from his operation.</sd>
+         <sp spk="HAN">
+
+He is at rest.  The Empire will never find him.  Are the systems working all
+right?</sp>
+         <sp spk="GENERAL">
+
+Full power...Is everything ready?</sp>
+         <sd>Datos nods yes, as the general closes the case holding Biggs.  The strain of
+watching her brothers placed in suspended animation is too great for Leia, and
+she retreats into the main room.</sd>
+      </scene>
+      <scene n="89">
+         <setting>  SLUM DWELLING - MAIN ROOM - AQUILAE</setting>
+         <sd>Captain Starkiller stands brooding near a window overlooking the crowded
+alleyway.  He does not acknowledge Leia's entrance.  She walks over to the
+window, and stands next to the young captain.  They are very close, but do not
+touch.</sd>
+         <sp spk="LEIA">
+
+I'm sorry.</sp>
+         <sd>He does not respond.  She is moved by his sorrow, and starts to touch the side
+of his face, but can't bring herself to do it.  Her royal training is too
+strong to let her show her true affection for Starkiller.  She breaks down and
+runs from the room.  The young Jedi continues his meditation.</sd>
+      </scene>
+      <scene n="90">
+         <setting>  SPACEPORT AT GORDON - SECURITY RAMP - AQUILAE</setting>
+         <sd>The spaceport is very crowded.  People rush about in a panicked rush as
+loudspeakers blurt out indiscernible announcements.  The Empire is in the
+process of changing the boarding procedures and the result is chaos.  Many
+flights are delayed, and people are running to and fro, switching boarding
+ramps.  Han guides the rebel group, dressed as a Baltarian crew, through the
+crowded terminal.  Whitsun and Starkiller carry the large micro-packs strapped
+to their backs.  The robots follow a few paces behind.</sd>
+         <sp spk="HAN">
+
+They're changing the boarding procedures.  I don't like it.</sp>
+         <sd>They are swept into a boarding gate and finally reach a security ramp scan
+station.  There are a great number of troops and guards standing around the
+security area.  An officer demands to see their passes and orders.  The
+tension builds as the officer confers with an aide about the passes.  The aide
+speaks quietly into a phone.</sd>
+         <sp spk="OFFICER">
+
+Where are your component receipts?</sp>
+         <sd>Starkiller and Whitsun hand the officer two additional discs which are placed
+in the computer.  A few moments later, the readout appears, and the group is
+motioned through the electron scanners.  On the other side of the scanner, new
+computer discs are issued to the group.  Everyone seems slightly relieved as
+they walk through several hallways leading to where the freighter is docked.
+Starkiller moves next to the general.</sd>
+         <sp spk="STARKILLER">
+
+I don't like the feel of this.</sp>
+         <sp spk="GENERAL">
+
+Your senses are strong.  It's a very small disruption.</sp>
+         <sp spk="STARKILLER">
+
+It's a Knight of the Sith.</sp>
+         <sp spk="GENERAL">
+
+Possibly.  Stay alert...Warn the others.</sp>
+         <sd>The group walks through the docking links and into the Baltarian spacecraft.
+Several Imperial guards pass them, and everyone is ready for the suspected
+trap, but nothing happens..</sd>
+      </scene>
+      <scene n="91">
+         <setting>  INTERIOR - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The group stops in a narrow electronics passageway near the bridge of the
+ship.  Starkiller and Whitsun unstrap the micro-packs containing the two young
+princes, and check the voltage packs.</sd>
+         <sp spk="WHITSUN">
+
+Little Biggs is losing power faster than normal.  I'd better check it out.</sp>
+         <sp spk="GENERAL">
+
+Wait until the situation is secure.  Stay here, and keep on your guard....Han!</sp>
+         <sd>The two young captains grow suspicious of several workmen gathering around the
+main exit hatch.  Han and the general enter the bridge area.  Several crewmen
+sit at elaborate controls and computer stations.</sd>
+         <sp spk="GENERAL">
+
+Where is your captain?</sp>
+         <sd>One of the crewmen directs him to a small chamber above the bridge.
+Starkiller and Whitsun strap on their micropacks as more workmen converge at
+the main hatch and begin to close it.  The two robots, Artwo and Threepio are
+confused about what is going on, and wear their gear in anticipation of
+moving.</sd>
+      </scene>
+      <scene n="92">
+         <setting>  PILOT CHAMBER - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Han and the general enter the small pilot's chamber and greet the captain,
+whose face is hidden in the shadows of a computer bank.</sd>
+         <sp spk="CAPTAIN">
+
+Welcome, gentlemen.  You must have had a difficult journey.  We'll be
+departing shortly....</sp>
+         <sp spk="">[p. 77 is all screwed up.  I attempt to interpret here:]</sp>
+         <sd>Four Imperial troopers silently enter the room behind the two [??] Their
+laserswords are drawn.</sd>
+         <sp spk="CAPTAIN (con't)">
+
+[?] I have been authorized to accept payment [?] the chrome company
+cooperation.  I [?] you've brought it with you.</sp>
+         <sp spk="">[?] moves out of the shadows, and is revealed to [be Valorum, F]irst Knight of
+the Sith.  Instantly, both Han and [the general] understand the situation.
+They turn, drawing their [laserswords? ?] the move, and cut down the four
+Imperial troopers.  [?] chamber instantly seals shut.  Valorum hasn't [?] and
+remains unusually calm.  The two Jedi turn [?]</sp>
+         <sp spk="VALORUM">
+
+[?] over, gentlemen.  The chamber is sealed.  [?] force me to release the Jai
+gas...</sp>
+         <sp spk="">[?] and the black knight turns to an intercom.</sp>
+         <sp spk="INTERCOM">
+
+[?]ion secure.  Prisoners taken to hold "B,"... [?] casualties.... gas was
+necessary.</sp>
+         <sp spk="">[?]eral relax and drop their weapons.  The door [?] behind them and six guards
+enter wearing face-[?]nd the two Jedi with chrome microcuffs.  A [?] creeps
+across Valorum's face.  General [?] unimpressed with the knightly trap.</sp>
+         <sp spk="VALORUM">
+
+[?] it's ended.  <sd>to guard</sd>  Take them [?] "G."  I don't want them with the
+others.  [?] for departure.</sp>
+         <sp spk="">[?esc]ort Han and the general out of the chamber [?] hallways.</sp>
+         <sp spk="">[?93.  INTERIOR - BALTA]RIAN FREIGHTERS - AQUILAE</sp>
+         <sp spk="">[?]ch Han and the general into the hold of the [?] near the main exit where
+Artwo and Threepio [?] looking lost.  Threepio sees the general pass [?]ay.</sp>
+         <sp spk="THREEPIO">
+
+[?]ere he is.  Come on.</sp>
+         <sp spk="">[end of p. 77]</sp>
+         <sd>The robots waddle off after the Jedi prisoners.  As the small procession
+passes detention cell B where the princess and the others are being held, Han
+and the general let out a horrifying Jedi scream, and leap to the corridor
+ceiling, thrusting their bound wrists into the lighting fixtures.  They land
+on top of the troops, instantly breaking the necks of four guards, with
+expertly placed Jedi blows.  The eight surviving guards are momentarily
+dumbfounded.  Han and the general grab laserswords from their victims, and
+swiftly cut down the remaining troops.  Han grabs a small card from one of the
+dead guards, and starts for detention cell B.</sd>
+         <sp spk="GENERAL">
+
+Watch it!  Those are cutters.</sp>
+         <sd>The general grabs one of the dead troopers and tosses him against the cell
+door.  Red rays engulf the body, and holds it there.  Han then places the card
+in a slot, and the door silently slides open.  Starkiller and Whitsun leap for
+the dead guard, then notice the death ray surrounding him.  General Skywalker
+grabs another body and throws it into the doorway.</sd>
+         <sp spk="GENERAL">
+
+Pass between them!</sp>
+         <sd>Starkiller squeezes between the slain guards, and is untouched by the rays.
+Whitsun and the princess quickly follow, picking up weapons as they leave.</sd>
+         <sp spk="STARKILLER">
+
+They've taken the cases.</sp>
+         <sp spk="GENERAL">
+
+Are they aware of the boys?</sp>
+         <sp spk="WHITSUN">
+
+I don't think so.</sp>
+         <sp spk="GENERAL">
+
+Find them!  Use your seeker.  We'll meet you at the main hatch.  Watch
+yourselves.  If an alarm is given, they'll gas the entire ship.</sp>
+         <sp spk="WHITSUN">
+
+Yes, Sir.</sp>
+         <sd>Whitsun and Starkiller each take a small humming device from their utility
+belts and head down a narrow hallway.  The general, Han and the princess
+continue toward the main hatch.  Artwo and Threepio have been completely
+confused by the turn of events.  They eventually follow the general toward the
+exit hatch.</sd>
+      </scene>
+      <scene n="94">
+         <setting>  ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The two young captains reach a storage area of the huge spacecraft.  They
+watch their seekers as they move along a row of electroclosets.  They quietly
+sneak past a group of workmen assembling a large gyro-housing.  A second row
+of micro-packs is searched to no avail.</sd>
+         <sp spk="WHITSUN">
+
+If they were discovered, they would have been sent to a medical station.</sp>
+         <sp spk="STARKILLER">
+
+There are more storage areas on the far side.</sp>
+      </scene>
+      <scene n="95">
+         <setting>  MAIN HATCH AREA - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Han and the general reach the main hatch, closely followed by Leia and the two
+robots.  Several lights over the hatch flash on and off.  The general cuts a
+camera off the wall with his lasersword.</sd>
+         <sp spk="HAN">
+
+They're going to take off....It's too late.</sp>
+         <sp spk="GENERAL">
+
+Threepio!  Come over here.</sp>
+         <sd>The lanky chrome man approaches the general, who is studying a complex
+computer control panel next to the hatch.</sd>
+         <sp spk="THREEPIO">
+
+Yes Sir.  May I be of service?</sp>
+         <sp spk="GENERAL">
+
+Get this hatch open.  Counterlock the departure pattern.</sp>
+         <sd>The robot immediately starts pushing buttons on the panel.</sd>
+      </scene>
+      <scene n="96">
+         <setting>  ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Starkiller and Whitsun reach a second series of electroclosets.  A signal
+appears on the seekers, and Starkiller cuts down the door of one of the small
+cabinets.  Whitsun stands guard.  Approaching troops are heard in the
+distance.  Starkiller quickly rummages through the electropacks until he spots
+the familiar cases containing the two boys.</sd>
+         <sp spk="WHITSUN">
+
+Troops!</sp>
+         <sd>Starkiller straps on one of the back packs, and hands the other to Whitsun, as
+they duck into a narrow passageway.  Four troops march through a nearby
+hallway.  After they have passed, the young captain checks to make sure the
+way is clear, then runs down a hallway toward the main hatch.</sd>
+      </scene>
+      <scene n="97">
+         <setting>  BRIDGE - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>As the crew makes the final preparations for the blast off, the main hatch
+light blinks on.  One of the pilots notices the light and begins to check it
+out.</sd>
+         <sp spk="PILOT (into intercom)">
+
+Is the main hatch secure?</sp>
+      </scene>
+      <scene n="98">
+         <setting>  MAIN HATCH - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The intercom sparks to life, and the general answers it.</sd>
+         <sp spk="GENERAL">
+
+Everything looks secure, but give me a minute to check it out.</sp>
+         <sp spk="PILOT">
+
+All right... Stand by.</sp>
+         <sd>The general gives a wink to Han, as Threepio continues his attempt to override
+the hatch computer.</sd>
+      </scene>
+      <scene n="99">
+         <setting>  HALLWAYS - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Starkiller and Whitsun cautiously move down a long hallway, ever watchful of
+Imperial troops.  They reach an intersection, carefully check in all
+directions, then rush down a main hallway.  They are about half way down the
+hallway, when a squad of Imperial guards appears at the end of the hallway,
+facing them.  The troops start toward the two captains with lowered
+laserrifles.</sd>
+         <sp spk="STARKILLER">
+
+Here's where it gets tricky.</sp>
+         <sd>Starkiller, then Whitsun, quickly and smoothly draw their laserpistols and
+fire at the troops.  A giant explosion destroys the far end of the hallway.  A
+few laserbolts are returned, but streak harmlessly overhead, and explode out
+of range.  The exchange of gunfire lasts only a few moments.  When the smoke
+clears, the troops have been destroyed.</sd>
+      </scene>
+      <scene n="100">
+         <setting>  MAIN HATCH - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The main hatch slowly begins to slide open, when the rumbling explosion of
+laserfire echoes through the hallways.  Han looks to the general, and they
+both instantly realize what has happened.  Han draws his weapons.  The hatch
+is now fully open.  Everyone stands silently, watching for the two captains.
+Alarms start screaming throughout the ship, and the giant hatch slowly begins
+to close.</sd>
+         <sp spk="GENERAL">
+
+Come on.  We can't wait.</sp>
+         <sd>The group reluctantly exits the spacecraft, giving one last look back to their
+lost friends.  The hatch continues to close slowly as the alarm sirens wail.
+Suddenly, Starkiller and Whitsun round a corner and head for the ever-closing
+hatch; battling several Imperial stormtroopers as they go.  Han and the
+general move up to the hatch and give cover fire.  Whitsun slips through the
+shrinking opening, and yells to Starkiller to hurry.  Many more troops bear
+down on the young Jedi as he squeezes through the very slim opening.  One of
+the troops dives after him, but is caught, and crushed by the emergency hatch.</sd>
+      </scene>
+      <scene n="101">
+         <setting>  BOARDING RAMPS - GORDON SPACEPORT - AQUILAE</setting>
+         <sd>The general leads the group through various corridors.</sd>
+         <sp spk="HAN">
+
+Once the alarm sounds, the entire spaceport will shut down.</sp>
+         <sd>They stop at a junction.  At the far end of one hallway, several troops guard
+a restricted passageway.</sd>
+         <sp spk="GENERAL">
+
+That's the military section.</sp>
+         <sp spk="STARKILLER">
+
+Fighter craft!</sp>
+         <sp spk="HAN">
+
+But it's very heavily guarded.  We can't take it with subtlety.</sp>
+         <sd>Before the general can answer, the acute scream of the spaceport alarm
+reverberates through the corridors.  The general, followed by his two young
+captains, charge toward the heavily guarded military passageway.  Han, with
+the princess and two robots, follow a safe distance behind.  A guard sees them
+coming, and orders them to stop.  Starkiller and the general fire their
+laserpistols at the passageway entrance and the troops disappear in a huge
+explosion.</sd>
+         <sd>The group jumps over the dead guards and smoking rubble, then runs through a
+series of hallways leading to a starship.  They stop just short of an
+intersection leading to a boarding ramp.  Starkiller peeks around a corner at
+two guards standing in front of the boarding ramp.</sd>
+         <sp spk="STARKILLER">
+
+Cutters!  We'll have to draw them out...A blast might alert the crew.</sp>
+         <sp spk="GENERAL">
+
+Artwo!  Come here.</sp>
+         <sd>The little robot waddles over to the old Jedi.</sd>
+         <sp spk="GENERAL (con't)">
+
+Move to that intersection and sound the alarm.</sp>
+         <sd>The mechanical dwarf dutifully marches into the intersection and lets out a
+high, electronic scream.  The guards shut off the deadly laser "cutters," and
+cautiously approach the wailing robot.</sd>
+         <sp spk="GUARD">
+
+What is it?  What's wrong?</sp>
+         <sd>With incredible speed, both guards are dropped by a few precision blows from
+the two young captains.  They immediately drag the unconscious guards into the
+starship.</sd>
+         <sp spk="GENERAL">
+
+Starkiller!  Whitsun!  Stand guard.  I'll signal at take-off minus
+thirty...And reverse that cutter!</sp>
+      </scene>
+      <scene n="102">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - AQUILAE</setting>
+         <sd>Han and the general, followed by Leia and the robots, enter the Imperial
+starship.  They rush through several narrow hallways leading to the bridge.
+Two crew members leaving a control station, stumble into the group and are
+quickly dispatched by Han.  The princess waits with the robots, as the general
+and Han enter the bridge.  The two pilots and navigator are taken by surprise
+and promptly are subdued.  Han switches on the intercom and listens.</sd>
+         <sp spk="HAN">
+
+How are we going to get them to open the silo cover?</sp>
+         <sp spk="GENERAL">
+
+Send Threepio in here.  Dispose of any crewmen left on board.</sp>
+      </scene>
+      <scene n="103">
+         <setting>  BOARDING RAMP - SPACEPORT - AQUILAE</setting>
+         <sd>Starkiller and Whitsun now wear the uniform of the Imperial guard.  Whitsun
+has removed a plate from the "cutter" machinism and is crossing a few wires.
+He replaces the "cutter" plate just as a squad of stormtroopers rushes toward
+the door.  An officer salutes them.</sd>
+         <sp spk="OFFICER">
+
+Have you seen them?</sp>
+         <sp spk="STARKILLER">
+
+No, Sir.</sp>
+         <sp spk="OFFICER">
+
+They're in this section somewhere.  I'm doubling all the guards.  Stay alert.</sp>
+         <sd>Two guards take up positions just outside the "cutter" areas, and the squad
+moves on to another starship.  Starkiller gives his partner a philosophical
+look.</sd>
+      </scene>
+      <scene n="104">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - AQUILAE</setting>
+         <sd>The gleaming chrome Threepio sits in the pilot's seat, talking on the intercom
+to a controller.  He breaks off his continual drone of take-off instructions
+to the controller and turns to the general, shaking his head.</sd>
+         <sp spk="THREEPIO">
+
+They won't buy it.  I think they're getting suspicious.</sp>
+         <sd>Han enters.</sd>
+         <sp spk="HAN">
+
+The crew is taken care of.</sp>
+         <sp spk="GENERAL">
+
+Well, they're not going to open the silo cover, so I'm afraid we'll have to
+take it with us.</sp>
+         <sp spk="HAN">
+
+We're going to sustain considerable damage if we blast off through that cover.</sp>
+         <sp spk="GENERAL">
+
+It's a thin shell.  There is no choice.  <sd>to Threepio</sd>  Signal the boys.</sp>
+      </scene>
+      <scene n="105">
+         <setting>  BOARDING RAMPS - SPACEPORT - AQUILAE</setting>
+         <sd>Warning lights flash and the main hatch to the starfighter slowly begins to
+close.  The two Imperial stormtroopers yell at Starkiller and Whitsun.</sd>
+         <sp spk="STORMTROOPER">
+
+Watch it!  Don't fire into those cutters!  <sd>to Starkiller</sd>  Shut down the
+cutters!</sp>
+         <sd>The two captains pretend to be confused, and not understand.  At the last
+minute, they leap aboard the starship.  The hatch slides closed, and the
+boarding ramp drops away.  Several more guards arrive, and give the troopers a
+special card, which turns the small cutter warning lights from red to green.
+The guards rush onto the boarding ramp and are wiped out by the reversed
+"cutters."</sd>
+      </scene>
+      <scene n="106">
+         <setting>  INTERIOR - STARSHIPS - AQUILAE</setting>
+         <sd>Everyone straps himself into the lifepods.  Threepio and the general troddle
+forward, and the giant ship shudders as it starts to lift off the launch pad.
+With tense expressions, everyone braces for the impact of the silo cover.</sd>
+      </scene>
+      <scene n="107">
+         <setting>  STARSHIP - SPACEPORT SILO - AQUILAE</setting>
+         <sd>The  mighty starship thunders out of the silo, crashing through the cover
+plate, sending shrapnel in all directions.  The ship leaps toward the heavens.</sd>
+      </scene>
+      <scene n="108">
+         <setting>  BOARDING CAMPS - SPACEPORT - AQUILAE</setting>
+         <sd>Imperial flight crews rush to their starships.   Pilots receive their
+clearances, and several giant silo covers swing away, revealing deadly hunter-
+destroyer spaceships.</sd>
+      </scene>
+      <scene n="109">
+         <setting>  INTERIOR - BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han and the general watch as five hunter-destroyers leave the spaceport at
+Gordon.</sd>
+         <sp spk="GENERAL">
+
+We suffered light damage to a deflector fin.  It will take them quite a while
+to catch up with us now.  Tell the boys to get some rest.</sp>
+      </scene>
+      <scene n="110">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Han retreats to the aft section of the ship, where the two captains are
+checking out the two main lasercannons mounted in large rotating bubble
+turrets.</sd>
+         <sp spk="HAN">
+
+The old boy says you two should get some rest... You've got some time before
+they catch up to us.</sp>
+         <sd>Han notices the packs containing the young princes.</sd>
+         <sp spk="HAN (con't)">
+Better store the boys in a lifepod.  Secure them well.</sp>
+         <sd>He heads back toward the bridge, followed by Whitsun.  Starkiller carries the
+two micro-packs to a lifepod, and straps them in.  He checks Biggs' energy
+supply.  It is low.  Leia approaches him.</sd>
+         <sp spk="LEIA">
+
+Couldn't we let them out now?</sp>
+         <sp spk="STARKILLER">
+
+It's better this way.  Things are going to get rough...</sp>
+         <sp spk="LEIA">
+
+Will we make it?  Is there any hope?  Stay with me.  [something deleted?]... I
+love you.</sp>
+         <sd>Starkiller is slightly shocked at this outburst.  The princess starts to cry
+and clings to him for support.</sd>
+         <sp spk="STARKILLER">
+
+No-one is going to die...so stop acting like a child, and start behaving like
+a queen.  What is this silly talk of love?  You belong to the people of
+Aquilae, and my job is to return you to them, nothing more.  Now straighten up
+and get into a lifepod.</sp>
+         <sd>She's deeply hurt by his callousness.  She breaks away from him and runs down
+a hallway into a lifepod.  He is tired, and angry at the whole incident.</sd>
+      </scene>
+      <scene n="111">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Threepio guides the starship toward the Ophuchi system.  The general watches
+the computer readout estimate the position of the Imperial hunter destroyers.</sd>
+         <sp spk="THREEPIO">
+
+Hostile craft will intercept at thirty plus.</sp>
+         <sp spk="GENERAL">
+
+What's the nearest star System?</sp>
+         <sp spk="THREEPIO">
+
+Yavin.</sp>
+         <sp spk="GENERAL">
+
+Set a course... Maybe we can lose them among the Systems.</sp>
+      </scene>
+      <scene n="112">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Starkiller rests in one of the lasercannon pod bays.  He is thinking about
+Leia.  Slowly a smile creeps across his face.  He makes a decision, jumps up,
+and hurries down a hallway.  He taps on the lifepod bulkhead, and Whitsun
+opens the door.  Starkiller is surprised.</sd>
+         <sp spk="WHITSUN">
+
+What is it?</sp>
+         <sp spk="STARKILLER">
+
+Where is Leia?</sp>
+         <sp spk="WHITSUN">
+
+She went forward.... What's going on with you two?</sp>
+         <sp spk="STARKILLER">
+
+We're in love.  She loves me, and I just realized,... I love her.</sp>
+         <sp spk="WHITSUN">
+
+[something whited out] You're asking for trouble... She's a queen... You're a
+warrior....Do you know what you're saying?</sp>
+         <sp spk="STARKILLER">
+
+I don't care... I've got to talk...</sp>
+         <sd>Whitsun just shakes his head, but before Starkiller can finish his sentence,
+the ship is rocked by a bombardment of proton torpedoes.  The intercom squawks
+to life.</sd>
+         <sp spk="GENERAL (over intercom)">
+
+Get to those guns!</sp>
+         <sd>Starkiller and Whitsun rush to the lasercannons, and jump into the protective
+suits and helmets.</sd>
+      </scene>
+      <scene n="113">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han enters the bridge and sits before a fire control center.  The general sits
+in a chair, slightly behind and above Threepio, directing the robot pilot.</sd>
+         <sp spk="GENERAL">
+
+Turn around!  Let's face them.</sp>
+         <sd>Artwo, sitting quietly in a corner, watches as Threepio punches new
+information into the computer and the giant starship swings around in a sharp
+circle.  Several torpedoes explode near the ship.  The general switches on the
+intercom.</sd>
+         <sp spk="GENERAL">
+
+Your boys ready?</sp>
+      </scene>
+      <scene n="114">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The captains adjust the lasercannon controls in front of them and check in
+with the general.</sd>
+         <sp spk="GENERAL">
+
+They should be within range in twelve seconds...</sp>
+         <sd>Starkiller adjusts his giant laser ack-ack cannon, searching his electronic
+tracking screen for the hunter destroyer.  Whitsun is having a problem with
+one of the rotating mechanisms on the huge gun.  He curses, climbs out of the
+chair, and attempts to fix it.</sd>
+         <sp spk="WHITSUN">
+
+My vertical rotating circuits are out...</sp>
+         <sd>The princess straps herself into a small lifepod.  [something whited out]
+Only the slightest hint of concern or worry shows in her face.  She listens to
+her protectors relay instructions as the enemy approaches.</sd>
+      </scene>
+      <scene n="115">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The starship shudders as the hunter-destroyers open fire.  Han relays the
+ship's status to the general, as Threepio struggles to keep up with the
+barrage of orders.</sd>
+         <sp spk="HAN">
+
+We're losing deflectors three thirty one and ten forty two...</sp>
+         <sp spk="GENERAL (to Threepio)">
+
+Cut hard to maridian nine zero six.  Level to three degrees...(into the
+intercom)  We're coming under one.  Wait for my signal!</sp>
+      </scene>
+      <scene n="116">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The constant flashing of deflected laser bolts reflect in the interior of the
+lasercannon bubble.  Starkiller rechecks his firing swithces..Whitsun adjusts
+his headphones, and lowers a glare reflector.  He raps on the power rotation
+circuits, and gives them a little test burst.  The pod instantly rotates a few
+degrees.  The large starship heads directly toward the three enemy ships and
+at the last moment dives under the attacking craft.  Starkiller watches the
+smaller crafts pass overhead, aching to open fire.  He calls Whitsun on the
+intercom.</sd>
+         <sp spk="STARKILLER">
+
+I've got no signal.  I'm on target.  What's wrong?  What are they waiting for?</sp>
+         <sd>I've got an open shield!</sd>
+         <sd>The three Imperial craft are firing incessantly at point blank range.</sd>
+         <sp spk="WHITSUN">
+
+Wait for the signal.</sp>
+         <sd>But Starkiller has a perfect shot, and he can't wait.  He squeezes the trigger
+and the giant lasercannon, with a burst of smoke and electrical charge, opens
+up on the enemy craft.  Moments later, the signal lights flash on and Whitsun
+commences firing on the receeding hunter-destroyers.  Two of the Imperial
+craft break off, and prepare for another attack run.  The third is hit by a
+concentrated barrage from the two captains, and begins spinning out of
+control, until it finally explodes.  Whitsun gives Starkiller a victory wave,
+which Starkiller gleefully returns.  These moments of triumph are broken by
+the intercom.</sd>
+         <sp spk="GENERAL">
+
+Annikin, next run you wait for my signal.  We haven't much power to spare on
+your inaccurate grandstanding!</sp>
+         <sd>Starkiller's pride is wounded.  He resets his accelerators, as the two
+remaining hunter-destroyers begin a second run.</sd>
+      </scene>
+      <scene n="117">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+
+We have a weakened shield on the port turret...</sp>
+         <sp spk="GENERAL">
+
+Warn Starkiller.  Get him out of there.  <sd>to Threepio</sd>  Change your heading by
+point five.</sp>
+      </scene>
+      <scene n="118">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Princess Leia listens to Han warn Starkiller.</sd>
+         <sp spk="HAN">
+
+Your shield power is down.  Abandon that positions, and seal that section.
+Report!  Captain, do you hear me?  Captain?!!!</sp>
+         <sd>Leia becomes worried that something has happened to Annikin.  The young
+captain switches off the intercom system and signals to Whitsun that the
+system has gone dead.  Before Whitsun can answer, the two hunter-destroyer
+spacecraft are upon them once again.  Laser bolts flash all around them.  The
+general's signal flashes on, and the captain starts to return the fire.  One
+of the Imperial fighters concentrates its fire on Starkiller's weakened
+gunport.  A direct hit blows open a hole in the turret, and everything that
+isn't bolted down is sucked into outer space, including Starkiller.  He bangs
+against the side of the starship, held only by a weakened lifeline.</sd>
+         <sd>The princess hears Whitsun explain Starkiller's predicament, and rushes back
+to help him.  She is stopped by a pressure locked door leading to the gun
+emplacement.</sd>
+      </scene>
+      <scene n="119">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The general orders Threepio to swing the spacecraft around and start a new
+attack.  He turns to Artwo.</sd>
+         <sp spk="GENERAL">
+
+Use the aft port...See what you can do for Starkiller.</sp>
+         <sd>Artwo hurriedly waddles out of the bridge.  Threepio and Han simultaneously
+turn to the general.</sd>
+         <sp spk="THREEPIO">
+
+More craft approaching!</sp>
+         <sp spk="HAN">
+
+It looks like at least six or seven.</sp>
+         <sd>The general studies the radar scopes and then checks a Galactic map displayed
+on one of the monitors.</sd>
+         <sp spk="GENERAL">
+
+Change course to three point one.</sp>
+         <sp spk="THREEPIO">
+
+That will head us directly into the path of the Norton Asteroid Belt.</sp>
+         <sp spk="HAN">
+
+That Asteroid Belt is too dense to pass through...The ship won't make it!</sp>
+         <sp spk="GENERAL">
+
+We'll never defeat them in combat.  It's our only chance to lose them.</sp>
+         <sd>Threepio punches in new coordinates, and the starship veers away toward the
+treacherous asteroid belt.</sd>
+      </scene>
+      <scene n="120">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Whitsun fires on one ofthe two hunter-destroyers which is pacing the rebel
+starship.  Starkiller unsuccessfully tries to pull himself back inside the
+spacecraft.  The enemy craft maneuvers wildly in an attempt to get into a
+better position, to fire on Starkiller.  Whitsun blasts away, until the
+Imperial spacecraft spews forth equipment and personnel, careens off, and
+eventually explodes.</sd>
+         <sd>Artwo wobbles along the exterior of the ship, until he reaches the stranded
+captain.  He attaches a new lifeline to the young Jedi's spacesuit, and makes
+his way back inside the wounded craft.  Starkiller is pulled to safety just as
+the starship enters the asteroid belt.  A barrage of small and large asteroids
+begins to pelt the ship, causing a great deal of damage.</sd>
+         <sp spk="GENERAL (over intercom)">
+
+Secure yourselves.  We may have to eject.  Abandon the turrets.</sp>
+         <sd>The princess rushes back to her lifepod and straps herself in.  Whitsun and
+Artwo help Starkiller make his way out of the lasercannon turrets and through
+a series of locks, to the lifepod area.</sd>
+      </scene>
+      <scene n="121">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The asteroids hit hard.  The ship is buffeted to and fro as the general, Han,
+and Threepio struggle into their spacesuit-like lifepods.  The Imperial
+hunter-destroyer closest to the rebel ship explodes in the onrush of deadly
+asteroids.  The new reinforcement hunter-destroyers turn back and give up the
+pursuit.  They disappear from the tracking monitors.  The asteroid bombardment
+becomes almost unbearable.  Warning lights begin to flash.  Extending foils,
+antennae, and armament pods are scraped away from the starship hull.  A
+baseball-sized hole is punched through the midsection, and hundreds of objects
+are sucked into space.  A large locker eventually plugs the opening.  The
+starship and her passengers shudder and sway under the punishment of the
+asteroid storm.</sd>
+         <sp spk="THREEPIO">
+
+The ship is breaking up.</sp>
+         <sp spk="HAN">
+
+We're almost clear of the storm.</sp>
+         <sp spk="THREEPIO">
+
+We'll never make it.  Eject, we must eject.</sp>
+         <sd>The general watches the computer monitor as the starship emerges from the far
+side of the Asteroid Belt.</sd>
+         <sp spk="HAN">
+
+We're approaching one of the Forbidden Systems....</sp>
+         <sp spk="GENERAL">
+
+We've got to achieve orbit.</sp>
+         <sp spk="THREEPIO">
+
+We'll never make it.</sp>
+         <sd>The starship heads for a small blue-green planet in the distance.</sd>
+      </scene>
+      <scene n="122">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Starkiller was considerably shaken in the destruction of his laserturret.  He
+is slightly dazed as Whitsun straps him into a lifepod with Artwo.</sd>
+         <sp spk="WHITSUN (to Artwo)">
+
+You watch him.  Make sure this pod gets off all right.</sp>
+         <sd>Artwo nods, and Whitsun moves to the second lifepod and straps himself in next
+to the princess.</sd>
+         <sp spk="LEIA">
+
+Will he be all right?</sp>
+         <sp spk="WHITSUN">
+
+I think so.. His feelings for you are dangerous.  You should discourage him.</sp>
+         <sd>She is surprised that Starkiller has any feeling for her, but keeps her
+emotions to herself.</sd>
+      </scene>
+      <scene n="123">
+         <setting>  BRIDGE - STARSHIP - YAVIN ORBIT</setting>
+         <sd>The general is strapped into the lifepod with the two micro-packs containing
+the young princes.  Han and Threepio are in the second lifepod.</sd>
+         <sp spk="HAN">
+
+We're in orbit.</sp>
+         <sp spk="THREEPIO">
+
+We've got to eject now!  Those reactors won't hold much longer.  This ship's
+going to end up in a million little pieces,... and I don't want to be one of
+them.</sp>
+         <sp spk="HAN">
+
+All lifepod systems are operative.</sp>
+         <sp spk="GENERAL (into intercom)">
+
+If you boys are ready back there, we'll get off this bucket.</sp>
+         <sp spk="WHITSUN">
+
+All systems operative...I have the signal.</sp>
+         <sp spk="ARTWO">
+
+All systems operative...We have the signal.</sp>
+         <sd>Han salutes the general, and his lifepod jettisons away from the crippled
+starship.  He is quickly followed by the general.</sd>
+      </scene>
+      <scene n="124">
+         <setting>  AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Artwo pushes the jettison switch, but nothing happens.  Starkiller slowly and
+with some difficulty, pushes the switch two or three times.  Nothing happens.
+He begins to look a little worried.</sd>
+         <sp spk="STARKILLER (into intercom)">
+
+We've got a problem...Wait a second...</sp>
+         <sd>Artwo pushes the switch again, and the lifepod blasts off in a cloud of smoke
+and debris.  Whitsun also seems to be having a problem.  Half the lights on
+his control panel have gone dead.  He struggles to reactivate them.</sd>
+         <sp spk="WHITSUN">
+
+My power's out!</sp>
+         <sp spk="GENERAL (over intercom)">
+
+Is it a faulty switch?</sp>
+         <sp spk="WHITSUN">
+
+No.  The whole bank is out.</sp>
+         <sd>Whitsun gives the princess a reassuring look, then punches some information
+into the computer.  The monitor flashes:  "Income line main power."  He looks
+outside the lifepod and sees a damaged cable.</sd>
+         <sp spk="WHITSUN">
+
+I've found it...</sp>
+         <sp spk="GENERAL">
+
+You haven't much time...The auxiliary units have already blown....</sp>
+         <sd>Whitsun scrambles out of the lifepod and rushes over to the severed connector.</sd>
+         <sd>He works on it for a few moments, then stops with a rather defeated look.  The
+princess watches him as he tries to think of a solution.  A great explosion is
+heard in the forward part of the ship.</sd>
+      </scene>
+      <scene n="125">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods containing the general, and Han and Threepio drift away from
+the disabled starship.</sd>
+         <sp spk="GENERAL">
+
+Where's Starkiller?</sp>
+         <sp spk="HAN">
+
+I can't see him either.</sp>
+         <sd>Starkiller uses the small rockets on his lifepod to maneuver back toward the
+burning starship.  He can hear the general over the intercom.</sd>
+         <sp spk="GENERAL">
+
+Starkiller, where are you?  Report in.</sp>
+         <sd>Starkiller reaches down and switches off the intercom.</sd>
+      </scene>
+      <scene n="126">
+         <setting>  AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Whitsun appears to have found a solution to his situation and rushes back to
+the princess.  He reaches in and locks on the power switch.</sd>
+         <sp spk="WHITSUN">
+
+There is only one possible solution, and we must use it.  Lock the hitch and
+make sure it is sealed.</sp>
+         <sp spk="PRINCESS">
+
+But what of...</sp>
+         <sd>Another explosion creates a large bulge in the wall of the aft section.</sd>
+         <sp spk="WHITSUN">
+
+We've no time!</sp>
+         <sd>He slams the hatch shut and runs to the power connector.  Smoke begins to fill
+the chamber, as Whitsun slams a large metallic dampening tool across the
+damaged connector terminals, and the lifepod jettisons away.</sd>
+      </scene>
+      <scene n="127">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The princess jettisons free, as Starkiller moves toward the crippled ship.
+Leia calls the general on the intercom.</sd>
+         <sp spk="LEIA">
+
+I'm all right, but Clieg is still on board.</sp>
+         <sp spk="GENERAL">
+
+Starkiller, stay out of there.</sp>
+         <sd>With a rumble, the starship disappears in a spectacular explosion, sending
+debris in all directions.  Starkiller stops his lifepod and it starts to
+drift.  He is weeping.  Han and the general helplessly watch the remains of
+the explosion drift away.</sd>
+         <sp spk="GENERAL">
+
+Starkiller, stay near Leia.  Use your beacon.  Coordinate with us.</sp>
+         <sd>Starkiller's intercom is weak, and there is a great deal of static.  The
+lifepods drift toward the awesome blue-green Yavin surface.  The general loses
+sight of the other lifepods as the descend through the cloud cover.</sd>
+         <sp spk="GENERAL">
+
+Captain, I'm losing your beacon.  Send me a new signal.</sp>
+         <sd>All he gets is static.  The planet surface rushes toward the falling lifepods.</sd>
+         <sd>Retrorockets automatically kick in and slow the pods.  Two of the small craft
+break through the clouds and land in the dense, steaming jungles.</sd>
+      </scene>
+      <scene n="128">
+         <setting>  VINE JUNGLE - YAVIN</setting>
+         <sd>The general's lifepod crashes through the foliage until it comes to rest in
+the middle of a large vine-covered tree.  He grabs the two micro-packs and
+climbs out of the lifepod, and onto a large moss-covered limb.  Han and
+Threepio run to the base of the huge tree.</sd>
+         <sp spk="HAN">
+
+Are you all right?</sp>
+         <sp spk="GENERAL">
+
+Fine...Any signal from Annikin?</sp>
+         <sp spk="HAN">
+
+Nothing yet.  I think they landed further south.</sp>
+         <sd>The general attaches a thin cable from his utility belt to the tree trunk, and
+slides to the ground.  Han takes the micro-packs from him.  The general looks
+around at the jungle.</sd>
+         <sp spk="GENERAL">
+
+This is dangerous country...We'd better stay together.</sp>
+         <sp spk="THREEPIO">
+
+The wildlife in the forbidden system is extremely hostile...Perhaps we should
+seek shelter?</sp>
+         <sd>Han inspects the power units of the micro packs.</sd>
+         <sp spk="HAN">
+
+Windy's unit is very low.  I can't tell if the unit is still functioning.</sp>
+         <sp spk="GENERAL">
+
+We have to find a place to revive them.  We'll start moving south.  We should
+find protection along that ridge.</sp>
+         <sd>The general grabs one of the micro-packs and starts off into the murky jungle.</sd>
+         <sd>Han and Threepio quickly follow.  The jungle is a strange and eerie, fog-laden
+purgatory.  Gruesome and unnatural sounds permeate this ghostly wasteland.
+Everyone is cautious, and on the alert for an unseen danger.</sd>
+      </scene>
+      <scene n="129">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Starkiller's lifepod is also caught in the limbs of a gargantuan tree.  The
+lifepod has been ripped in half by the crash landing.  The unconscious Jedi
+hangs half out of the damaged craft.  A two foot high insect-like creature
+scoots down a branch and onto the back of the dormant warrior.  The insect
+lets out a chilling hissing sound, and a slimy tube emerges from its hairy
+mouth, waking Starkiller.  He is immediately aware of the insect.  His eyes
+are open, but he doesn't move.  Suddenly, with one quick blow, he knocks the
+creature against the side of the spacecraft, and it is squashed lifeless.</sd>
+         <sd>Starkiller is a little groggy, but he manages to climb out of the wreckage.
+He looks around for Artwo.</sd>
+         <sp spk="STARKILLER">
+
+Artwo!  Artwo Detwo!</sp>
+         <sp spk="ARTWO">
+
+Help!</sp>
+         <sd>Starkiller turns and sees the little robot hanging upside down, one of his
+three feet caught in a vine.  He lifts Artwo out of his predicament and places
+him securely on a wide limb.</sd>
+         <sp spk="STARKILLER">
+
+Did you see Leia?</sp>
+         <sp spk="ARTWO">
+
+She landed on the other side of those trees, approximately eight hundred
+meters.</sp>
+         <sp spk="STARKILLER">
+
+Well, come on, old buddy.  Let's get ourselves out of this tree.</sp>
+      </scene>
+      <scene n="130">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general, Han and Threepio reach a shallow cave near the top of a steep
+ridge.  They quickly pull off the micro-packs and place them on a clear piece
+of ground at the mouth of the cave.</sd>
+         <sp spk="GENERAL (to Han)">
+
+Check out the inside.  Threepio, stand guard.  Keep your eyes on the
+countryside.</sp>
+         <sd>He looks at the power units on the micro-packs and shakes his head with a
+worried look.  Han returns from a survey of the inside of the cave.</sd>
+         <sp spk="HAN">
+
+It doesn't go very far.  There's nothing back there.</sp>
+         <sp spk="GENERAL">
+
+Help me with this.</sp>
+         <sd>Han helps the general lift the top from the case containing Windy, the younger
+of the two princes.  The small boy appears lifeless as the general pulls him
+from his encasement, and rests him on the cave floor.  Han pulls a small
+respiration out of the micro-packs and places it over the boy's nose.  The
+general attaches two electrodes over his heart.</sd>
+         <sp spk="HAN">
+
+He doesn't look good.</sp>
+         <sd>The little prince begins to turn blue.  The general grows tense.  Windy starts
+to regain consciousness, but begins coughing and choking, then goes limp
+again.  The general quickly props Windy's mouth open with a small plastic rod
+and checks the reading on his power pack.</sd>
+         <sp spk="GENERAL">
+
+We need more power...tap off Biggs' unit...Quickly!</sp>
+         <sd>He then places Windy's arms behind his back and starts pressing on his chest
+with sharp, rhythmic movements.  Han attaches new electrodes to the boy's
+heart.  Windy again comes to, choking and coughing.  Finally, he begins to
+cry.  The general takes the plastic tube from his mouth and tenderly pats him
+on the back.</sd>
+         <sp spk="GENERAL">
+
+Let's get Biggs out of there.  He shouldn't be a problem.</sp>
+      </scene>
+      <scene n="131">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Starkiller slams closed the hatch of Princess Leia's lifepod.  In the
+distance, the subhuman cries of lonesome tree beasts cut through the forest
+murmur.</sd>
+         <sp spk="ARTWO">
+
+Perhaps she went in search of us.</sp>
+         <sd>Starkiller studies the ground around the capsule.  There are a great many
+footprints, and much broken foliage.</sd>
+         <sp spk="STARKILLER">
+
+Someone's got her.  She put up quite a fight...It's an easy trail to follow.</sp>
+      </scene>
+      <scene n="132">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Both Biggs and Windy are sleeping restlessly on the floor of the cave.  Han
+watches over them as the general scans the valley below with a pair of
+electrobinoculars.</sd>
+         <sp spk="THREEPIO">
+
+It's about fourteen degrees below the horizon... a little to the left.</sp>
+         <sd>The electrobinoculars sweep the rich green landscape until the come to rest on
+a bright reflection, revealing some type of structure.</sd>
+         <sp spk="GENERAL">
+
+It's too small to be a military base...Could belong to a trapper.</sp>
+         <sp spk="THREEPIO">
+
+Highly unusual...</sp>
+         <sp spk="GENERAL">
+
+It's on the way.  Perhaps we should investigate.</sp>
+         <sd>Little Biggs wakes up with a giant yawn.</sd>
+         <sp spk="BIGGS">
+
+Hey!  Where are we?</sp>
+      </scene>
+      <scene n="133">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>The gargantuan trees are shrouded in mist, and the ominous sounds of unearthly
+creatures fill the air.  Starkiller moves quietly and cautiously, followed by
+Artwo, who inadvertently makes a loud clicking sound.  The young warrior
+stops, and motions to the stubby little robot.</sd>
+         <sp spk="STARKILLER">
+
+Wait here.  If I don't return by zero two hundred, come looking for me.</sp>
+         <sd>The mechanical dwarf acknowledges with his computer light.  Starkiller moves
+swiftly and silently forward, until he hears laughing and voices.  He climbs
+up the bankside of a huge tree, and inches his way out onto one of the huge
+overhanging branches.  Below him, he can see a group of scruffy, alien
+trappers sitting around a nutron stove joking and telling stories.  Parked on
+either side of the group are two large, tank-like "jungle crawlers."  Behind
+the crawlers, five Wookees, (huge grey and furry beasts) hang upside down in a
+tree.  Occasionally, they thrash about in great anger and frustration.</sd>
+         <sd>The trappers speak in a strange language, and although they appear slightly
+human, they are slimy, deformed, hideous looking creatures.  Two of the
+trappers yell at one another in a friendly argument.  One shirtless creature
+goes into a "crawler," and the remaining eight laugh hysterically.  Starkiller
+moves further out on the limb to get a better view.  A couple of pieces of
+bark break loose, and float a hundred feet to the ground.  The trappers fail
+to notice.  Moments later, the shirtless trapper emerges from the crawler with
+Princess Leia held unconscious and half naked over his head.  Starkiller's
+rage knows no bounds.  With a terrifying Jedi war cry, the young captain jumps
+from the tree, sails over a hundred feet, and with great agility, lands in the
+middle of the startled trappers.  In one continuous rapid motion, he ignites
+his lasersword and cuts down three of the vile creatures.  The shirtless
+trapper swings the princess over his shoulder, and runs back into the huge
+"jungle crawler."  Two other trappers reach for their pistols, but the Jedi
+has killed them before their weapons can clear leather.  The three remaining
+creatures have their pistols out and start firing.  Explosions erupt all
+around Starkiller.  One blast hits the branch holding the Wookees, and they
+collapse with a loud screech in a heap.  One of the trappers is caught in the
+crossfire and is blown apart.</sd>
+         <sd>When the smoke clears, Starkiller lies unconscious amid the burning rubble.
+The jungle crawler begins to move out of the camp.  The last two trappers run
+after it.  One is able to jump on board, but the second trapper runs too close
+to the now freed Wookees.  Chewbacca, one of the furry giants, grabs him and
+snaps him in two, like a stick of wood.  The jungle crawler disappears in the
+forest mist.  The eight foot Chewbacca, who resembles a huge, grey bushbaby
+with fierce baboon-like fangs, struggles to free his companions.</sd>
+         <sd>Starkiller regains semiconsciousness, and attempts to get up, only to groan
+and collapse back into unconsciousness.  The Wookees gather around him and
+poke him a couple times to see if he is still alive.  They squawk and jabber,
+apparently in some kind of argument.  Finally, Dewanna, the largest of the
+Wookees, picks up Starkiller and puts him over his shoulder.  The group
+disappears into the jungle foliage.</sd>
+      </scene>
+      <scene n="134">
+         <setting>  TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Han and Threepio carry the two little boys on their shoulders.  The general
+stops on the edge of a clearing, and motions for the others to be still.
+Biggs turns around, and signals his little brother to be quiet.  On the
+opposite side of the clearing, a small metal structure is attached to one of
+the huge trees.  It is a small, weatherbeaten hut of futuristic design.  It
+appears deserted.  The general cautiously approaches the structure.</sd>
+         <sp spk="VOICE">
+
+Howdy stranger...What can I offer you?</sp>
+         <sd>The general spins around and sees Owen Lars, an aged and scruffy looking
+anthropologist.</sd>
+         <sp spk="LARS (con't)">
+
+I'm Owen Lars of Bastine.</sp>
+         <sd>The general takes the old man's extended hand.</sd>
+         <sp spk="GENERAL">
+
+I'm Luke Skywalker of Aquilae.</sp>
+         <sd>He signals for the others to join him in the clearing.</sd>
+      </scene>
+      <scene n="135">
+         <setting>  WOOKEE CAMP - YAVIN</setting>
+         <sd>The small caravan of Wookees, led by Chewbacca, enters a small clearing
+surrounded by many bark and mud hovels.  Young Wookees race ahead of the group
+yelling, and running in and out of the grubby little dwellings.  Giant,
+bushbaby-like Wookees of all ages and sizes, make their way into the clearing.</sd>
+         <sd>Many stand dumbfounded, but others let out a joyful scream and rush up to
+members of the group, hugging and kissing them.</sd>
+         <sd>Dewanna dumps the unconscious Starkiller on a raised area in the middle of the
+clearing.  Armed Wookees immediately surround the helpless human.  Chewbacca
+enters the largest of the lodges.  He is greeted by his father, Auzituck,
+Chief of the Kaapauku tribe; an old and feeble Wookee dressed in royal skins
+and headdress.</sd>
+      </scene>
+      <scene n="136">
+         <setting>  INTERIOR - ANTHROPOLOGIST HUT - YAVIN</setting>
+         <sd>Anthropologist Lars, the general, Han and the children sit around a large
+table eating.  Lars yells into the kitchen.</sd>
+         <sp spk="LARS">
+
+Beru!  Where's the thanta sauce?</sp>
+         <sd>Beru Lars, Owen's warm, plump wife, enters, carrying a small pitcher.  She
+smiles at Owen.</sd>
+         <sp spk="BERU">
+
+I swan!  I put it right here in front, so you'd see it...<sd>to Han</sd>  Here's some
+Bum Bum extract.  It's very mild...</sp>
+         <sp spk="LARS (to general)">
+
+There are no settlers to the south since the Dau family was wiped out... I'm
+afraid I couldn't even get in there to bury them... Those Wookees are the
+fiercest critters I've ever run across.  A new tribe moved in down there about
+a year ago...and it's been hell ever since.  Only Yourellian trappers venture
+in there now, and many of them don't even come back.</sp>
+         <sp spk="GENERAL">
+
+Where's the nearest city?</sp>
+         <sp spk="LARS">
+
+No cities at all...only a few scattered settlers and -- one Imperial
+outpost... But the troops are of no help.  They kill and plunder rather than
+protect...Enough...If your friends landed father south, I'd fear for them.</sp>
+         <sp spk="HAN">
+
+How far is the outpost from here?</sp>
+         <sp spk="LARS">
+
+Five leagues...an oppressive blight.</sp>
+         <sp spk="GENERAL">
+
+What class is it?  How many support craft?</sp>
+         <sp spk="LARS">
+
+It's very small, a class two....Only ten or twelve starraiders, I think.</sp>
+         <sd>Beru fusses over the boys, who refuse to eat their vegetables.  She makes up a
+game, which tricks them into eating.  The general ponders the situation.  Han
+eats, like he hasn't eaten in years.</sd>
+      </scene>
+      <scene n="137">
+         <setting>  WOOKEE CAMP - AQUILAE [??  Yavin?]</setting>
+         <sd>Starkiller is surrounded by Wookees.  Young ones push through to get a better
+look, as the adults jabber and argue about the human.  Starkiller regains
+consciousness with a groan, and a sudden hush sweeps over the gathering.
+Starkiller staggers to his feet, and the group of Wookees back away in mass.
+The young Jedi surveys the situation for a few moments.  The Wookees appear to
+be frightened of this brave warrior.  He reaches for his weapons, but they are
+gone.  Three guards with long spears attempt to contain Starkiller.  With a
+loud shout, he lunges at them, and they give him a little room.</sd>
+         <sd>Jommillia, a large, ferocious Wookee, steps forward.  He says something to the
+guards, and they quickly move away.  He struts before Starkiller, boasting and
+taunting him with his spear and battle ax.  The captain studies the Wookee
+warrior as he paces back and forth, his helmet plumes dancing and chest armor
+jangling.  Without warning, Starkiller lets out another loud yell, startling
+Jommillia into backing off.  Starkiller continues his verbal assault, calling
+the uncomprehending Wookee all manner of vile and degrading things.  Jommillia
+continues to back into the surrounding crowd, momentarily confused by this odd
+behaviour.  Slowly, Jommillia begins to grin.  He takes a defensive stance,
+then begins to laugh hysterically.  This stops Starkiller.  The giant Wookee
+swings his deadly, double-bladed battle ax over his head and expertly throws
+it directly at the young captain's head.  To the amazement of Jommillia and
+the other Wookees, Starkiller, with Jedi skill and concentration, catches the
+ax in mid-air, then charges his furry opponent.</sd>
+         <sd>Jommillia is caught off-guard, but manages to block Starkiller's attack with
+his spear.  The two warriors engage in a savage and fantastic duel.
+Starkiller cuts the Wookee's spear in half, but is hit along the side of the
+head by the shaft and is momentarily dazed.  The battle ax is knocked from his
+hands.  He grabs the spear shaft and rams the giant creature in the belly.  A
+loud command from outside the crowd stops the fight.  The Wookees part,
+revealing Chewbacca and his father, who approach the two warriors.  Jommillia
+bows before his chief, and is commanded to move away.  Chewbacca speaks to
+Starkiller.  He doesn't understand, but welcomes the chance to catch his
+breath.  Chewbacca then presents his father, who steps forward and bows before
+the mighty Jedi.  Chewbacca bows also, as the crowd of Wookees chatter in
+disbelief.  When the chief and his son rise, Starkiller bows down before them.</sd>
+         <sd>This pleases the Wookees, and they screech and cheer.</sd>
+      </scene>
+      <scene n="138">
+         <setting>  TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Mr. and Mrs. Lars stand on the balcony of their tree house with Threepio and
+the two little princes, Biggs, and Windy.  Han and the general emerge with
+large survival backpacks and multiplelaser weapons.</sd>
+         <sp spk="GENERAL (to Threepio)">
+
+We'll call for you when we've found them.</sp>
+         <sp spk="THREEPIO">
+
+Your orders are quite clear.  The boys will be quite safe.</sp>
+         <sp spk="LARS">
+
+Don't worry.  The patrols never come out this far.  We'll take good care of
+the boys.</sp>
+         <sp spk="GENERAL">
+
+Lars, your kindness will surely be rewarded.</sp>
+         <sp spk="LARS">
+
+Just be careful out there...</sp>
+         <sd>He pats Skywalker on the back as the old Jedi and the ever faithful Han
+descend from the tree house.  [something whited out?]  At the base of the huge
+tree, the warriors climb aboard two small rocket powered platforms.</sd>
+         <sp spk="LARS (yelling down to them)">
+
+They're pretty old.  I hope they'll be all right!</sp>
+         <sp spk="GENERAL">
+
+Out here, they're a wonderment.</sp>
+         <sd>Threepio and the kids wave as the jelsticks start with a whine.  They idle
+about five feet above the ground.</sd>
+         <sp spk="LARS">
+
+Good hunting.  May the force of others be with you.</sp>
+         <sd>Han and the general wave as they ride off into the foreboding Yavin sunset.</sd>
+      </scene>
+      <scene n="139">
+         <setting>  WOOKEE CAMP - YAVIN - NIGHT</setting>
+         <sd>A beautiful, but frenzied fire festival is underway.  Wookees perform the
+Waita Tar dance, and yodel in a barking fashion around a large fire.  The
+female Wookees arrive, carrying torches, and move in a circle around the
+males.  The giant creatures are too involved to notice that little Artwo makes
+his way around the dancers.  The stubby robot stops near one of the mud huts,
+and looks around.  He then wobbles off toward the large chief's quarters, and
+enters.</sd>
+      </scene>
+      <scene n="140">
+         <setting>  WOOKEE CAMP - YAVIN - MORNING</setting>
+         <sd>Artwo exits the chief's hut and looks around.  It is a quiet, grey morning.  A
+low mist hangs over the now deserted clearing.  He turns and signals back into
+the hut.  Starkiller cautiously emerges from the mud house.  he wears a crude
+backpack, and carries a large battle ax.  They start across the clearing.
+Suddenly, out of nowhere, Chewbacca is standing before them.  He says nothing,
+but scratches his head and then circles around Starkiller.</sd>
+         <sp spk="STARKILLER">
+
+We are leaving...We must go.  Stand away!</sp>
+         <sd>The huge Wookee kneels and bows down in front of the young Jedi.  Starkiller
+looks down and smiles.</sd>
+         <sp spk="STARKILLER">
+
+Rise my friend.  We will meet again.</sp>
+         <sd>Starkiller walks toward the jungle and Chewbacca scurries ahead of him and
+bows down once more.</sd>
+         <sp spk="ARTWO">
+
+What does he want?</sp>
+         <sd>Starkiller shakes his head, and rubs his several days growth of beard.  He
+leans down toward Chewbacca.</sd>
+         <sp spk="STARKILLER">
+
+Stand up so we can talk properly.</sp>
+         <sd>Chewbacca jabbers in a [something whited out] questioning fashion.</sd>
+         <sp spk="STARKILLER">
+
+I am grateful to you and your people, but I must go.  I wish you understood
+me.  It would make things so much easier.  Go!  Go!</sp>
+         <sd>Starkiller turns away, and begins to walk toward the jungle again.  Chewbacca
+gets to his feet, and runs after the Jedi, following a few paces behind.
+Starkiller notices the Wookee following them, and shakes his head.</sd>
+      </scene>
+      <scene n="141">
+         <setting>  FOREST OF THE GARGANTUANS - TRAPPER SIGHT [sic] - YAVIN</setting>
+         <sd>The bodies of the killed trappers are covered with rat-sized insects.  A laser
+explosion erupts in the middle of the slimy creatures and they scatter into
+the underbrush.  Han and the general turn over one of the dead trappers.</sd>
+         <sp spk="HAN">
+
+They ran into something.</sp>
+         <sp spk="GENERAL">
+
+It's strange they left their dead.  Something...</sp>
+         <sd>The constant cacophony of jungle creatures suddenly stops.  The two warriors
+scan the jungle for possible danger.  Han draws his laserpistol.  The
+cacophony starts again, as the general ignites his lasersword.</sd>
+         <sp spk="HAN">
+
+Two or three moving this way, from the east.</sp>
+         <sd>He listens more closely for a few moments.</sd>
+         <sp spk="HAN (con't)">
+
+It's Artwo!</sp>
+         <sd>Starkiller and Artwo break out of the dark foliage into the clearing.  He
+waves to Han and the general.  Artwo waddles a few paces behind.  Chewbacca
+sees the humans and stops at the edge of the jungle.  He watches as Starkiller
+and the general carry on an animated conversation.  Han sees the Wookee
+lurking in the shadows.</sd>
+         <sp spk="HAN">
+
+You were followed.</sp>
+         <sp spk="STARKILLER">
+
+He wouldn't stay.  He's one of the ones I saved...</sp>
+         <sd>Han calls out to Chewbacca in the Wookee's own language, and the huge,
+lumbering creature approaches the group.  Han and the Wookee talk for a few
+moments, then embrace as if they were old friends.  Starkiller is surprised.</sd>
+         <sp spk="HAN (to Starkiller)">
+
+This is Chewbacca, son of Auzituck, Prince of the Sawas, a very powerful
+tribe.  It seems they've made you a god.</sp>
+         <sd>The general smiles.  Starkiller is embarrassed.</sd>
+      </scene>
+      <scene n="142">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Starkiller joins the general on a ridge overlooking the Imperial outpost of
+Mavassi.  All that can be seen of the fortress is a lone guard standing on a
+small pedastal, jutting out above the dense jungle.</sd>
+         <sp spk="GENERAL">
+
+Their trail leads directly to the outpost.  Patrols are probably out looking
+for us by now.</sp>
+         <sp spk="STARKILLER">
+
+Finding her in there isn't going to be easy.</sp>
+         <sp spk="GENERAL">
+
+Getting in there is going to be impossible.  We could sure use one of those
+starships.</sp>
+         <sd>Starkiller spots something moving in the jungle.  He scans the area with his
+electrobinoculars.</sd>
+         <sp spk="STARKILLER">
+
+Something's going on down there...Han!</sp>
+         <sd>Han moves up next to Starkiller, followed closely by Chewbacca.</sd>
+         <sp spk="STARKILLER">
+
+Your eyes are better than mine....What do you make of that?</sp>
+         <sp spk="HAN">
+
+They look like Wookees...hundreds of them.</sp>
+         <sd>Han turns and speaks to Chewbacca, gesturing toward the movement far below in
+the jungle.</sd>
+         <sp spk="HAN">
+
+Apparently, it's a siege.  They've been harassing the outpost for almost two
+years.</sp>
+         <sp spk="GENERAL">
+
+Have they ever tried to take the fortress?</sp>
+         <sd>Han relays this to Chewbacca.</sd>
+         <sp spk="HAN">
+
+He says they've made several assaults, but they are no match for the weapons.</sp>
+         <sp spk="GENERAL">
+
+It's only a class three fortress.  Maybe they just need a little help.</sp>
+         <sd>Starkiller grins, and Han says something to Chewbacca, who becomes excited and
+screeches loudly.</sd>
+      </scene>
+      <scene n="143">
+         <setting>  INTERIOR - TREEHOUSE - YAVIN</setting>
+         <sd>The incoming signal alarm on the anthropologist's radio system wails through
+the calm of the tree house.  Biggs, dragging an eight-legged, furry rodent,
+rushes up to the old radio and flips the receiver.</sd>
+         <sp spk="BIGGS">
+
+I'm reading yah.  Go ahead.</sp>
+         <sp spk="GENERAL">
+
+Biggs, how are you getting along?</sp>
+         <sp spk="BIGGS">
+
+Great!  I caught a thumper...a really big one.  Its name is "Amber."</sp>
+         <sd>He yanks on the leash, and the furry beast lets out a strained yelp.</sd>
+         <sp spk="GENERAL">
+
+Good, Biggs.  How's your brother?  Are you taking good care of him?</sp>
+         <sp spk="BIGGS">
+
+Oh, sure.  He's out collecting "Abas" with Owen and Beru.  I'm in charge here.</sp>
+         <sd>Did you find Leia?</sd>
+         <sp spk="GENERAL">
+
+Not yet.  We'll be away for a while.  You mind Lars until we return.  May the
+force of others be with you.</sp>
+         <sp spk="BIGGS">
+
+All right.  Take care.</sp>
+         <sd>Threepio enters the room, carrying a plate of steaming food.  Biggs turns the
+radio off, and puts the receiver away.  A crashing sound and voices are heard
+in the clearing below.</sd>
+         <sp spk="THREEPIO">
+
+Come and eat your dinner.</sp>
+         <sp spk="BIGGS">
+
+They're back!  They're back!  Come Amber!</sp>
+         <sd>The furry rodent jumps up onto its eight stubby legs and rushes over to the
+door, but stops short, and begins to growl.  Biggs stops behind the creature.</sd>
+         <sp spk="BIGGS">
+
+What is it, Amber?</sp>
+         <sd>Biggs peeks out the window, and sees a patrol of six Imperial stormtroopers
+climbing out of an airtank.  He ducks back, and tugs Amber away from the door.</sd>
+         <sp spk="BIGGS">
+
+Quiet, Amber.  Come here.  Come on.</sp>
+         <sp spk="THREEPIO">
+
+What's wrong?</sp>
+         <sp spk="BIGGS">
+
+Troopers.  We must hide!  Stay quiet.</sp>
+         <sd>Biggs and the robot scramble for a trap door near a large shelf.  The troops
+begin to climb the ladder to the tree house.  The trap door is heavy, and the
+robot and the little boy struggle to get it open.  The troops break in the
+door, just as Threepio closes the trap door.  The stormtroopers are led by a
+rough looking sergeant.  They poke around, tearing everything apart.  Biggs
+struggles to keep Amber quiet.  Suddenly he realizes something.</sd>
+         <sp spk="BIGGS">
+
+The food!</sp>
+         <sd>The sergeant takes the bowl of food from the table and studies it.  He then
+takes a small chrome ball from his pocket, and tosses it into the air.
+[something whited out?]  Antennae shoot from its surface as it floats around
+the room.  Eventually, it hovers over the trap door.  A sinister grin sweeps
+across the sergeant's face as he moves over to the trap door and puts the
+chrome ball back into his pocket.</sd>
+         <sd>Threepio puts his arm around Biggs who is desperately clutching the struggling
+thumper.  All the movement above them stops, and Biggs looks to the robot.</sd>
+         <sp spk="THREEPIO (quietly)">
+
+They're still up there.  Stay still.</sp>
+         <sd>The silence continues, then suddenly the trap door swings open with a loud
+bang.  Amber breaks away from Biggs, and attacks the sergeant.  One of the
+other troopers cuts the thumper in half with his lasersword.  The sergeant
+pulls Biggs out of his hiding place.  Biggs stares at the dead thumper.</sd>
+         <sp spk="SERGEANT">
+
+Well, well, here's one of them, anyway.  Send seekers in all directions.  Find
+the others!</sp>
+      </scene>
+      <scene n="144">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general sits at the head of the large stone table, pushing small markers
+around.  Han explains what the general is doing, to ten or fifteen Wookee
+chiefs gathered around the table.  Occasionally, Chewbacca puts in a word of
+further explanation or answers a question.  Starkiller sits back silently
+watching the Wookee warriors and listens to the general's plan.</sd>
+         <sp spk="GENERAL">
+
+.... then they pull back to here.  That's where the trap will be set.  No-one
+must advance.  An assault on the perimeter is useless.  Our only hope is to
+use their weapons against them.</sp>
+         <sd>The general pauses, while Han and Chewbacca translate.</sd>
+         <sp spk="GENERAL (to Starkiller)">
+
+Once we acquire those tanks, our prime object must be to secure the starship.
+No-one must escape.</sp>
+      </scene>
+      <scene n="145">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three officers run along a row of giant air tnaks to a perimeter bunker.
+There, two stormtroopers are watching the jungle.  When the officers arrive,
+the troopers let them look through the powerful, mounted electrobinoculars.
+One of the troopers points out several areas in the dense jungle.</sd>
+      </scene>
+      <scene n="146">
+         <setting>  INTERIOR - CONTROL ROOM - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>A trooper sitting at an elaborate control panel, turns to an officer watching
+a monitor system.</sd>
+         <sp spk="TROOPER">
+
+A large concentration of trestuals at point E-2.</sp>
+         <sp spk="OFFICER">
+
+Alert squads one through six!</sp>
+      </scene>
+      <scene n="147">
+         <setting>  VINE JUNGLES - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands in a small clearing surrounded, by many armed Wookees
+carrying large shiny shields.  Han moves back and forth, barking orders to the
+assembled creatures.</sd>
+         <sp spk="GENERAL (to Han)">
+
+We're ready.  Give them the signal.</sp>
+         <sd>Han motions to a young Wookee, who takes off, running through the jungle.</sd>
+      </scene>
+      <scene n="148">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three large air tanks slowly move toward the outpost perimeter.  The tank
+pilots sit on the hatch rims of the ponderous weapons, studying the movements
+of the Wookees.  The tank personnel talk to one another on an intercom system.</sd>
+         <sp spk="TANK PILOT">
+
+There is a large concentration....red two by C-3.  Let's break them up.</sp>
+         <sd>The pilots slip into the tanks and close the hatches.  The tanks open up with
+a barrage of laser bolts which create a wall of explosions.  The Wookies
+retreat, and the tanks follow.  The tank crews track the feeling creatures
+with various electronic scopes, and laugh at the fleeing creatures.</sd>
+      </scene>
+      <scene n="149">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands on a limb of a jungle tree, watching the advancing tanks.
+Starkiller is on another branch a few feet away.</sd>
+         <sp spk="GENERAL">
+
+They've grown sloppy fighting Wookees.  The intra-fazer systems aren't on.
+They're in for a little surprise.</sp>
+         <sd>Starkiller flashes a signal mirror, which is received by a Wookee near the
+tanks.  The Wookees are in pairs, and they hold heavy stone wedges attached to
+woven vines; which in turn, are fastened high in the trees.  When the tanks
+pass directly under the Wookees, they let loose with the heavy stone
+pendulums.  The wedges fly through the air, neatly clipping off the antenna
+groupings protruding from the tops of the air tanks.</sd>
+      </scene>
+      <scene n="150">
+         <setting>  INTERIOR - AIR TANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Several of the lights and monitors go dark on the main control panel.  The
+pilot flips several switches in a panic.</sd>
+         <sp spk="PILOT">
+
+All high phasing units are out.  We've lost all contact....</sp>
+         <sp spk="SERGEANT">
+
+Send out a ground signal!</sp>
+         <sd>Suddenly, all of the monitors go white, and static fills the crowded tank
+interior.  An alarm signal sounds.</sd>
+         <sp spk="SERGEANT">
+
+What is it?!!!</sp>
+         <sp spk="PILOT">
+
+All signals...sensers....everything is coming right back to us.  Some kind of
+deflection screen.  It's a total blackout.</sp>
+         <sp spk="SERGEANT">
+
+Get out there and see if you can see anything.</sp>
+         <sd>The pilot pushes a button and the main hatch slowly slides away.</sd>
+      </scene>
+      <scene n="151">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The pilot pops out of the hatch and sses two rows of Wookee warriors holding
+reflective shields.  They form a circle that totally encompasses the massive
+air tank.  Han shouts a signal to a group of Wookees in another tree, and they
+cut loose a bent limb which is attached to a noose around the tank's hatch.
+The noose instantly tightens around the pilot, and he is plucked from the tank
+and suspended fifty feet in the air.  In an equally swift move, Starkiller
+drops a small gas grenade into the open hatch.  It explodes and engulfs the
+tank in a grey mist.</sd>
+         <sd>The Wookees let out a joyful yell, and charge the tank.  Han yells at them to
+stop, but several make it to the conquered craft before the gas cloud
+dissipates and they are felled by the fumes.  Starkiller shakes his head, then
+after the smoke clears, jumps on the back of the immobile tank.</sd>
+         <sd>Several signal mirrors flash their messages to Han and the general.</sd>
+         <sp spk="HAN">
+
+That makes four captured.</sp>
+         <sp spk="GENERAL">
+
+Have them camouflaged.  I'm going with Starkiller.</sp>
+      </scene>
+      <scene n="152">
+         <setting>  INTERIOR - AIR-TANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Wookees are removing the tank crew as Starkiller checks out the power
+controls.  The general slides through the main hatch.</sd>
+         <sp spk="GENERAL">
+
+Any damage?</sp>
+         <sp spk="STARKILLER">
+
+She's fine...We're ready to move.</sp>
+         <sp spk="GENERAL">
+
+Then let's go...</sp>
+         <sd>The general yells for the Wookees to clear the tanks, and they scramble out of
+the hatch.</sd>
+      </scene>
+      <scene n="153">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The tank starts up with a loud roar, startling the many Wookees resting on the
+mighty vehicle.  Chewbacca yells at the warriors and they fall a few feet
+behind the tank, their shields forming a shiny protective wall.</sd>
+      </scene>
+      <scene n="154">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Several officers stand on a parked air-tank trying to get a better view of the
+operation.  A light landspeeder pulls up next to the group, and a general gets
+out.  The officers snap to attention.</sd>
+         <sp spk="GENERAL">
+
+Can you see anything?</sp>
+         <sp spk="OFFICER">
+
+No Sir, but they've stopped firing.</sp>
+         <sp spk="AID [sic]">
+
+Communications still can't reach them, Sir.</sp>
+         <sp spk="GENERAL">
+
+Nobody seems to know what's going on.</sp>
+         <sp spk="OFFICER">
+
+I'm sure they've got them on the run, Sir.</sp>
+         <sd>A laserbolt flashes out of the jungle and knocks out a guard tower about a
+quarter of a mile from where the men are standing.  Seconds later, the air-
+tank on which they are standing explodes into a million pieces.  Out of the
+jungle, rumbles the captured air-tank, driven by Starkiller and followed by a
+column of Wookee warriors.</sd>
+         <sd>Alarms sound, troops rush from the low block houses, and a battle rages inside
+the outpost.  Wookees with spears, axes, and arrows, manage to hold their own
+against the laser weapons of the stormtroopers.  Explosions erupt everywhere,
+as the Wookees begin to use captured laserrifles.  They are much fiercer
+fighters than the soft Imperial troops.</sd>
+      </scene>
+      <scene n="155">
+         <setting>  INTERIOR - AIR-TANK - OUTPOST - YAVIN</setting>
+         <sd>Starkiller works the controls of the air-tank as the general watches the
+monitors, and works the laserguns.</sd>
+         <sp spk="GENERAL">
+
+Swing left.  They're trying to cut us off.</sp>
+      </scene>
+      <scene n="156">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Starkiller maneuvers the air-tank in front of a line of ten starships, cutting
+off a platoon of stormtroopers.  The troops open fire on the tank, but are cut
+down by a group of Wookees who have moved in behind them.  Han and Artwo run
+up to the tank as Starkiller and the general climb out of the hatch.</sd>
+         <sp spk="HAN">
+
+We've taken the main control center.  All power units have been shut down.
+They're helpless.</sp>
+         <sp spk="STARKILLER">
+
+Have they found Leia?</sp>
+         <sp spk="HAN">
+
+They've taken her back to Aquilae.  The ship left not more than ten hours ago.</sp>
+         <sp spk="GENERAL (to Han)">
+
+Set up a perimeter around these starships...Use as many men as you need.</sp>
+      </scene>
+      <scene n="157">
+         <setting>  STAFF OFFICE - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Starkiller and the general sit at a large table in the deserted office of the
+Imperial Chief of Staff.  The room is in a state of disarray; papers are
+scattered everywhere.  Artwo stands on a chair, projecting an image of the
+"death star" fortress orbiting Aquilae, on the table top.</sd>
+         <sp spk="ARTWO">
+
+....And are connected to the central system by a series of crossing networks
+similar to section TB4 or F687.</sp>
+         <sd>The projection switches to a close-up view of the transformer.  The general
+studies it carefully, then leans back in his chair.  Artwo turns off the
+projector.</sd>
+         <sp spk="GENERAL">
+
+I'm not going to stop you, but I think it's a reckless move.  Even if you
+could get in, you'd never be able to get out... Just be patient.  We now have
+enough ships to attack in force.</sp>
+         <sp spk="STARKILLER">
+
+But no pilots...</sp>
+         <sd>Han and Chewbacca enter the office.</sd>
+         <sp spk="HAN">
+
+Still no contact with Owen Lars or the kids...I'm afraid something's happened.</sp>
+         <sp spk="GENERAL">
+
+Have Chewbacca send two of his best warriors out there to get them.</sp>
+         <sd>Han relates this to Chewbacca.  The general turns back to Starkiller, who
+watches Chewbacca leave the room.</sd>
+         <sp spk="STARKILLER (mocking)">
+
+They're fierce warriors, but you'll never teach them to fly.</sp>
+         <sd>The general gives him a stern look.</sd>
+         <sp spk="GENERAL">
+
+They'll fly, and Aquilae will be free.</sp>
+         <sp spk="STARKILLER">
+
+May the force of others be with you.</sp>
+         <sd>The general embraces the young Jedi.</sd>
+         <sp spk="GENERAL">
+
+Bring her back safely.</sp>
+      </scene>
+      <scene n="158">
+         <setting>  OUTPOST RUNWAY - STARSHIP - YAVIN</setting>
+         <sd>Starkiller, dressed as an Imperial skyraider, and Artwo climb aboard one of
+the giant four-man starships.  A crowd of Wookees, lead by Chewbacca, give a
+rousing cheer for the departing Jedi.  Starkiller breaks into a smile and
+waves to the joyous warriors.  The general watches the proceedings from a
+bunker turret.  He is lost in thought.</sd>
+      </scene>
+      <scene n="159">
+         <setting>  SPACE FORTRESS - AQUILAE</setting>
+         <sd>Three Imperial space transports dock inside the huge artificial moon.  Two
+smaller convoy starships circle the larger craft until the three ships are
+safely inside the vast fortress.</sd>
+      </scene>
+      <scene n="160">
+         <setting>  CONFERENCE ROOM - INTERIOR SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader of the Imperial Space Fleet, hurries down a hallway, followed by
+a group of officers.  They enter the large conference room where Leia is held
+under heavy squad.  She appears well, but saddened.  Vader approaches her and
+bows  before her.</sd>
+         <sp spk="VADER">
+
+I pray you have been treated honorably?  I am your servant, Darth Vader.  It
+won't be long before we will be able to return you to your people.  (to an
+aide)  Are the chambers ready?</sp>
+         <sp spk="AIDE">
+
+They are working on it, Sir.</sp>
+         <sd>Leia stares defiantly at him.  She starts to speak, but a powerful electric
+shock engulfs her body, and she whines in extreme pain.</sd>
+         <sp spk="VADER">
+
+Just relax, and everything will be fine.  <sd>to guards</sd>  Take her to section
+twenty-five.</sp>
+         <sd>Leia is forcibly taken from the room.</sd>
+         <sp spk="VADER (to officer)">
+
+What time do the doctors from Alderaan arrive?</sp>
+         <sp spk="OFFICER">
+
+Sixty-five hours, Sir.</sp>
+         <sp spk="VADER">
+
+Put all security stations on alert until they arrive.</sp>
+         <sd>The officer salutes smartly, and exits.</sd>
+      </scene>
+      <scene n="161">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>A huge air tank rumbles along the approach to the Imperial outpost.  The pilot
+sits on the main hatch of the tank, talking to his crew, by headphones.</sd>
+         <sp spk="PILOT">
+
+Any contact yet?... It appears deserted...I don't like it.</sp>
+         <sd>The tank enters the outpost perimeter and smoking rubble from the recent
+battle comes into view.  The pilot becomes alarmed.</sd>
+         <sp spk="PILOT">
+
+There has been an attack!  Reverse direction.</sp>
+         <sd>The tank comes to a grinding halt, but before it can start up again, it is
+surrounded by the Wookee army.  From out of nowhere, a Wookee is on the back
+of the air-tank and has the pilot in a powerful armlock.</sd>
+         <sd>A Wookee chieftain rushes from a bunker, followed by an excited, jabbering
+warrior.  They reach the captured air-tank just as the last crewman is hauled
+out, and little Biggs pokes his head out of the hatch.  He is frightened.  His
+younger brother, Windy, follows him out of the tank.  Below them, the Wookees
+bully the captured crewmen.</sd>
+         <sp spk="WINDY">
+
+What will they do to us?</sp>
+         <sp spk="BIGGS">
+
+I don't know, but it don't look good.</sp>
+         <sd>Threepio pulls himself out of the air-tank, followed by Owen Lars and his
+wife.  The Wookee chieftain climbs on board, and starts to jabber at the
+group.  The Wookee carries on for some time, gesturing wildly, and continually
+pointing at the sky.  The two boys are too scared to say anything.  Finally,
+the Wookee kneels before them.  Threepio politely returns a short bow.</sd>
+         <sp spk="BIGGS">
+
+I don't get it.</sp>
+         <sd>The Wookee rises and again gestures skyward, just then a starship wildly
+buzzes the field, upsidedown.  All the Wookees run for cover.  The chief
+Wookee points to the crafts, and jabbers incessantly.</sd>
+      </scene>
+      <scene n="162">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - SKY OVER YAVIN</setting>
+         <sd>Chewbacca sits at the controls of a four-man starship.  His face is a twisted
+combination of complete panic and an awesome religious experience.  The
+general, sitting next to him, calmly switches a few buttons on the control
+panel, as Han watches from the seat directly behind the Wookee.</sd>
+         <sp spk="GENERAL">
+
+You'll get the hang of it.</sp>
+         <sd>Han also gives the Wookee a few words of encouragement.</sd>
+         <sp spk="GENERAL">
+
+Now, let's see if we can get into orbit...Push this, then ease her up.</sp>
+         <sd>Chewbacca follows the instructions, but pulls back on the lever too fast and
+the ships begins to vibrate and bounce violently.  Chewbacca thinks it's
+funny, and begins to laugh hysterically.  Han becomes nervous and quiet.</sd>
+         <sp spk="GENERAL">
+
+Not so fast - Back off!  Back off!</sp>
+         <sd>Han yells at the Wookee, who can't respond because he is laughing so hard.
+The general pulls back on the lever.  Han shakes his head, and gives the
+general a worried look.</sd>
+         <sp spk="GENERAL">
+
+Don't worry.  Ignorance is on their side.</sp>
+         <sd>Han is beginning to look a little sick.  He gets up and rushes to the back of
+the ship.</sd>
+      </scene>
+      <scene n="163">
+         <setting>  IMPERIAL SPACE FORTRESS - DOCKING AREA - AQUILAE</setting>
+         <sd>The canopy on the starship pops open, and Artwo and the young Jedi, disguised
+as a starraider, climb out onto the docking platform.  An officer and two
+groundcrew approach him and salute.  Starkiller hands him his papers.</sd>
+         <sp spk="STARKILLER">
+
+I'm here to check the vent ports in the rim tracks.</sp>
+         <sp spk="OFFICER">
+
+Your ship is from Yavin... We've lost all contact with them.  What's going on
+out there?</sp>
+         <sp spk="STARKILLER">
+
+There is a fierce inversion just east of Bull Pup station... It's really a
+mess out there.</sp>
+         <sd>The officer smiles and the ground crew starts to check out the starship.
+Starkiller heads for the main docking exit, followed by Artwo.  He remembers
+something as he passes the control station, and calls out to the officer.</sd>
+         <sp spk="STARKILLER">
+
+Do you mind if I use your com-link?</sp>
+         <sp spk="OFFICER">
+
+No.  Go ahead.</sp>
+         <sd>Starkiller walks into the small control area and pretends to talk on an
+intercom system.</sd>
+         <sp spk="STARKILLER (to Artwo)">
+
+Find the highest security area.</sp>
+         <sd>Artwo punches his claw arm into a computer socket, and the brain comes to
+life, feeding information to the little robot.</sd>
+         <sd>Starkiller watches the officer as he directs the crewmen in the securing of
+the starship.  Artwo removes his arm from the computer, and the duo leave the
+control station.</sd>
+         <sp spk="ARTWO">
+
+Station 325 is the highest security area on board.  It's a detention area.</sp>
+         <sd>They disappear into a chamber lock hallway.</sd>
+      </scene>
+      <scene n="164">
+         <setting>  ELEVATOR TUBE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller, trying to look inconspicuous, waits for a horizontal elevator.
+Troops and fortress personnel come and go, but no-one seems to pay any
+attention to the pair.  Finally a small car arrives, and Starkiller follows
+Artwo into the podlike vehicle, and it takes off through a vacuum tunnel.</sd>
+      </scene>
+      <scene n="165">
+         <setting>  DETENTION AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller and Artwo enter a security station.  Guards and electronic cutters
+are everywhere.  An officer approaches Starkiller, and checks his papers.</sd>
+         <sp spk="OFFICER">
+
+The B-23 can't enter this station.</sp>
+         <sp spk="STARKILLER">
+
+But I need him.</sp>
+         <sp spk="OFFICER">
+
+Sorry.  No mechanical personnel.  It's restricted.</sp>
+         <sd>Starkiller watches helplessly, as Artwo is led into a waiting area.</sd>
+         <sp spk="OFFICER">
+
+You may proceed, but you'll have to be escorted.</sp>
+         <sd>A trooper joins Starkiller and leads him through a series of hallways.
+Starkiller carefully surveys the area as he follows the guard.</sd>
+         <sp spk="TROOPER">
+
+Mathusians just beat the PDR's again.  They should be in another league.  Do
+you follow the ecometrics?</sp>
+         <sd>The guard turns to discover that Starkiller has disappeared.  He is stunned,
+then manages to pull out a small ring radio.</sd>
+         <sp spk="TROOPER">
+
+Code six - Alert.</sp>
+      </scene>
+      <scene n="166">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Six Wookees sit before Han and the general, listening to Han explain something
+about space fighting.  Owen Lars approaches the general.</sd>
+         <sp spk="LARS">
+
+We've made contact with the underground on Aquilae.  Things are tighter.  They
+can only get one man out.  Datos is on his way.</sp>
+         <sp spk="GENERAL">
+
+We should be ready by the time he arrives.</sp>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+
+They're ready to go up.</sp>
+         <sd>The general makes a short statement to the Wookes in their own language.  They
+let out a loud cheer, and run for the row of starships.</sd>
+      </scene>
+      <scene n="167">
+         <setting>  STARSHIP - SPACE - YAVIN</setting>
+         <sd>The general sits next to Chewbacca, as he leads two other Wookee piloted
+starships in a tight formation.  They head for a small cluster of asteroids
+orbiting near the planet's surface.  The general quietly gives Chewbacca some
+reassuring instructions.  Han leads a second formation of three ships,
+following Chewbacca's group.  The two formations of starships make an attack
+run on the asteroids.  The general watches as Chewbacca lines up and fires at
+an asteroid blowing it into a million pieces.  The general smiles, and slaps
+Chewbacca on the back.  The Wookees excitedly chatter among themselves over
+the intercom system.</sd>
+      </scene>
+      <scene n="168">
+         <setting>  DETENTION AREA HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>A patrol of ten men marches through one of the long hallways in the detention
+area.  They stop at an intersection.  The officer in charge reports on the
+intercom.</sd>
+         <sp spk="OFFICER">
+
+Ben Five to Moma.  All clear.</sp>
+         <sd>The troops relax, some stand in groups, others wander a distance away, poking
+into the various small alleyways running off the main hallway.  One trooper
+notices a small reflected light in one of the narrow corridors, and carefully
+moves down the dark passageway to check it out.  Out of no-where, a fist
+knocks the trooper unconscious and drags him into a small alcove.</sd>
+         <sd>The officer finishes his report on the intercom and yells for the troops to
+fall-in.  Men scurry in all directions and out of a narrow corridor emerges
+Starkiller, dressed in the uniform of an Imperial startrooper.  He joins the
+platoon, and they march away.</sd>
+      </scene>
+      <scene n="169">
+         <setting>  GENERAL'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader and several officers watch the progress of the search on TV
+monitors.  The general speaks into an intercom.</sd>
+         <sp spk="VADER">
+
+Have them clear the area.  Bring in the seekers.</sp>
+         <sd>On the monitors, the troops are assembled in the main entry-way and several
+small chrome balls are thrown into the hallway.  Small antennae pop from the
+chrome surface, and the small balls float down the hallways.  Valorum, once a
+proud Knight of the Sith, enters wearing the uniform of a stormtrooper.  He
+snaps to attention before the general, and hands him a report.  Vader gives
+Valorum a sly grin.</sd>
+         <sp spk="VALORUM">
+
+Contact has been lost with the ship carrying the doctors from Alderaan.  The
+princess' treatment will have to be delayed.</sp>
+         <sp spk="VADER">
+
+We've just trapped your own friend Starkiller.  Watch us accomplish what you
+found to be impossible.</sp>
+         <sd>Valorum is humiliated, but stays at attention.  Valorum [Vader?] gets an
+emergency call on the intercom.</sd>
+         <sp spk="VADER">
+
+Yes...Yes... Put it on the view screen.</sp>
+         <sd>One of the TV monitors switches to an image of the unconscious trooper
+Starkiller stripped.</sd>
+         <sp spk="VADER">
+
+Get me the Captain of the Guard.</sp>
+      </scene>
+      <scene n="170">
+         <setting>  DETENTION AREA - MAIN ENTRY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Three squads of troops including Starkiller, stand at attention in the main
+entrance to the detention center, while the Captain of the Guard gets new
+orders over his headphones.  Starkiller studies the situation carefully,
+looking for a way out of his predicament.  The Captain of the Guard calls up
+the platoon sergeants and gives them a series of orders.  They return to their
+squads and begin to inspect the troops.  Starkiller begins to get worried.</sd>
+         <sd>The sergeant works his way down the line until he gets to the trooper next to
+Starkiller.  He sees no chance of escape, but surprise.  Suddenly, he bolts
+from the ranks and races down the hallway.</sd>
+         <sp spk="CAPTAIN OF THE GUARD">
+
+Squad leaders!</sp>
+         <sd>Ten troopers break out of the ranks and take up the chase.  Starkiller runs
+down a corridor and rounds a corner, reaching a dead end.  The troops round
+the corner and confront the trapped Jedi.  The sound of igniting laserswords
+fills the hallway.  Starkiller takes a defensive stance, his huge lasersword
+buzzing loudly.  The troops attack.  They fight with skill and bravery, but
+are eventually all cut down by the invincible Jedi warrior.</sd>
+         <sd>Starkiller breaks away from the troops and runs down a long hallway.  A safety
+door slides shut, closing off his escape.  He turns around in time to see
+another door seal off the opposite end of the hallway.  Before he can make any
+attempt to pry open the door, gas fills the sealed corridor.  Starkiller
+collapses in a heap on the floor.</sd>
+      </scene>
+      <scene n="171">
+         <setting>  GENERAL'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Vader laughs as he watches the unconscious Starkiller on the TV monitors.  All
+of the other officers in the room are [something whited out] laughing and
+joking, except Valorum, who remains grimly at attention.</sd>
+         <sp spk="GENERAL (to Valorum)">
+
+Take him to the special section.</sp>
+         <sd>Valorum salutes, and exits the offices.  Vader laughs again.</sd>
+      </scene>
+      <scene n="172">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Nine gleaming starships sit in a row along the edge of the vast jungle runway.</sd>
+         <sd>Bizarre and colorful Wookee designs have been painted across the large
+deflector fins of the spacecraft.  Some designs transform the ships into huge
+and grotesque animals, while others create unique mosaic patterns.  The four-
+man Wookee crews stand proudly at attention in front of their ships.  The
+general, along with Han and the underground leader, Datos, review the
+assembled Wookees.</sd>
+         <sd>In one of the Wookee crews, a pilot is picking fleas off the back of his tail
+gunner.  When the general passes, he snaps to attention.  There is a gleam in
+the general's eye as he shows off his strike force to the crusty old
+underground leader.  When they've inspected the last starship, Datos turns to
+the general.</sd>
+         <sp spk="DATOS">
+
+I'm speechless.  It's amazing.  A most impressive display.  For the first time
+since the take-over, I feel real hope.</sp>
+         <sp spk="GENERAL">
+
+Will your people be ready?</sp>
+         <sp spk="DATOS">
+
+Our forces have already started sabotaging their com-link set ups.  A refugee
+camp on Mananyo has been conducting raids on shipping from Alderaan.  That's
+how we intercepted those doctors...</sp>
+         <sp spk="GENERAL (to Han)">
+
+Get them in the ships... We're on our way.  <sd>to Datos</sd>  Send the code signal.</sp>
+      </scene>
+      <scene n="173">
+         <setting>  DETENTION CELL - SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader and Valorum watch as a medic revives Starkiller, who has been
+strapped to an upright slab, protected by cutter-rays.</sd>
+         <sp spk="MEDIC">
+
+He's coming round.</sp>
+         <sd>The medic backs away, and throws the switch which activates the cutters.  A
+blue glow surrounds Starkiller as he wakes up and sees Vader and Valorum.</sd>
+         <sp spk="VADER">
+
+For all the myths and the trouble, you don't seem like much...</sp>
+         <sd>He laughs and leaves Valorum alone in the room with the young Jedi.  Valorum
+appears sad and frustrated at the capture of the noble warrior.  They stare at
+one another for a few moments.</sd>
+         <sp spk="VALORUM">
+
+You were insane to come here.  The security on this... this thing is
+impossible.  Why?....For her?  I can't believe your loyalty is that strong.
+You're a great warrior... but you're a greater fool.  This is a place for
+androids, no codes, no honor.  Our ways are useless here.  Why couldn't you
+have stayed away?</sp>
+         <sd>He storms out of the cell.  Starkiller struggles to free himself.</sd>
+      </scene>
+      <scene n="174">
+         <setting>  SLUM DWELLING - GORDON SPACEPORT - AQUILAE</setting>
+         <sd>The young partisan, Occo, listens to a small transmitter in a secret closet
+behind the main room in a slum dwelling.  He jumps up and runs into the main
+room, where Quist and several other men are sitting around a table covered
+with maps and plans.</sd>
+         <sp spk="OCCO">
+
+It's Datos.  We've got the go ahead.</sp>
+         <sd>Everyone cheers and starts hugging and slapping each other on the back.
+Finally, they settle down.</sd>
+         <sp spk="QUIST">
+
+Go to your organizations.  <sd>to Occo</sd>  What's the code time?</sp>
+         <sp spk="OCCO">
+
+Zero three thirty...</sp>
+         <sp spk="QUIST">
+
+May the force of others be with you.</sp>
+         <sd>The men solemnly shake hands and leave the room.</sd>
+      </scene>
+      <scene n="175">
+         <setting>  GOVERNOR'S OFFICE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller stands on a small platform before Governor Hoedaack and the High
+Consul.  His hands are held behind his back by electric bonds.</sd>
+         <sp spk="GOVERNOR">
+
+.... And I'm sure the emperor will enjoy your execution.  I only regret I
+won't be there myself.  This should end the Jedi myth once and for all.  Take
+him to Alderaan.</sp>
+         <sd>Valorum steps forward with a squad of stormtroopers and escorts the prisoner
+away.  Vader and the governor seem very pleased with themselves.  Valorum
+looks back in disgust.</sd>
+      </scene>
+      <scene n="176">
+         <setting>  CONTROL CENTER - SPACE FORTRESS - AQUILAE</setting>
+         <sd>In the large central control room, two officers sit above a row of monitors
+and giant read-outs.</sd>
+         <sp spk="FIRST OFFICER">
+
+Look!  That whole sector just went dead.  We're losing contact with the
+surface.  Use the IF link and find out what's going on.</sp>
+      </scene>
+      <scene n="177">
+         <setting>  DOCKING AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Valorum halts the squad guarding Starkiller on an observation deck overlooking
+a starship docking port.  Valorum reports to the officer in charge.</sd>
+         <sp spk="VALORUM">
+
+Where is the ship?</sp>
+         <sp spk="OFFICER">
+
+It's on its way in.  It will just be a few minutes.</sp>
+         <sd>Valorum returns to his squad and watches the large starship slowly move into
+the docking area.  He glances at Starkiller, who stands defiant, ready to meet
+his fate.</sd>
+         <sd>Valorum continues to study Starkiller.  The young Jedi returns his gaze.
+Slowly, the spacecraft locks onto the docking port with a loud jolt.  The
+troops snap to attention, but Valorum grabs two laserswords and in one swift
+move, switches off Starkiller's bonds and tosses him one of the laserswords.
+Starkiller assumes a defensive stance, as the troops realize what has happened
+and draw their swords.</sd>
+         <sp spk="VALORUM">
+
+This way!</sp>
+         <sd>The two warriors fight their way through a side exit.  The door slides closed
+behind them, and Valorum throws the lock, trapping the troops on the
+observation platform.  They race down the hallway and stop at an intersection.</sd>
+         <sp spk="VALORUM">
+
+This way!  We can get a starship and be out of here before they've
+discovered...</sp>
+         <sp spk="STARKILLER">
+
+I'm not leaving without the princess.</sp>
+         <sp spk="VALORUM">
+
+It's impossible; there are traps everywhere... You're mad!</sp>
+         <sd>Starkiller just grins and runs down the passageway leading to the detention
+area.  Valorum rushes and catches up.  An alarm signal wails through the
+hallways.</sd>
+      </scene>
+      <scene n="178">
+         <setting>  WOOKEE STARSHIPS - SPACE</setting>
+         <sd>The general leads three squads, of three starships each toward the glowing
+planet of Aquilae.</sd>
+         <sp spk="GENERAL">
+
+There she is.  Activate your deflection shields.</sp>
+      </scene>
+      <scene n="179">
+         <setting>  DETENTION AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Valorum talks with the Captain of the Guard.  He gestures wildly, like
+something important had happened.  Four troops run into the central detention
+area leading the bound Princess Leia.  The Captain of the Guard salutes
+Valorum, and the Sith knight, followed by the four troops and Leia, leave the
+main area.</sd>
+      </scene>
+      <scene n="180">
+         <setting>  DETENTION HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller appears boldly at the end of the hallway, facing Valorum and the
+troops.</sd>
+         <sp spk="VALORUM">
+
+Get him!</sp>
+         <sd>The troops rush for Starkiller, swords drawn.  They are no match for the
+skilled Jedi.  He makes short work of them, as Valorum frees the princess.
+The trio then run into another hallway.  The princess embraces Starkiller.</sd>
+         <sp spk="VALORUM">
+
+We only have a few seconds before they find us.  All of these hallways are
+sealable...</sp>
+         <sd>Starkiller spots a small garbage chute on the corridor wall.  He goes and
+looks into it.</sd>
+         <sp spk="STARKILLER">
+
+Is this pressurized?</sp>
+         <sd>Valorum nods yes, and they lift the princess into the chute and quickly
+follow.</sd>
+      </scene>
+      <scene n="181">
+         <setting>  GARBAGE CHUTE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The trio slides through a series of chutes, until they end up in a large room
+full of garbage.  Starkiller spots a doorway and struggles to get it open.</sd>
+         <sp spk="VALORUM">
+
+They're power sealed...We'll have to find another way, or some way to shut the
+power off...</sp>
+         <sd>They search the smooth-walled room for another exit.</sd>
+      </scene>
+      <scene n="182">
+         <setting>  GOVERNOR'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Governor Hoedaack watches General Vader as he supervises the hunt for
+Starkiller and Valorum.  They watch troops move through the detention area via
+TV monitors.  Seekers buzz through the hallways.  The general gets a report
+from an officer on another monitor.</sd>
+         <sp spk="OFFICER">
+
+We've lost contact with the surface.  There is a good probability of an
+uprising.  Even the IF links are out.</sp>
+         <sp spk="GENERAL">
+
+Use a substandard relay and put all units on alert.</sp>
+         <sd>The officer disappears from the monitor and is replaced with the Captain of
+the Guard.</sd>
+         <sp spk="CAPTAIN">
+
+All sections D through P-12 are clear.  We have reason to suspect they escaped
+through the disposal system.  We are checking....(he is interrupted by an
+excited trooper who tells him something)....We've found them in Receptacle B-
+29.  You should....</sp>
+         <sd>A red light flashes on one of the other monitors.</sd>
+         <sp spk="GENERAL">
+
+Hold on...</sp>
+         <sd>A controller appears on the second monitor.</sd>
+         <sp spk="CONTROLLER">
+
+Starships approaching, three squads.  Imperial design, but no clearance...</sp>
+         <sp spk="GENERAL">
+
+Full alert.  Battle stations....</sp>
+         <sd>The general turns back to the Captain of the Guards.</sd>
+         <sp spk="CAPTAIN">
+
+You should have them on your screen.</sp>
+         <sd>Alarms sound throughout the fortress.  Lights flash a warning.</sd>
+      </scene>
+      <scene n="182.2">
+         <setting>  [SECOND 182] GARBAGE RECEPTACLE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>A floodlight switches on, revealing Valorum and Starkiller attempting to cut
+open the door.  The princess stands up and stares into the floodlight.
+Vader's voice comes over an intercom.</sd>
+         <sp spk="VADER">
+
+I'm afraid I have no more time to deal with you.  A senseless and futile
+attack by your friends has forced me to take a rather unpleasant course of
+action.  Your execution will have to be expedited.</sp>
+         <sd>The intercom clicks off, and a loud rumbling begins to shake the room.  With a
+loud shriek, the princess points to the far wall; which starts to move toward
+the trio.  The situation looks desperate.</sd>
+      </scene>
+      <scene n="183">
+         <setting>  SPACE - WOOKEE STARSHIPS - AQUILAE</setting>
+         <sd>Laserfire from the space fortress creates a wall of death, which the three
+squadrons of Wookee starships miraculously emerge through undamaged.  The
+general barks orders to the Wookee craft, and Chewbacca and his squadron break
+off and start an attack dive.  Laser fire from Chewbacca's brightly colored
+ship hits one of the prime power terminals on the fortress surface.  It
+explodes, creating weird electric arcs, as it goes.</sd>
+         <sd>Han and the general also concentrate fire on the distinctive black power
+terminals.  Two more are destroyed in an arcing spectacle.  A chain reaction
+is set off, creating a series of explosions leaping across the surface of the
+fortress from power terminal to power terminal.</sd>
+      </scene>
+      <scene n="184">
+         <setting>  GARBAGE RECEPTACLE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The shock of the explosion can be felt over the rumbling of the trash masher.
+The wall has moved within a few yards of squashing Valorum, Starkiller and the
+princess.  They are still frantically trying to somehow stop the relentless
+wall, to no avail.  The lights blink off, then on again, and the moving wall
+rumbles to a halt.  Leia breathes a sigh of relief.</sd>
+         <sp spk="STARKILLER">
+
+They must have knocked the power out.</sp>
+         <sd>Valorum runs over to the door, and kicks it open.  They rush out of the would-
+be death trap.</sd>
+      </scene>
+      <scene n="185">
+         <setting>  SPACE - WOOKEE STARSHIPS - AQUILAE</setting>
+         <sd>One of the Wookee starships is caught in a crossfire and disappears in a cloud
+of smoke.  Another ship for some unknown reason dives headlong into the
+surface of the fortress, creating a huge explosion.</sd>
+      </scene>
+      <scene n="186">
+         <setting>  MAIN HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller, Valorum, and the princess are thrown to a hallway floor by the
+explosion.  They get up and start down the hallway again.  A voice calls out
+from a connecting corridor.</sd>
+         <sp spk="ARTWO">
+
+Hey!  Over here.</sp>
+         <sd>The trio turns and see little Artwo standing at the other end of the corridor.</sd>
+         <sd>He waves his claw arm at them, and wobbles toward them.</sd>
+         <sp spk="ARTWO">
+
+The power core has exceeded the normal stress quotient by point eight.  The
+magnetic fusion pods have evaporated.  There appears to be an immediate
+danger.</sp>
+         <sp spk="VALORUM">
+
+There is a lifepod station at the other end of this sector... Hurry.</sp>
+         <sd>The group, followed by Artwo, make a dash for the lifepod, but are knocked to
+the ground by another explosion, which rocks the hallway.  A hole is ripped in
+one wall, sucking debris into space.  Everyone holds on to wall fixtures for
+dear life.</sd>
+      </scene>
+      <scene n="187">
+         <setting>  GOVERNOR'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Aides and officers rush through the office, as Vader tries to keep things
+under control.  Governor Hoedaack remains calm, watching the progress of the
+battle.  Vader turns to the governor.</sd>
+         <sp spk="VADER">
+
+They've pinpointed every terminal.  It's impossible.  What are they?  Where
+did they come from?  An electromagnetic transfer has started....There's no
+stopping it...</sp>
+         <sp spk="GOVERNOR">
+
+Continue the fight...</sp>
+         <sp spk="VADER">
+
+We've already lost control of the planet.  We must abandon ship while there is
+still time...Conditions are much worse than...</sp>
+         <sp spk="GOVERNOR">
+
+Continue the fight...This fortress is invincible.  I will not give up.</sp>
+         <sd>A giant explosion sweeps through the office.</sd>
+      </scene>
+      <scene n="188">
+         <setting>  SPACE - WOOKEE STARSHIPS</setting>
+         <sd>The tiny starships race the chain reaction explosions across the surface of
+the fortress.  Laserfire is everywhere.  one of the starships skimming across
+the surface, lags behind and is caught in an explosion and disappears.</sd>
+         <sp spk="GENERAL">
+
+Han!  Get everyone out of there.  The whole thing's going to go....Return to
+Gordon... Get them out.</sp>
+         <sd>Han relays the order to the Wookees, and then starships pull away from the
+crippled fortress.</sd>
+      </scene>
+      <scene n="189">
+         <setting>  MAIN HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The group has made its way past the hole in the wall and is climbing into the
+lifepods.  Starkiller helps the princess into one, while Valorum and Artwo get
+into the other.  Warning sirens scream throughout the hallways.  Three troops
+run toward the lifepods, firing laserpistols.  Valorum returns the fire,
+stopping the oncoming troops.  Hatches are closed, and the lifepods eject into
+space.</sd>
+      </scene>
+      <scene n="190">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods drift toward the calm of the planet's surface.  Starkiller
+and the princess embrace, and he kisses her tenderly.  They watch the ominous
+fortress grow smaller and smaller as they drift away.  Suddenly, a great flash
+replaces the fortress and rubble streaks past the lifepods.  Several giant
+explosions follow, then there is only a smoke cloud where the mighty fortress
+once orbited Aquilae.</sd>
+      </scene>
+      <scene n="191">
+         <setting>  THRONE ROOM - PALACE OF LITE - AQUILAE</setting>
+         <sd>Queen Leia, in all her grandeur, sits on the magnificent throne of Aquilae.
+Starkiller and the general stand to her right.  Several old advisors stand to
+her left.  Han presents Chewbacca and a delegation of Wookees with a treaty,
+gifts, and a medal of honor.  They bow and exit.  Han moves to one side of the
+crowded court.  Valorum stands next to him.  They watch as the two robots,
+Artwo and Threepio, approach the queen, and bow.</sd>
+         <sp spk="QUEEN">
+
+Your service to Aquilae is greatly appreciated.  You are designated class A-4,
+and will serve Annikin Starkiller, the new Lord Protector of Aquilae.  Rise!</sp>
+         <sd>The robots rise and exit through the long entrance hall to the throne.  The
+queen turns and smiles at Starkiller and the general.  The general and
+Starkiller salute their new queen.</sd>
+         <sd>FADE OUT</sd>
+         <sd>END CREDITS</sd>
+      </scene>
+   </body>
+</xml>

--- a/scripts/ANHDraftsXML/XSLT/scriptIDTransform-1.xsl
+++ b/scripts/ANHDraftsXML/XSLT/scriptIDTransform-1.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    exclude-result-prefixes="xs math"
+    version="3.0">
+   
+   <xsl:mode on-no-match="shallow-copy"/>
+    <!--2022-03-21 ebb: This is the first stage of an identity transformation stylesheet 
+        for the DIGIT StarWars project to add scene numbers if they are missing,
+    and to move <speaker> elements into attributes on <sp>. It outputs to the transform1 folder.
+   
+    A second XSLT stylesheet will search for 
+    parentheses in <sp> elements to mark them as internal <sd>. We have to do this in a separate
+    step after moving the <speaker> elements to attributes because analyze-string will preserve the 
+    text of the speaker elements even if we remove the tags. 
+    -->
+    <xsl:variable name="starWarsColl" as="document-node()+" select="collection('../XMLdocuments')"/>
+    <xsl:template match="/">
+        <xsl:for-each select="$starWarsColl">
+            <xsl:variable name="filename" as="xs:string" select="base-uri() ! tokenize(., '/')[last()]"/>
+            <xsl:result-document method="xml" indent="yes" href="transform1/{$filename}">
+                <xsl:apply-templates/>
+            </xsl:result-document>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template match="scene">
+        <xsl:choose>
+            <xsl:when test="@n">       
+               <scene n="{@n}">
+                   <xsl:apply-templates/>
+               </scene>
+            </xsl:when>
+            <xsl:otherwise>
+                <scene n="{count(preceding::scene) + 1}">
+                    <xsl:apply-templates/>
+                </scene>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="sp">
+        <sp spk="{speaker}">
+         <xsl:apply-templates/>
+        </sp>
+    </xsl:template>
+    
+    <xsl:template match="speaker"/>
+
+ 
+</xsl:stylesheet>

--- a/scripts/ANHDraftsXML/XSLT/scriptIDTransform-2.xsl
+++ b/scripts/ANHDraftsXML/XSLT/scriptIDTransform-2.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    exclude-result-prefixes="xs math"
+    version="3.0">
+    
+    <xsl:mode on-no-match="shallow-copy"/>
+    <!--2022-03-21 ebb: This is part two of the XSLT identity transformation, to apply 
+    <xsl:analyze-string to the contents of the <sp> elements to replace stage cues
+    in parentheses with <sd>. Run this over this files in the transform1 folder.  
+    -->
+    <xsl:variable name="transform1" as="document-node()+" select="collection('transform1')"/>
+    <xsl:template match="/">
+       <xsl:for-each select="$transform1"> 
+           <xsl:variable name="filename" as="xs:string" select="base-uri() ! tokenize(., '/')[last()]"/>
+        <xsl:result-document method="xml" indent="yes" href="../XMLtransformed/{$filename}">
+            <xsl:apply-templates/>
+        </xsl:result-document>
+       </xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template match="sp">
+        <sp spk="{@spk}">
+          <xsl:analyze-string select="." regex="\((.+?)\)">
+              <xsl:matching-substring>
+                  <sd><xsl:value-of select="regex-group(1)"/></sd>
+              </xsl:matching-substring>
+              <xsl:non-matching-substring>
+                  <xsl:value-of select="."/>
+              </xsl:non-matching-substring>
+          </xsl:analyze-string>
+        </sp>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/scripts/ANHDraftsXML/XSLT/transform1/ANHfinalDraft.xml
+++ b/scripts/ANHDraftsXML/XSLT/transform1/ANHfinalDraft.xml
@@ -1,0 +1,6838 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>STAR WARS Episode IV A NEW HOPE </title>
+      <author>From the JOURNAL OF THE WHILLS By George Lucas</author>
+      <draft>Revised Fourth Draft</draft>
+      <date>January 15, 1976</date>
+   </metadata>
+						LUCASFILM LTD.
+					 ----------------------
+A long time ago, in a galaxy far, far, away...
+	A vast sea of stars serves as the backdrop for the main
+	title. War drums echo through the heavens as a rollup 
+	slowly crawls into infinity.
+   It is a period of civil war. Rebel spaceships, striking from a
+hidden base, have won their first victory against the evil Galactic
+Empire.
+   During the battle, Rebel spies managed to steal secret plans to the
+Empire's ultimate weapon, the Death Star, an armored space station
+with enough power to destroy an entire planet.
+   Pursued by the Empire's sinister agents, Princess Leia races home
+aboard her starship, custodian of the stolen plans that can save her
+people and restore freedom to the galaxy...
+	The awesome yellow planet of Tatooine emerges from a total
+	eclipse, her two moons glowing against the darkness. A tiny
+	silver spacecraft, a Rebel Blockade Runner firing lasers from
+	the back of the ship, races through space. It is pursed by a
+	giant Imperial Stardestroyer. Hundreds of deadly laserbolts
+	streak from the Imperial Stardestroyer, causing the main solar
+	fin of the Rebel craft to disintegrate.
+
+
+
+<scene n="1">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- MAIN PASSAGEWAY.
+	An explosion rocks the ship as two robots, Artoo-Detoo (R2-D2)
+	and See-Threepio (C-3PO) struggle to make their way through the
+	shaking, bouncing passageway. Both robots are old and battered. 
+	Artoo is a short, claw-armed tripod. His face is a mass of
+	computer lights surrounding a radar eye. Threepio, on the
+	other hand, is a tall, slender robot of human proportions. He
+	has a gleaming bronze-like metallic surface of an Art Deco
+	design. 
+		 Another blast shakes them as they struggle along their
+	way.
+</sd>
+      <sp spk="THREEPIO"> Did you hear that? They've shut down the main reactor. We'll
+be destroyed for sure. This is madness!
+		</sp>
+      <sd> Rebel troopers rush past the robots and take up positions
+	in the main passageway. They aim their weapons toward the door.
+</sd>
+      <sp spk="THREEPIO"> We're doomed!
+		</sp>
+      <sd> The little R2 unit makes a series of electronic sounds that
+	only another robot could understand.
+</sd>
+      <sp spk="THREEPIO"> There'll be no escape for the Princess this time.
+		</sp>
+      <sd> Artoo continues making beeping sounds. Tension mounts as
+	loud metallic latches clank and the scream of heavy equipment
+	are heard moving around the outside hull of the ship.
+</sd>
+      <sp spk="THREEPIO"> What's that?
+</sp>
+   </scene>
+   <scene n="2">
+      <sd>EXTERIOR: SPACECRAFT IN SPACE.
+	The Imperial craft has easily overtaken the Rebel Blockade
+	Runner. The smaller Rebel ship is being drawn into the
+	underside dock of the giant Imperial starship.
+</sd>
+   </scene>
+   <scene n="3">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	The nervous Rebel troopers aim their weapons. Suddenly a
+	tremendous blast opens up a hole in the main passageway and a
+	score of fearsome armored spacesuited stormtroopers make their
+	way into the smoke-filled corridor.
+		 In a few minutes the entire passageway is ablaze with
+	laserfire. The deadly bolts ricochet in wild random patterns
+	creating huge explosions. Stormtroopers scatter and duck
+	behind storage lockers. Laserbolts hit several Rebel soldiers
+	who scream and stagger through the smoke, holding shattered
+	arms and faces.
+		 An explosion hits near the robots.
+</sd>
+      <sp spk="THREEPIO"> I should have known better than to trust the logic of a
+half-sized thermocapsulary dehousing assister...
+		</sp>
+      <sd> Artoo counters with an angry rebuttal as the battle rages
+	around the two hapless robots.
+</sd>
+   </scene>
+   <scene n="4">
+      <sd>EXTERIOR: TATOOINE -- DESERT WASTELAND -- DAY.
+	A death-white wasteland stretches from horizon to horizon. The
+	tremendous heat of two huge twin suns settle on a lone figure,
+	Luke Skywalker, a farm boy with heroic aspirations who looks
+	much younger than his eighteen years. His shaggy hair and
+	baggy tunic give him the air of a simple but lovable lad with
+	a prize-winning smile.
+		 A light wind whips at him as he adjusts several valves on a
+	large battered moisture vaporator which sticks out of the
+	desert floor much like an oil pipe with valves. He is aided by
+	a beatup tread-robot with six claw arms. The little robot
+	appears to be barely functioning and moves with jerky motions.
+	A bright sparkle in the morning sky catches Luke's eye and he
+	instinctively grabs a pair of electrobinoculars from his utility
+	belt. He stands transfixed for a few moments studying the
+	heavens, then dashed toward his dented, crudely repaired
+	Landspeeder (an auto-like transport that travels a few feet
+	above the ground on a magnetic-field). He motions for the tiny
+	robot to follow him.
+</sd>
+      <sp spk="LUKE"> Hurry up! Come with me! What are you waiting for?! Get in gear!
+		</sp>
+      <sd> The robot scoots around in a tight circle, stops short, and
+	smoke begins to pour out of every joint. Luke throws his arms
+	up in disgust. Exasperated, the young farm boy jumps into his
+	Landspeeder leaving the smoldering robot to hum madly.
+</sd>
+   </scene>
+   <scene n="5">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- MAIN HALLWAY.
+	The awesome, seven-foot-tall Dark Lord of the Sith makes his
+	way into the blinding light of the main passageway. This is
+	Darth Vader, right hand of the Emperor. His face is obscured
+	by his flowing black robes and grotesque breath mask, which
+	stands out next to the fascist white armored suits of the
+	Imperial stormtroopers. Everyone instinctively backs away from
+	the imposing warrior and a deathly quiet sweeps through the
+	Rebel troops. Several of the Rebel troops break and run in a
+	frenzied panic.
+</sd>
+   </scene>
+   <scene n="6">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	A woman's hand puts a card into an opening in Artoo's dome.
+	Artoo makes beeping sounds.
+</sd>
+   </scene>
+   <scene n="7">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER.
+	Threepio stands in a hallway, somewhat bewildered. Artoo is
+	nowhere in sight. The pitiful screams of the doomed Rebel
+	soldiers can be heard in the distance.
+</sd>
+      <sp spk="THREEPIO"> Artoo! Artoo-Detoo, where are you?
+		</sp>
+      <sd> A familiar clanking sound attacks Threepio's attention and
+	he spots little Artoo at the end of the hallway in a
+	smoke-filled alcove. A beautiful young girl (about sixteen
+	years old) stands in front of Artoo. Surreal and out of place,
+	dreamlike and half hidden in the smoke, she finishes adjusting
+	something on Artoo's computer face, then watches as the little
+	robot joins his companion.
+</sd>
+      <sp spk="THREEPIO"> At last! Where have you been?</sp>
+      <sd>Stormtroopers can be heard battling in the distance.
+</sd>
+      <sp spk="THREEPIO"> They're heading in this direction. What are we going to do?
+We'll be sent to the spice mine of Kessel or smashed into who knows
+what!
+		</sp>
+      <sd> Artoo scoots past his bronze friend and races down the
+	subhallway. Threepio chases after him.
+</sd>
+      <sp spk="THREEPIO"> Wait a minute, where are you going?
+		</sp>
+      <sd> Artoo responds with electronic beeps.
+</sd>
+   </scene>
+   <scene n="8">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- CORRIDOR
+	The evil Darth Vader stands amid the broken and twisted bodies
+	of his foes. He grabs a wounded Rebel Officer by the neck as
+	an Imperial Officer rushes up to the Dark Lord.
+</sd>
+      <sp spk="IMPERIAL OFFICER"> The Death Star plans are not in the main computer.
+		</sp>
+      <sd> Vader squeezes the neck of the Rebel Officer, who struggles
+	in vain.
+</sd>
+      <sp spk="VADER"> Where are those transmissions you intercepted?
+		</sp>
+      <sd> Vader lifts the Rebel off his feet by his throat.
+</sd>
+      <sp spk="VADER"> What have you done with those plans?
+</sp>
+      <sp spk="REBEL OFFICER"> We intercepted no transmissions. Aaah....This is a
+consular ship. Were on a diplomatic mission.
+</sp>
+      <sp spk="VADER"> If this is a consular ship...were is the Ambassador?
+		</sp>
+      <sd> The Rebel refuses to speak but eventually cries out as the
+	Dark Lord begins to squeeze the officer's throat, creating a
+	gruesome snapping and choking, until the soldier goes limp.
+	Vader tosses the dead soldier against the wall and turns to
+	his troops.
+</sd>
+      <sp spk="VADER"> Commander, tear this ship apart until you've found those plans
+and bring me the Ambassador. I want her alive!
+		</sp>
+      <sd> The stormtroopers scurry into the subhallways.
+</sd>
+   </scene>
+   <scene n="9">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- SUBHALLWAY.
+	The lovely young girl huddles in a small alcove as the
+	stormtroopers search through the ship. She is Princess Leia
+	Organa, a member of the Alderaan Senate. The fear in her eyes
+	slowly gives way to anger as the muted crushing sounds of the
+	approaching stormtroopers grow louder. One of the troopers
+	spots her.
+</sd>
+      <sp spk="TROOPER"> There she is! Set for stun!
+		</sp>
+      <sd> Leia steps from her hiding place and blasts a trooper with
+	her laser pistol. She starts to run but is felled by a
+	paralyzing ray. The troopers inspect her inert body.
+</sd>
+      <sp spk="TROOPER"> She'll be all right. Inform Lord Vader we have a prisoner.
+</sp>
+   </scene>
+   <scene n="10">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- SUBHALLWAY.
+	Artoo stops before the small hatch of an emergency lifepod. He
+	snaps the seal on the main latch and a red warning light
+	begins to flash. The stubby astro-robot works his way into the
+	cramped four-man pod.
+</sd>
+      <sp spk="THREEPIO"> Hey, you're not permitted in there. It's restricted. You'll
+be deactivated for sure..
+		</sp>
+      <sd> Artoo beeps something to him.
+</sd>
+      <sp spk="THREEPIO"> Don't call me a mindless philosopher, you overweight glob of
+grease! Now come out before somebody sees you.
+		</sp>
+      <sd> Artoo whistles something at his reluctant friend regarding
+	the mission he is about to perform.
+</sd>
+      <sp spk="THREEPIO"> Secret mission? What plans? What are you talking about? I'm
+not getting in there!
+		</sp>
+      <sd> Artoo isn't happy with Threepio's stubbornness, and he beeps
+	and twangs angrily.
+	A new explosion, this time very close, sends dust and debris
+	through the narrow subhallway. Flames lick at Threepio and,
+	after a flurry of electronic swearing from Artoo, the lanky
+	robot jumps into the lifepod.
+</sd>
+      <sp spk="THREEPIO"> I'm going to regret this.
+</sp>
+   </scene>
+   <scene n="11">
+      <sd>INTERIOR: IMPERIAL STARDESTROYER.
+	On the main viewscreen, the lifepod carrying the two terrified
+	robots speeds away from the stricken Rebel spacecraft.
+</sd>
+      <sp spk="CHIEF PILOT"> There goes another one.
+</sp>
+      <sp spk="CAPTAIN"> Hold your fire. There are no life forms. It must have been
+short-circuited.
+</sp>
+   </scene>
+   <scene n="12">
+      <sd>INTERIOR: LIFEPOD.
+	Artoo and Threepio look out at the receding Imperial starship.
+	Stars circle as the pod rotates through the galaxy.
+</sd>
+      <sp spk="THREEPIO"> That's funny, the damage doesn't look as bad from out here.</sp>
+      <sd>Artoo beeps an assuring response.
+</sd>
+      <sp spk="THREEPIO"> Are you sure this things safe?
+</sp>
+   </scene>
+   <scene n="13">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD SETTLEMENT -- POWER STATION -- DAY.
+	Heat waves radiate from the dozen or so bleached white
+	buildings. Luke pilots his Landspeeder through the dusty empty
+	street of the tiny settlement. An old woman runs to get out of
+	the way of the speeding vehicle, shaking her fist at Luke as
+	he flies past.
+</sd>
+      <sp spk="WOMAN"> I've told you kids to slow down!
+</sp>
+   </scene>
+   <scene n="14">
+      <sd>INTERIOR: POWER STATION -- DAY.
+	Luke bursts into the power station, waking The Fixer, a rugged
+	mechanic and Camie, a sexy, disheveled girl who has been
+	asleep in his lap. They grumbled as he races through the
+	office, yelling wildly.
+</sd>
+      <sp spk="FIXER"> Did I hear a young noise blast through here?
+</sp>
+      <sp spk="CAMIE"> It was just wormie on another rampage.
+		</sp>
+      <sd> Luke bounces into a small room behind the office where Deak
+	and Windy, two tough boys about the same age as Luke, are
+	playing a computer pool-like game with Biggs, a burly,
+	handsome boy a few years older than the rest. His flashy city
+	attire is a sharp contrast to the loose-fitting tunics of the
+	farm boys. A robot repairs some equipment in the background.
+</sd>
+      <sp spk="LUKE"> Shape it up you guys!.... Biggs?
+		</sp>
+      <sd> Luke's surprise at the appearance of Biggs gives way to
+	great joy and emotion. They give each other a great bear hug.
+</sd>
+      <sp spk="LUKE"> I didn't know you were back! When did you get in?
+</sp>
+      <sp spk="BIGGS"> Just now. I wanted to surprise you, hot shot. I thought you'd be
+here...certainly didn't expect you to be out working. (he laughs.)
+</sp>
+      <sp spk="LUKE"> The Academy didn't change you much...but you're back so soon?
+Hey, what happened, didn't you get your commission?
+		</sp>
+      <sd> Biggs has an air of cool that seems slightly phony.
+</sd>
+      <sp spk="BIGGS"> Of course I got it. Signed aboard The Rand Ecliptic last week.
+First mate Biggs Darklighter at your service...(he salutes)...I just
+came to say good-bye to all you unfortunate landlocked simpletons.
+		</sp>
+      <sd> Everyone laughs. The dazzling spectacle of his dashing
+	friend is almost too much for Luke, but suddenly he snaps out
+	of it.
+</sd>
+      <sp spk="LUKE"> I almost forgot. There's a battle going on! Right here in our
+system. Come and look!
+</sp>
+      <sp spk="DEAK"> Not again! Forget it.
+</sp>
+   </scene>
+   <scene n="15">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD -- SETTLEMENT -- POWER STATION -- DAY.
+	The group stumbles out into the stifling desert sun. Camie and
+	The Fixer complain and are forced to shade their eyes. Luke
+	has his binoculars out scanning the heavens.
+</sd>
+      <sp spk="LUKE"> There they are!
+		</sp>
+      <sd> Biggs takes the binoculars from Luke as the others strain
+	to see something with the naked eye. Through the binoculars
+	Biggs sees two small silver specks.
+</sd>
+      <sp spk="BIGGS"> That's no battle, hot shot...they're just sitting there!
+Probably a freighter-tanker refueling.
+</sp>
+      <sp spk="LUKE"> But there was a lot of firing earlier...
+		</sp>
+      <sd> Camie grabs the binoculars away banging them against the
+	building in the process. Luke grabs them.
+</sd>
+      <sp spk="LUKE"> Hey, easy with those...
+</sp>
+      <sp spk="CAMIE"> Don't worry about it, Wormie.
+		</sp>
+      <sd> The Fixer gives Luke a hard look and the young farm boy
+	shrugs his shoulders in resignation.
+</sd>
+      <sp spk="FIXER"> I keep telling you, the Rebellion is a long way from here. I
+doubt if the Empire would even fight to keep this system. Believe me
+Luke, this planet is a big hunk of nothing...
+		</sp>
+      <sd> Luke agrees, although it's obvious he isn't sure why. The
+	group stumbles back into the power station, grumbling about
+	Luke's ineptitude.
+</sd>
+   </scene>
+   <scene n="16">
+      <sd>INTERIOR: REBEL BLOCKADE RUNNER -- HALLWAY
+	Princess Leia is led down a low-ceilinged hallway by a squad
+	of armored stormtroopers. Her hands are bound and she is
+	brutally shoved when she is unable to keep up with the briskly
+	marching troops. They stop in a smoky hallway as Darth Vader
+	emerges from the shadows. The sinister Dark Lord stares hard
+	at the frail young senator, but she doesn't move.
+</sd>
+      <sp spk="LEIA"> Lord Vader, I should have known. Only you could be so bold. The
+Imperial Senate will not sit for this, when they hear you've attacked
+a diplomatic...
+</sp>
+      <sp spk="VADER"> Don't play games with me, Your Highness. You weren't on any
+mercy mission this time. You passed directly through a restricted
+system. Several transmissions were beamed to this ship by Rebel spies.
+I want to know what happened to the plans they sent you.
+</sp>
+      <sp spk="LEIA"> I don't know what you're talking about. I'm a member of the
+Imperial Senate on a diplomatic mission to Alderaan...
+</sp>
+      <sp spk="VADER"> You're a part of the Rebel Alliance...and a traitor. Take her
+away!
+		</sp>
+      <sd> Leia is marched away down the hallway and into the
+	smoldering hole blasted in the side of the ship. An Imperial
+	Commander turns to Vader.
+</sd>
+      <sp spk="COMMANDER"> Holding her is dangerous. If word of this gets out, it
+could generate sympathy for the Rebellion in the senate.
+</sp>
+      <sp spk="VADER"> I have traced the Rebel spies to her. Now she is my only link
+to find their secret base!
+</sp>
+      <sp spk="COMMANDER"> She'll die before she tells you anything.
+</sp>
+      <sp spk="VADER"> Leave that to me. Send a distress signal and then inform the
+senate that all aboard were killed!
+		</sp>
+      <sd> Another Imperial Officer approaches Vader and the
+	Commander. They stop and snap to attention.
+</sd>
+      <sp spk="SECOND OFFICER"> Lord Vader, the battle station plans are not aboard
+this ship! And no transmissions were made. An escape pod was
+jettisoned during the fighting, but no life forms were aboard.
+		</sp>
+      <sd> Vader turns to the Commander.
+</sd>
+      <sp spk="VADER"> She must have hidden the plans in the escape pod. Send a
+detachment down to retrieve them. See to it personally, Commander.
+There'll be no one to stop us this time.
+</sp>
+      <sp spk="COMMANDER"> Yes, sir.
+</sp>
+   </scene>
+   <scene n="17">
+      <sd>EXTERIOR: SPACE.
+	The Imperial Stardestroyer comes over the surface of the
+	planet Tatooine.
+</sd>
+   </scene>
+   <scene n="18">
+      <sd>EXTERIOR: TATOOINE -- DESERT.
+	Jundland, or "No Man's Land", where the rugged desert mesas
+	meet the foreboding dune sea. The two helpless astro-droids
+	kick up clouds of sand as they leave the lifepod and clumsily
+	work their way across the desert wasteland. The lifepod in the
+	distance rests half buried in the sand.
+</sd>
+      <sp spk="THREEPIO"> How did I get into this mess? I really don't know how. We
+seem to be made to suffer. It's our lot in life.
+		</sp>
+      <sd> Artoo answers with beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> I've got to rest before I fall apart. My joints are almost
+frozen. 
+		</sp>
+      <sd> Artoo continues to respond with beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> What a desolate place this is.
+		</sp>
+      <sd> Suddenly Artoo whistles, makes a sharp right turn and
+	starts off in the direction of the rocky desert mesas. Threepio
+	stops and yells at him.
+</sd>
+      <sp spk="THREEPIO"> Where are you going?
+		</sp>
+      <sd> A stream of electronic noises pours forth from the small
+	robot.
+</sd>
+      <sp spk="THREEPIO"> Well, I'm not going that way. It's much too rocky. This way
+is much easier.
+		</sp>
+      <sd> Artoo counters with a long whistle.
+</sd>
+      <sp spk="THREEPIO"> What makes you think there are settlements over there?
+		</sp>
+      <sd> Artoo continues to make beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> Don't get technical with me.
+		</sp>
+      <sd> Artoo continues to make beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> What mission? What are you talking about? I've had just
+about enough of you! Go that way! You'll be malfunctioning within a
+day, you nearsighted scrap pile!
+		</sp>
+      <sd> Threepio gives the little robot a kick and starts off in
+	the direction of the vast dune sea.
+</sd>
+      <sp spk="THREEPIO"> And don't let me catch you following me begging for help,
+because you won't get it.
+		</sp>
+      <sd> Artoo's reply is a rather rude sound. He turns and trudges
+	off in the direction of the towering mesas.
+</sd>
+      <sp spk="THREEPIO"> No more adventures. I'm not going that way.
+		</sp>
+      <sd> Artoo beeps to himself as he makes his way toward the
+	distant mountains.
+</sd>
+   </scene>
+   <scene n="19">
+      <sd>EXTERIOR: TATOOINE -- DUNE SEA.
+	Threepio, hot and tired, struggles up over the ridge of a dune;
+	only to find more dunes, which seem to go on for endless
+	miles.  He looks back in the direction of the now distant rock
+	mesas. 
+</sd>
+      <sp spk="THREEPIO"> That malfunctioning little twerp. This is all his fault! He
+tricked me into going this way, but he'll do no better.
+		</sp>
+      <sd> In a huff of anger and frustration, Threepio knocks the
+	sand from his joints. His plight seems hopeless, when a glint
+	of reflected light in the distance reveals an object moving
+	towards him.
+</sd>
+      <sp spk="THREEPIO"> Wait, what's that? A transport! I'm saved!
+		</sp>
+      <sd> The bronze android waves frantically and yells at the
+	approaching transport.
+</sd>
+      <sp spk="THREEPIO"> Over here! Help! Please, help!
+</sp>
+   </scene>
+   <scene n="20">
+      <sd>EXTERIOR: TATOOINE -- ANCHORHEAD SETTLEMENT -- POWER STATION -- DAY.
+	Luke and Biggs are walking and drinking a malt brew. Fixer and
+	the others can be heard working inside.
+</sd>
+      <sp spk="LUKE"> (Very animated)...so I cut off my power, shut down the
+afterburners and came in low on Deak's trail. I was so close I thought
+I was going to fry my instruments. As it was I busted up the Skyhopper
+pretty bad. Uncle Owen was pretty upset. He grounded me for the rest
+of the season. You should have been there...it was fantastic.
+</sp>
+      <sp spk="BIGGS"> You ought to take it easy Luke. You may be the hottest
+bushpilot this side of Mos Eisley, but those little Skyhoppers are
+dangerous. Keep it up, and one day, whammo, you're going to be nothing
+more than a dark spot on the down side of a canyon wall.
+</sp>
+      <sp spk="LUKE"> Look who's talking. Now that you've been around those giant
+starships you're beginning to sound like my uncle. You've gotten soft
+in the city...
+</sp>
+      <sp spk="BIGGS"> I've missed you kid.
+</sp>
+      <sp spk="LUKE"> Well, things haven't been the same since you left, Biggs. It's
+been so...quiet.
+		</sp>
+      <sd> Biggs looks around then leans close to Luke.
+</sd>
+      <sp spk="BIGGS"> Luke, I didn't come back just to say good-bye...I shouldn't
+tell you this, but you're the only one I can trust...and if I don't
+come back, I want somebody to know.
+		</sp>
+      <sd> Luke's eyes are wide with Biggs' seriousness and loyalty.
+</sd>
+      <sp spk="LUKE"> What are you talking about?
+</sp>
+      <sp spk="BIGGS"> I made some friends at the Academy. (he whispers)...when our
+frigate goes to one of the central systems, we're going to jump ship
+and join the Alliance...
+		</sp>
+      <sd> Luke, amazed and stunned, is almost speechless.
+</sd>
+      <sp spk="LUKE"> Join the Rebellion?! Are you kidding! How?
+</sp>
+      <sp spk="BIGGS"> Quiet down will ya! You got a mouth bigger than a meteor
+crater!
+</sp>
+      <sp spk="LUKE"> I'm sorry. I'm quiet. (he whispers) Listen how quiet I am. You
+can barely hear me...
+		</sp>
+      <sd> Biggs shakes his head angrily and then continues.
+</sd>
+      <sp spk="BIGGS"> My friend has a friend on Bestine who might help us make
+contact.
+</sp>
+      <sp spk="LUKE"> Your crazy! You could wander around forever trying to find them.
+</sp>
+      <sp spk="BIGGS"> I know it's a long shot, but if I don't find them I'll do what
+I can on my own...It's what we always talked about. Luke, I'm not
+going to wait for the Empire to draft me into service. The Rebellion
+is spreading and I want to be on the right side -- the side I believe
+in. 
+</sp>
+      <sp spk="LUKE"> And I'm stuck here...
+</sp>
+      <sp spk="BIGGS"> I thought you were going to the Academy next term. You'll get
+your chance to get off this rock.
+</sp>
+      <sp spk="LUKE"> Not likely! I had to cancel my application. There has been a lot
+of unrest among the Sandpeople since you left...they've even raided
+the outskirts of Anchorhead.
+</sp>
+      <sp spk="BIGGS"> Your uncle could hold off a whole colony of Sandpeople with one
+blaster.
+</sp>
+      <sp spk="LUKE"> I know, but he's got enough vaporators going to make the place
+pay off. He needs me for just one more season. I can't leave him now.
+</sp>
+      <sp spk="BIGGS"> I feel for you, Luke, you're going to have to learn what seems
+to be important or what really is important. What good is all your
+uncle's work if it's taken over by the Empire?...You know they're
+starting to nationalize commerce in the central systems...it won't be
+long before your uncle is merely a tenant, slaving for the greater
+glory of the Empire.
+</sp>
+      <sp spk="LUKE"> It couldn't happen here. You said it yourself. The Empire won't
+bother with this rock.
+</sp>
+      <sp spk="BIGGS"> Things always change.
+</sp>
+      <sp spk="LUKE"> I wish I was going...Are you going to be around long? 
+</sp>
+      <sp spk="BIGGS"> No, I'm leaving in the morning...
+</sp>
+      <sp spk="LUKE"> Then I guess I won't see you.
+</sp>
+      <sp spk="BIGGS"> Maybe someday...I'll keep a lookout.
+</sp>
+      <sp spk="LUKE"> Well, I'll be at the Academy next season...after that who knows.
+I won't be drafted into the Imperial Starfleet that's for sure...Take
+care of yourself, you'll always be the best friend I've got.
+</sp>
+      <sp spk="BIGGS"> So long, Luke.
+		</sp>
+      <sd> Biggs turns away from his old friend and heads towards the
+	power station.
+</sd>
+   </scene>
+   <scene n="21">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SUNSET.
+	The gargantuan rock formations are shrouded in a strange
+	foreboding mist and the onimous sounds of unearthly creatures
+	fill the air. Artoo moves cautiously through the creepy rock
+	canyon, inadvertently making a loud clicking noise as he goes.
+	He hears a distant, hard, metallic sound and stops for a
+	moment. Convinced he is alone, he continues on his way.
+		 In the distance, a pepple tumbles down the steep canyon
+	wall and a small dark figure darts into the shadows. A little
+	further up the canyon a slight flicker of light reveals a pair
+	of eyes in the dark recesses only a few feet from the narrow
+	path.
+		 The unsuspecting robot waddles along the rugged trail until
+	suddenly, out of nowhere, a powerful magnetic ray shoots out
+	of the rocks and engulfs him in an eerie glow. He manages one
+	short electronic squeak before he topples over onto his back.
+	His bright computer lights flicker off, then on, then off
+	again. Out of the rocks scurry three Jawas, no taller than
+	Artoo. They holster strange and complex weapons as they
+	cautiously approach the robot. They wear grubby cloaks and
+	their faces are shrouded so only their glowing eyes can be
+	seen. They hiss and make odd guttural sounds as they heave the
+	heavy robot onto their shoulders and carry him off down the
+	trail. 
+</sd>
+   </scene>
+   <scene n="22">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SANDCRAWLER -- SUNSET.
+	The eight Jawas carry Artoo out of the canyon to a huge
+	tank-like vehicle the size of a four-story house. They weld a
+	small disk on the side of Artoo and then put him under a large
+	tube on the side of the vehicle and the little robot is sucked
+	into the giant machine.
+		 The filthy little Jawas scurry like rats up small ladders
+	and enter the main cabin of the behemoth transport.
+</sd>
+   </scene>
+   <scene n="23">
+      <sd>INTERIOR: SANDCRAWLER -- HOLD AREA.
+	It is dim inside the hold area of the Sandcrawler. Artoo
+	switches on a small floodlight on his forehead and stumbles
+	around the scrap heap. The narrow beam swings across rusty
+	metal rocket parts and an array of grotesquely twisted and
+	maimed astro-robots. He lets out a pathetic electronic whimper
+	and stumbles off toward what appears to be a door at the end
+	of the chamber.
+</sd>
+   </scene>
+   <scene n="24">
+      <sd>INTERIOR: SANDCRAWLER -- PRISON AREA.
+	Artoo enters a wide room with a four-foot ceiling. In the
+	middle of the scrap heap sit a dozen or so robots of various
+	shapes and sizes. Some are engaged in electronic conversation,
+	while others simply mill about. A voice of recognition calls
+	out from the gloom.
+</sd>
+      <sp spk="THREEPIO"> Artoo-Detoo! It's you! It's you!
+		</sp>
+      <sd> A battered Threepio scrambles up to Artoo and embraces him.
+</sd>
+   </scene>
+   <scene n="25">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- SANDCRAWLER -- SUNSET.
+	The enormous Sandcrawler lumbers off toward the magnificent
+	twin suns, which are slowly setting over a distant mountain
+	ridge.
+</sd>
+   </scene>
+   <scene n="26">
+      <sd>EXTERIOR: TATOOINE -- DESERT -- DAY.
+	Four Imperial stormtroopers mill about in front of the half-
+	buried lifepod that brought Artoo and Threepio to Tatooine. A
+	trooper yells to an officer some distance away.
+</sd>
+      <sp spk="FIRST TROOPER"> Someone was in the pod. The tracks go off in this
+direction. 
+		</sp>
+      <sd> A second trooper picks a small bit of metal out of the sand
+	and gives it to the first trooper.
+</sd>
+      <sp spk="SECOND TROOPER"> Look, sir -- droids.
+</sp>
+   </scene>
+   <scene n="27">
+      <sd>EXTERIOR: TATOOINE -- DUNES.
+	The Sandcrawler moves slowly down a great sand dune.
+</sd>
+   </scene>
+   <scene n="28">
+      <sd>INTERIOR: SANDCRAWLER.
+	Threepio and Artoo noisily bounce along inside the cramped
+	prison chamber. Artoo appears to be shut off.
+</sd>
+      <sp spk="THREEPIO"> Wake up! Wake up!
+		</sp>
+      <sd> Suddenly the shaking and bouncing of the Sandcrawler stops,
+	creating quite a commotion among the mechanical men.
+	Threepio's fist bangs the head of Artoo whose computer lights
+	pop on as he begins beeping. At the far end of the long
+	chamber a hatch opens, filling the chamber with blinding white
+	light. a dozen or so Jawas make their way through the odd
+	assortment of robots.
+</sd>
+      <sp spk="THREEPIO"> We're doomed.
+		</sp>
+      <sd> A Jawa starts moving toward them.
+</sd>
+      <sp spk="THREEPIO"> Do you think they'll melt us down?
+		</sp>
+      <sd> Artoo responds, making beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> Don't shoot! Don't shoot! Will this never end?
+</sp>
+   </scene>
+   <scene n="29">
+      <sd>EXTERIOR: TATOOINE -- DESERT -- LARS HOMESTEAD -- AFTERNOON.
+	The Jawas mutter gibberish as they busily line up their
+	battered captives, including Artoo and Threepio, in front of
+	the enormous Sandcrawler, which is parked beside a small
+	homestead consisting of three large holes in the ground
+	surrounded by several tall moisture vaporators and one small
+	adobe block house.
+		 The Jawas scurry around fussing over the robots,
+	straightening them up or brushing some dust from a dented
+	metallic elbow. The shrouded little creatures smell horribly,
+	attracting small insects to the dark areas when their mouths
+	and nostrils should be.
+		 Out of the shadows of a dingy side-building limps Owen
+	Lars, a large burly man in his mid-fifties. His reddish eyes
+	are sunken in a dust-covered face. As the farmer carefully
+	inspects each robot, he is closely followed by his slump-
+	shouldered nephew, Luke Skywalker. One of the vile little
+	Jawas walks ahead of the farmer spouting an animated sales
+	pitch in a queer, unintelligible language.
+		 A voice calls out from one of the huge holes that form the
+	homestead. Luke goes over to the edge and sees his Aunt Beru
+	standing in the main courtyard.
+</sd>
+      <sp spk="BERU"> Luke, tell Owen that if he gets a translator to be sure it
+speaks Bocce.
+</sp>
+      <sp spk="LUKE"> It looks like we don't have much of a choice but I'll remind
+him.
+		</sp>
+      <sd> Luke returns to his uncle as they look over the equipment
+	for sale with the Jawa leader.
+</sd>
+      <sp spk="OWEN"> I have no need for a protocol droid.
+</sp>
+      <sp spk="THREEPIO"> (quickly) Sir -- not in an environment such as this --
+that's why I've also been programmed for over thirty secondary
+functions that...
+</sp>
+      <sp spk="OWEN"> What I really need is a droid that understands the binary
+language of moisture vaporators.
+</sp>
+      <sp spk="THREEPIO"> Vaporators! Sir -- My first job was programming binary load
+lifter...very similar to your vaporators. You could say...
+</sp>
+      <sp spk="OWEN"> Do you speak Bocce?
+</sp>
+      <sp spk="THREEPIO"> Of course I can, sir. It's like a second language for
+me...I'm as fluent in Bocce...
+</sp>
+      <sp spk="OWEN"> All right shut up! (turning to Jawa) I'll take this one.
+</sp>
+      <sp spk="THREEPIO"> Shutting up, sir.
+</sp>
+      <sp spk="OWEN"> Luke, take these two over to the garage, will you? I want you to
+have both of them cleaned up before dinner.
+</sp>
+      <sp spk="LUKE"> But I was going into Toshi Station to pick up some power
+converters...
+</sp>
+      <sp spk="OWEN"> You can waste time with your friends when your chores are done.
+Now come on, get to it!
+</sp>
+      <sp spk="LUKE"> All right, come on! And the red one, come on. Well, come on,
+Red, let's go.
+		</sp>
+      <sd> As the Jawas start to lead the three remaining robots
+	back into the Sandcrawler, Artoo lets out a pathetic little
+	beep and starts after his old friend Threepio. He is
+	restrained by a slimy Jawa, who zaps him with a control box.
+</sd>
+      <sd> Owen is negotiating with the head Jawa. Luke and the two
+	robots start off for the garage when a plate pops off the head
+	of the red astro-droid's head plate and it sparks wildly.
+</sd>
+      <sp spk="LUKE"> Uncle Owen...
+</sp>
+      <sp spk="OWEN"> Yeah?
+</sp>
+      <sp spk="LUKE"> This R2 unit has a bad motivator. Look!
+</sp>
+      <sp spk="OWEN"> (to the head Jawa) Hey, what're you trying to push on us?
+		</sp>
+      <sd> The Jawa goes into a loud spiel. Meanwhile, Artoo has
+	sneaked out of line and is moving up and down trying to
+	attract attention. He lets out with a low whistle. Threepio
+	taps Luke on the shoulder.
+</sd>
+      <sp spk="THREEPIO"> (pointing to Artoo) Excuse me, sir, but that R2 unit is in
+prime condition. A real bargain.
+</sp>
+      <sp spk="LUKE"> Uncle Owen...
+</sp>
+      <sp spk="OWEN"> Yeah?
+</sp>
+      <sp spk="LUKE"> What about that one?
+</sp>
+      <sp spk="OWEN"> (to Jawa) What about that blue one? We'll take that one.
+		</sp>
+      <sd> With a little reluctance the scruffy dwarf trades the
+	damaged astro-droid for Artoo.
+</sd>
+      <sp spk="LUKE"> Yeah, take it away.
+</sp>
+      <sp spk="THREEPIO"> Uh, I'm quite sure you'll be very pleased with that one,
+sir. He really is in first-class condition. I've worked with him
+before. Here he comes.
+		</sp>
+      <sd> Owen pays off the whining Jawa as Luke and the two robots
+	trudge off toward a grimy homestead entry.
+</sd>
+      <sp spk="LUKE"> Okay, let's go.
+</sp>
+      <sp spk="THREEPIO"> (to Artoo) Now, don't you forget this! Why I should stick my
+neck out for you is quite beyond my capacity!
+</sp>
+   </scene>
+   <scene n="30">
+      <sd>INTERIOR: LARS HOMESTEAD -- GARAGE AREA -- LATE AFTERNOON.
+	The garage is cluttered and worn, but a friendly peaceful
+	atmosphere permeates the low grey chamber. Threepio lowers
+	himself into a large tub filled with warm oil. Near the
+	battered Landspeeder little Artoo rests on a large battery
+	with a cord to his face.
+</sd>
+      <sp spk="THREEPIO"> Thank the maker! This oil bath is going to feel so good.
+I've got such a bad case of dust contamination, I can barely move!
+		</sp>
+      <sd> Artoo beeps a muffled reply. Luke seems to be lost in
+	thought as he runs his hand over the damaged fin of a small
+	two-man Skyhopper spaceship resting in a low hangar off the
+	garage. Finally Luke's frustrations get the better of him and
+	he slams a wrench across the workbench.
+</sd>
+      <sp spk="LUKE"> It just isn't fair. Oh, Biggs is right. I'm never gonna get out
+of here!
+</sp>
+      <sp spk="THREEPIO"> Is there anything I might do to help? 
+		</sp>
+      <sd> Luke glances at the battered robot. A bit of his anger
+	drains and a tiny smile creeps across his face.
+</sd>
+      <sp spk="LUKE"> Well, not unless you can alter time, speed up the harvest, or
+teleport me off this rock!
+</sp>
+      <sp spk="THREEPIO"> I don't think so, sir. I'm only a droid and not very
+knowledgeable about such things. Not on this planet, anyways. As a
+matter of fact, I'm not even sure which planet I'm on.
+</sp>
+      <sp spk="LUKE"> Well, if there's a bright center to the universe, you're on the
+planet that it's farthest from.
+</sp>
+      <sp spk="THREEPIO"> I see, sir.
+</sp>
+      <sp spk="LUKE"> Uh, you can call me Luke.
+</sp>
+      <sp spk="THREEPIO"> I see, sir Luke.
+</sp>
+      <sp spk="LUKE"> (laughing) Just Luke.
+</sp>
+      <sp spk="THREEPIO"> And I am See-Threepio, human-cyborg relations, and this is
+my counterpart, Artoo-Detoo.
+</sp>
+      <sp spk="LUKE"> Hello.
+		</sp>
+      <sd> Artoo beeps in response. Luke unplugs Artoo and begins to
+	scrape several connectors on the robot's head with a chrome
+	pick. Threepio climbs out of the oil tub and begins wiping oil
+	from his bronze body.
+</sd>
+      <sp spk="LUKE"> You got a lot of carbon scoring here. It looks like you boys
+have seen a lot of action.
+</sp>
+      <sp spk="THREEPIO"> With all we've been through, sometimes I'm amazed we're in
+as good condition as we are, what with the Rebellion and all.
+</sp>
+      <sp spk="LUKE"> You know of the Rebellion against the Empire?
+</sp>
+      <sp spk="THREEPIO"> That's how we came to be in your service, if you take my
+meaning, sir.
+</sp>
+      <sp spk="LUKE"> Have you been in many battles?
+</sp>
+      <sp spk="THREEPIO"> Several, I think. Actually, there's not much to tell. I'm
+not much more than an interpreter, and not very good at telling
+stories. Well, not at making them interesting, anyways.
+		</sp>
+      <sd> Luke struggles to remove a small metal fragment from Artoo's
+	neck joint. He uses a larger pick.
+</sd>
+      <sp spk="LUKE"> Well, my little friend, you've got something jammed in here real
+good. Were you on a cruiser or...
+		</sp>
+      <sd> The fragment breaks loose with a snap, sending Luke
+	tumbling head over heels. He sits up and sees a twelve-inch
+	three-dimensional hologram of Leia Organa, the Rebel senator,
+	being projected from the face of little Artoo. The image is a
+	rainbow of colors as it flickers and jiggles in the dimly lit
+	garage. Luke's mouth hangs open in awe.
+</sd>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi. You're my only hope.
+</sp>
+      <sp spk="LUKE"> What's this?
+		</sp>
+      <sd> Artoo looks around and sheepishly beeps an answer for
+	Threepio to translate. Leia continues to repeat the sentence
+	fragment over and over.
+</sd>
+      <sp spk="THREEPIO"> What is what?!? He asked you a question...(pointing to Leia)
+What is that?
+		</sp>
+      <sd> Artoo whistles his surprise as he pretends to just notice
+	the hologram. He looks around and sheepishly beeps an answer
+	for Threepio to translate. Leia continues to repeat the
+	sentence fragment over and over.
+</sd>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi. You're my only hope. Help me, Obi-Wan
+Kenobi. You're my only hope.
+</sp>
+      <sp spk="THREEPIO"> Oh, he says it's nothing, sir. Merely a malfunction. Old
+data. Pay it no mind.
+		</sp>
+      <sd> Luke becomes intrigued by the beautiful girl.
+</sd>
+      <sp spk="LUKE"> Who is she? She's beautiful.
+</sp>
+      <sp spk="THREEPIO"> I'm afraid I'm not quite sure, sir.
+</sp>
+      <sp spk="LEIA"> Help me, Obi-Wan Kenobi...
+</sp>
+      <sp spk="THREEPIO"> I think she was a passenger on our last voyage. A person of
+some importance, sir -- I believe. Our captain was attached to...
+</sp>
+      <sp spk="LUKE"> Is there more to this recording?
+		</sp>
+      <sd> Luke reaches out for Artoo but he lets out several frantic
+	squeaks and a whistle.
+</sd>
+      <sp spk="THREEPIO"> Behave yourself, Artoo. You're going to get us in trouble.
+It's all right, you can trust him. He's our new master.
+		</sp>
+      <sd> Artoo whistles and beeps a long message to Threepio.
+</sd>
+      <sp spk="THREEPIO"> He says he's the property of Obi-Wan Kenobi, a resident of
+these parts. And it's a private message for him. Quite frankly, sir I
+don't know what he's talking about. Our last master was Captain
+Antilles, but with what we've been through, this little R2 unit has
+become a bit eccentric.
+</sp>
+      <sp spk="LUKE"> Obi-Wan Kenobi? I wonder if he means old Ben Kenobi?
+</sp>
+      <sp spk="THREEPIO"> I beg your pardon, sir, but do you know what he's talking
+about?
+</sp>
+      <sp spk="LUKE"> Well, I don't know anyone named Obi-Wan, but old Ben lives out
+beyond the dune sea. He's kind of a strange old hermit.
+		</sp>
+      <sd> Luke's gazes at the beautiful young princess for a few
+	moments. 
+</sd>
+      <sp spk="LUKE"> I wonder who she is. It sounds like she's in trouble. I'd better
+play back the whole thing.
+		</sp>
+      <sd> Artoo beeps something to Threepio.
+</sd>
+      <sp spk="THREEPIO"> He says the restraining bolt has short circuited his
+recording system. He suggests that if you remove the bolt, he might be
+able to play back the entire recording.
+		</sp>
+      <sd> Luke looks longingly at the lovely, little princess and
+	hasn't really heard what Threepio has been saying.
+</sd>
+      <sp spk="LUKE"> H'm? Oh, yeah, well, I guess you're too small to run away on me
+if I take this off! Okay.
+		</sp>
+      <sd> Luke takes a wedged bar and pops the restraining bolt off
+	Artoo's side.
+</sd>
+      <sp spk="LUKE"> There you go.
+		</sp>
+      <sd> The princess immediately disappears...
+</sd>
+      <sp spk="LUKE"> Well, wait a minute. Where'd she go? Bring her back! Play back
+the entire message.
+		</sp>
+      <sd> Artoo beeps an innocent reply as Threepio sits up in
+	embarrassment.
+</sd>
+      <sp spk="THREEPIO"> What message? The one you're carrying inside your rusty
+innards! 
+		</sp>
+      <sd> A women's voice calls out from another room.
+</sd>
+      <sp spk="AUNT BERU"> Luke? Luke! Come to dinner!
+		</sp>
+      <sd> Luke stands up and shakes his head at the malfunctioning
+	robot.
+</sd>
+      <sp spk="LUKE"> All right, I'll be right there, Aunt Beru.
+</sp>
+      <sp spk="THREEPIO"> I'm sorry, sir, but he appears to have picked up a slight
+flutter.
+		</sp>
+      <sd> Luke tosses Artoo's restraining bolt on the workbench and
+	hurries out of the room.
+</sd>
+      <sp spk="LUKE"> Well, see what you can do with him. I'll be right back.
+</sp>
+      <sp spk="THREEPIO"> (to Artoo) Just you reconsider playing that message for him.
+		</sp>
+      <sd> Artoo beeps in response.
+</sd>
+      <sp spk="THREEPIO"> No, I don't think he likes you at all.
+		</sp>
+      <sd> Artoo beeps.
+</sd>
+      <sp spk="THREEPIO"> No, I don't like you either.
+</sp>
+   </scene>
+   <scene n="31">
+      <sd>INTERIOR: LARS HOMESTEAD -- DINING AREA.
+	 Luke's Aunt Beru, a warm, motherly woman, fills a pitcher
+	with blue fluid from a refrigerated container in the well-used
+	kitchen. She puts the pitcher on a tray with some bowls of
+	food and starts for the dining area.
+		 Luke sits with his Uncle Owen before a table covered with
+	steaming bowls of food as Aunt Beru carries in a bowl of red
+	grain.
+</sd>
+      <sp spk="LUKE"> You know, I think that R2 unit we bought might have been stolen.
+</sp>
+      <sp spk="OWEN"> What makes you think that?
+</sp>
+      <sp spk="LUKE"> Well, I stumbled across a recording while I was cleaning him. He
+says he belongs to someone called Obi-Wan Kenobi.
+		</sp>
+      <sd> Owen is greatly alarmed at the mention of his name, but
+	manages to control himself.
+</sd>
+      <sp spk="LUKE"> I thought he might have meant old Ben. Do you know what he's
+talking about? Well, I wonder if he's related to Ben.
+		</sp>
+      <sd> Owen breaks loose with a fit of uncontrolled anger.
+</sd>
+      <sp spk="OWEN"> That old man's just a crazy old wizard. Tomorrow I want you to
+take that R2 unit into Anchorhead and have its memory flushed. That'll
+be the end of it. It belongs to us now.
+</sp>
+      <sp spk="LUKE"> But what if this Obi-Wan comes looking for him?
+</sp>
+      <sp spk="OWEN"> He won't, I don't think he exists any more. He died about the
+same time as your father.
+</sp>
+      <sp spk="LUKE"> He knew my father?
+</sp>
+      <sp spk="OWEN"> I told you to forget it. Your only concern is to prepare the new
+droids for tomorrow. In the morning I want them on the south ridge
+working out those condensers.
+</sp>
+      <sp spk="LUKE"> Yes, sir. I think those new droids are going to work out fine.
+In fact, I, uh, was also thinking about our agreement about my staying
+on another season. And if these new droids do work out, I want to
+transmit my application to the Academy this year.
+		</sp>
+      <sd> Owen's face becomes a scowl, although he tries to suppress
+	it.
+</sd>
+      <sp spk="OWEN"> You mean the next semester before harvest?
+</sp>
+      <sp spk="LUKE"> Sure, there're more than enough droids.
+</sp>
+      <sp spk="OWEN"> Harvest is when I need you the most. Only one more season. This
+year we'll make enough on the harvest so I'll be able to hire some
+more hands. And then you can go to the Academy next year.
+		</sp>
+      <sd> Luke continues to toy with his food, not looking at his
+	uncle.
+</sd>
+      <sp spk="OWEN"> You must understand I need you here, Luke.
+</sp>
+      <sp spk="LUKE"> But it's a whole 'nother year.
+</sp>
+      <sp spk="OWEN"> Look, it's only one more season.
+		</sp>
+      <sd> Luke pushes his half-eaten plate of food aside and stands.
+</sd>
+      <sp spk="LUKE"> Yeah, that's what you said last year when Biggs and Tank left.
+</sp>
+      <sp spk="AUNT BERU"> Where are you going?
+</sp>
+      <sp spk="LUKE"> It looks like I'm going nowhere. I have to finish cleaning those
+droids.
+		</sp>
+      <sd> Resigned to his fate, Luke paddles out of the room. Owen
+	mechanically finishes his dinner.
+</sd>
+      <sp spk="AUNT BERU"> Owen, he can't stay here forever. Most of his friends have
+gone. It means so much to him.
+</sp>
+      <sp spk="OWEN"> I'll make it up to him next year. I promise.
+</sp>
+      <sp spk="AUNT BERU"> Luke's just not a farmer, Owen. He has too much of his
+father in him.
+</sp>
+      <sp spk="OWEN"> That's what I'm afraid of.
+</sp>
+   </scene>
+   <scene n="32">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	The giant twin suns of Tatooine slowly disappear behind a
+	distant dune range. Luke stands watching them for a few
+	moments, then reluctantly enters the doomed entrance to the
+	homestead.
+</sd>
+   </scene>
+   <scene n="33">
+      <sd>INTERIOR: LARS HOMESTEAD -- GARAGE.
+		 Luke enters the garage to discover the robots nowhere in
+	sight. He takes a small control box from his utility belt
+	similar to the one the Jawas were carrying. He activates the
+	box, which creates a low hum, and Threepio, letting out a
+	short yell, pops up from behind the Skyhopper spaceship.
+</sd>
+      <sp spk="LUKE"> What are you doing hiding there?
+		</sp>
+      <sd> Threepio stumbles forward, but Artoo is still nowhere in
+	sight. 
+</sd>
+      <sp spk="THREEPIO"> It wasn't my fault, sir. Please don't deactivate me. I told
+him not to go, but he's faulty, malfunctioning; kept babbling on about
+his mission.
+</sp>
+      <sp spk="LUKE"> Oh, no!</sp>
+      <sd>Luke races out of the garage followed by Threepio.
+</sd>
+   </scene>
+   <scene n="34">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	Luke rushes out of the small doomed entry to the homestead and
+	searches the darkening horizon for the small triped astro-
+	robot. Threepio struggles out of the homestead and on the salt
+	flat as Luke scans the landscape with his electrobinoculars.
+</sd>
+      <sp spk="THREEPIO"> That R2 unit has always been a problem. These astro-droids
+are getting quite out of hand. Even I can't understand their logic at
+times. 
+</sp>
+      <sp spk="LUKE"> How could I be so stupid? He's nowhere in sight. Blast it!
+</sp>
+      <sp spk="THREEPIO"> Pardon me, sir, but couldn't we go after him?
+</sp>
+      <sp spk="LUKE"> It's too dangerous with all the Sandpeople around. We'll have to
+wait until morning.
+		</sp>
+      <sd> Owen yells up from the homestead plaza.
+</sd>
+      <sp spk="OWEN"> Luke, I'm shutting the power down for the night.
+</sp>
+      <sp spk="LUKE"> All right, I'll be there in a few minutes. Boy, am I gonna get it.</sp>
+      <sd>He takes one final look across the dim horizon.
+</sd>
+      <sp spk="LUKE"> You know that little droid is going to cause me a lot of
+trouble.
+</sp>
+      <sp spk="THREEPIO"> Oh, he excels at that, sir.
+</sp>
+   </scene>
+   <scene n="35">
+      <sd>INTERIOR: LARS HOMESTEAD -- PLAZA.
+	Morning slowly creeps into the sparse but sparkling oasis of
+	the open courtyard. The idyll is broken be the yelling of
+	Uncle Owen, his voice echoing throughout the homestead.
+</sd>
+      <sp spk="OWEN"> Luke? Luke? Luke? Where could he be loafing now!
+</sp>
+   </scene>
+   <scene n="36">
+      <sd>INTERIOR: LARS HOMESTEAD -- KITCHEN.
+	The interior of the kitchen is a worm glow as Aunt Beru prepares
+	the morning breakfast. Owen enters in a huff.
+</sd>
+      <sp spk="OWEN"> Have you seen Luke this morning?
+</sp>
+      <sp spk="AUNT BERU"> He said he had some things to do before he started today,
+so he left early.
+</sp>
+      <sp spk="OWEN"> Uh? Did he take those two new droids with him?
+</sp>
+      <sp spk="AUNT BERU"> I think so.
+</sp>
+      <sp spk="OWEN"> Well, he'd better have those units in the south range repaired
+be midday or there'll be hell to pay!
+</sp>
+   </scene>
+   <scene n="37">
+      <sd>EXTERIOR: TATOOINE -- DESERT WASTELAND -- LUKE'S SPEEDER -- DAY.
+	The rock and sand of the desert floor are a blur as Threepio
+	pilots the sleek Landspeeder gracefully across the vast
+	wasteland. 
+</sd>
+      <sd>INTERIOR/EXTERIOR: LUKE'S SPEEDER -- DESERT WASTELAND -- TRAVELING -- DAY.
+	Luke leans over the back of the speeder and adjusts something
+	in the motor compartment.
+</sd>
+      <sp spk="LUKE"> (yelling) How's that.
+		</sp>
+      <sd> Threepio signals that is fine and Luke turns back into the
+	wind-whipped cockpit and pops the canopy shut.
+</sd>
+      <sp spk="LUKE"> Old Ben Kenobi lives out in this direction somewhere, but I
+don't see how that R2 unit could have come this far. We must have
+missed him. Uncle Owen isn't going to take this very well.
+</sp>
+      <sp spk="THREEPIO"> Sir, would it help if you told him it was my fault.
+</sp>
+      <sp spk="LUKE"> (brightening) Sure. He needs you. He'd probably only deactivate
+you for a day or so...
+</sp>
+      <sp spk="THREEPIO"> Deactivate! Well, on the other hand if you hadn't removed
+his restraining bolt...
+</sp>
+      <sp spk="LUKE"> Wait, there's something dead ahead on the scanner. It looks like
+our droid...hit the accelerator.
+</sp>
+   </scene>
+   <scene n="38">
+      <sd>EXTERIOR: TATOOINE -- ROCK MESA -- DUNE SEA -- COASTLINE -- DAY.
+	From high on a rock mesa, the tiny Landspeeder can be seen
+	gliding across the desert floor. Suddenly in the foreground
+	two weather-beaten Sandpeople shrouded in their grimy desert
+	cloaks peer over the edge of the rock mesa. One of the
+	marginally human creatures raises a long ominous laser rifle
+	and points it at the speeder but the second creature grabs the
+	gun before it can be fired.
+		 The Sandpeople, or Tusken Raiders as they're sometimes
+	called, speak in a coarse barbaric language as they get into
+	an animated argument. The second Tusken Raider seems to get in
+	the final word and the nomads scurry over the rocky terrain.
+</sd>
+   </scene>
+   <scene n="39">
+      <sd>EXTERIOR: TATOOINE -- ROCK MESA -- CANYON.
+	The Tusken Raider approaches two large Banthas standing tied
+	to a rock. The monstrous, bear-like creatures are as large as
+	elephants, with huge red eyes, tremendous looped horns, and
+	long, furry, dinosaur-like tails. The Tusken Raiders mount
+	saddles strapped to the huge creatures' shaggy backs and ride
+	off down the rugged bluff.
+</sd>
+   </scene>
+   <scene n="40">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- FLOOR.
+	The speeder is parked on the floor of a massive canyon. Luke,
+	with his long laser rifle slung over his shoulder, stands
+	before little Artoo.
+</sd>
+      <sp spk="LUKE"> Hey, whoa, just where do you think you're going?
+		</sp>
+      <sd> The little droid whistles a feeble reply, as Threepio poses
+	menacingly behind the little runaway.
+</sd>
+      <sp spk="THREEPIO"> Master Luke here is your rightful owner. We'll have no more
+of this Obi-Wan Kenobi jibberish...and don't talk to me about your
+mission, either. You're fortunate he doesn't blast you into a million
+pieces right here.
+</sp>
+      <sp spk="LUKE"> Well, come on. It's getting late. I only hope we can get back
+before Uncle Owen really blows up.
+</sp>
+      <sp spk="THREEPIO"> If you don't mind my saying so, sir, I think you should
+deactivate the little fugitive until you've gotten him back to your
+workshop.
+</sp>
+      <sp spk="LUKE"> No, he's not going to try anything.
+		</sp>
+      <sd> Suddenly the little robot jumps to life with a mass of
+	frantic whistles and screams.
+</sd>
+      <sp spk="LUKE"> What's wrong with him now?
+</sp>
+      <sp spk="THREEPIO"> Oh my...sir, he says there are several creatures approaching
+from the southeast.
+		</sp>
+      <sd> Luke swings his rifle into position and looks to the south.
+</sd>
+      <sp spk="LUKE"> Sandpeople! Or worst! Come on, let's have a look. Come on.
+</sp>
+   </scene>
+   <scene n="41">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- RIDGE -- DAY.
+	Luke carefully makes his way to the top of a rock ridge and
+	scans the canyon with his electrobinoculars. He spots the two
+	riderless Banthas. Threepio struggles up behind the young
+	adventurer.
+</sd>
+      <sp spk="LUKE"> There are two Banthas down there but I don't see any...wait a
+second, they're Sandpeople all right. I can see one of them now.
+		</sp>
+      <sd> Luke watches the distant Tusken Raider through his
+	electrobinoculars. Suddenly something huge moves in front of
+	his field of view. Before Luke or Threepio can react, a large,
+	gruesome Tusken Raider looms over them. Threepio is startled
+	and backs away, right off the side if the cliff. He can be
+	heard for several moments as he clangs, bangs and rattles down
+	the side of the mountain.
+</sd>
+      <sd> The towering creature brings down his curved,
+	double-pointed gaderffii -- the dreaded axe blade that has
+	struck terror in the heart of the local settlers. But Luke
+	manages to block the blow with his laser rifle, which is
+	smashed to pieces. The terrified farm boy scrambles backward
+	until he is forced to the edge of a deep crevice. The sinister
+	Raider stands over him with his weapon raised and lets out a
+	horrible shrieking laugh.
+</sd>
+   </scene>
+   <scene n="42">
+      <sd>EXTERIOR: TATOOINE -- ROCK CANYON -- FLOOR -- DAY.
+	Artoo forces himself into the shadows of a small alcove in the
+	rocks as the vicious Sandpeople walk past carrying the inert
+	Luke Skywalker, who is dropped in a heap before the speeder.
+	The Sandpeople ransack the speeder, throwing parts and
+	supplies in all directions. Suddenly they stop. Then
+	everything is quiet for a few moments. A great howling moan is
+	heard echoing throughout the canyon which sends the Sandpeople
+	fleeing in terror.
+		 Artoo moves even tighter into the shadows as the slight
+	swishing sound that frightened off the Sandpeople grows even
+	closer, until a shabby old desert-rat-of-a-man appears and
+	leans over Luke. His ancient leathery face, cracked and
+	weathered by exotic climates is set off by dark, penetrating
+	eyes and a scraggly white beard. Ben Kenobi squints his eyes
+	as he scrutinizes the unconscious farm boy. Artoo makes a
+	slight sound and Ben turns and looks right at him.
+</sd>
+      <sp spk="BEN"> Hello there! Come here my little friend. Don't be afraid.</sp>
+      <sd>Artoo waddles over to were Luke lies crumpled in a 
+	heap and begins to whistle and beep his concern. Ben
+	puts his hand on Luke's forehead and he begins to 
+	come around.
+</sd>
+      <sp spk="BEN"> Don't worry, he'll be all right.
+</sp>
+      <sp spk="LUKE"> What happened?
+</sp>
+      <sp spk="BEN"> Rest easy, son, you've had a busy day. You're fortunate you're
+still in one piece.
+</sp>
+      <sp spk="LUKE"> Ben? Ben Kenobi! Boy, am I glad to see you! 
+</sp>
+      <sp spk="BEN"> The Jundland wastes are not to be traveled lightly. Tell me young
+Luke, what brings you out this far?
+</sp>
+      <sp spk="LUKE"> Oh, this little droid! I think he's searching for his former
+master...I've never seen such devotion in a droid before...there
+seems to be no stopping him. He claims to be the property of an Obi-
+Wan Kenobi. Is he a relative of yours? Do you know who he's talking 
+about?</sp>
+      <sd>Ben ponders this for a moment, scratching his scruffy beard.
+</sd>
+      <sp spk="BEN"> Obi-Wan Kenobi...Obi-Wan? Now thats a name I haven't heard in a 
+long time...a long time.
+</sp>
+      <sp spk="LUKE"> I think my uncle knew him. He said he was dead.
+</sp>
+      <sp spk="BEN"> Oh, he's not dead, not...not yet.
+</sp>
+      <sp spk="LUKE"> You know him!
+</sp>
+      <sp spk="BEN"> Well of course, of course I know him. He's me! I haven't gone by
+the name Obi-Wan since oh, before you were born.
+</sp>
+      <sp spk="LUKE"> Then the droid does belong to you.
+</sp>
+      <sp spk="BEN"> Don't seem to remember ever owning a droid. Very interesting...</sp>
+      <sd>He suddenly looks up at the overhanging cliffs.
+</sd>
+      <sp spk="BEN"> I think we better get indoors. The Sandpeople are easily startled
+but they will soon be back and in greater numbers.</sp>
+      <sd>Luke sits up and rubs his head. Artoo lets out a pathetic
+	beep causing Luke to remember something. He looks around.
+</sd>
+      <sp spk="LUKE"> Threepio!
+</sp>
+   </scene>
+   <scene n="43">
+      <sd>EXTERIOR: TATOOINE -- SAND PIT -- ROCK MESA -- DAY.
+	Little Artoo stands at the edge of a large sand pit and begins
+	to chatter away in electronic whistles and beeps. Luke and Ben
+	stand over a very dented and tangled Threepio lying half
+	buried in the sand. One of his arms has broken off.
+		 Luke tries to revive the inert robot by shaking him and
+	then flips a hidden switch on his back several times until
+	finally the mechanical man's systems turn on.
+</sd>
+      <sp spk="THREEPIO"> Where am I? I must have taken a bad step...
+</sp>
+      <sp spk="LUKE"> Can you stand? We've got to get out of here before the
+Sandpeople return.
+</sp>
+      <sp spk="THREEPIO"> I don't think I can make it. You go on, Master Luke. There's
+no sense in you risking yourself on my account. I'm done for.
+	
+		</sp>
+      <sd> Artoo makes a beeping sound.
+</sd>
+      <sp spk="LUKE"> No, you're not. What kind of talk is that?
+		</sp>
+      <sd> Luke and Ben help the battered robot to his feet. Little
+	Artoo watches from the top of the pit. Ben glances around
+	suspiciously. Sensing something, he stands up and sniffs the
+	air.
+</sd>
+      <sp spk="BEN"> Quickly, son...they're on the move.
+</sp>
+   </scene>
+   <scene n="44">
+      <sd>INTERIOR: KENOBI'S DWELLING.
+	The small, spartan hovel is cluttered with desert junk but
+	still manages to radiate an air of time-worn comfort and
+	security. Luke is in one corner repairing Threepio's arm, as
+	old Ben sits thinking.
+</sd>
+      <sp spk="LUKE"> No, my father didn't fight in the wars. He was a navigator on a
+spice freighter.
+</sp>
+      <sp spk="BEN"> That's what your uncle told you. He didn't hold with your
+father's ideals. Thought he should have stayed here and not gotten
+involved.
+</sp>
+      <sp spk="LUKE"> You fought in the Clone Wars?
+</sp>
+      <sp spk="BEN"> Yes, I was once a Jedi Knight the same as your father.
+</sp>
+      <sp spk="LUKE"> I wish I'd known him.
+</sp>
+      <sp spk="BEN"> He was the best star-pilot in the galaxy, and a cunning warrior.
+I understand you've become quite a good pilot yourself. And he was a
+good friend. Which reminds me...
+		</sp>
+      <sd> Ben gets up and goes to a chest where he rummages around.
+	As Luke finishes repairing Threepio and starts to fit the
+	restraining bolt back on, Threepio looks at him nervously.
+	Luke thinks about the bolt for a moment then puts it on the
+	table. Ben shuffles up and presents Luke with a short handle
+	with several electronic gadgets attached to it.
+</sd>
+      <sp spk="BEN"> I have something here for you. Your father wanted you to have
+this when you were old enough, but your uncle wouldn't allow it. He
+feared you might follow old Obi-Wan on some damned-fool idealistic
+crusade like your father did. 
+</sp>
+      <sp spk="THREEPIO"> Sir, if you'll not be needing me, I'll close down for
+awhile.
+</sp>
+      <sp spk="LUKE"> Sure, go ahead.
+		</sp>
+      <sd> Ben hands Luke the saber.
+</sd>
+      <sp spk="LUKE"> What is it?
+</sp>
+      <sp spk="BEN"> Your fathers lightsaber. This is the weapon of a Jedi Knight. Not
+as clumsy or as random as a blaster.
+		</sp>
+      <sd>	 
+		 Luke pushes a button on the handle. A long beam shoots out
+	about four feet and flickers there. The light plays across the
+	ceiling.</sd>
+      <sp spk="BEN"> An elegant weapon for a more civilized time. For over a thousand
+generations the Jedi Knights were the guardians of peace and justice
+in the Old Republic. Before the dark times, before the Empire.
+		</sp>
+      <sd> Luke hasn't really been listening.
+</sd>
+      <sp spk="LUKE"> How did my father die?
+</sp>
+      <sp spk="BEN"> A young Jedi named Darth Vader, who was a pupil of mine until he
+turned to evil, helped the Empire hunt down and destroy the Jedi
+Knights. He betrayed and murdered your father. Now the Jedi are all
+but extinct. Vader was seduced by the dark side of the Force.
+</sp>
+      <sp spk="LUKE"> The Force?
+</sp>
+      <sp spk="BEN"> Well, the Force is what gives a Jedi his power. It's an energy
+field created by all living things. It surrounds us and penetrates us.
+It binds the galaxy together.
+		</sp>
+      <sd> Artoo makes beeping sounds.
+</sd>
+      <sp spk="BEN"> Now, let's see if we can't figure out what you are, my little
+friend. And where you come from.
+</sp>
+      <sp spk="LUKE"> I saw part of the message he was...
+		</sp>
+      <sd> Luke is cut short as the recorded image of the beautiful
+	young Rebel princess is projected from Artoo's face.
+</sd>
+      <sp spk="BEN"> I seem to have found it.
+		</sp>
+      <sd> Luke stops his work as the lovely girl's image flickers
+	before his eyes.
+</sd>
+      <sp spk="LEIA"> General Kenobi, years ago you served my father in the Clone
+Wars. Now he begs you to help him in his struggle against the Empire.
+I regret that I am unable to present my father's request to you in
+person, but my ship has fallen under attack and I'm afraid my mission
+to bring you to Alderaan has failed. I have placed information vital
+to the survival of the Rebellion into the memory systems of this R2
+unit. My father will know how to retrieve it. You must see this droid
+safely delivered to him on Alderaan. This is our most desperate hour.
+Help me, Obi-Wan Kenobi, you're my only hope.</sp>
+      <sd>There is a little static and the transmission is cut short.
+	Old Ben leans back and scratches his head. He silently puffs
+	on a tarnished chrome water pipe. Luke has stars in his eyes.
+</sd>
+      <sp spk="BEN"> You must learn the ways of the Force if you're to come with me to
+Alderaan.
+</sp>
+      <sp spk="LUKE"> (laughing) Alderaan? I'm not going to Alderaan. I've got to go
+home. It's late, I'm in for it as it is.
+</sp>
+      <sp spk="BEN"> I need your help, Luke. She needs your help. I'm getting too old
+for this sort of thing.
+</sp>
+      <sp spk="LUKE"> I can't get involved! I've got work to do! It's not that I like
+the Empire. I hate it! But there's nothing I can do about it right
+now. It's such a long way from here.
+</sp>
+      <sp spk="BEN"> That's your uncle talking.
+</sp>
+      <sp spk="LUKE"> (sighing) Oh, God, my uncle. How am I ever going to explain
+this?
+</sp>
+      <sp spk="BEN"> Learn about the Force, Luke.
+</sp>
+      <sp spk="LUKE"> Look, I can take you as far as Anchorhead. You can get a
+transport there to Mos Eisley or wherever you're going.
+</sp>
+      <sp spk="BEN"> You must do what you feel is right, of course.
+</sp>
+   </scene>
+   <scene n="45">
+      <sd>EXTERIOR: SPACE.
+	An Imperial Stardestroyer heads toward the evil planet-like
+	battle station: the Death Star!
+</sd>
+   </scene>
+   <scene n="46">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Eight Imperial senators and generals sit around a black
+	conference table. Imperial stormtroopers stand guard around
+	the room. Commander Tagge, a young, slimy-looking general, is
+	speaking.
+</sd>
+      <sp spk="TAGGE"> Until this battle station is fully operational we are
+vulnerable. The Rebel Alliance is too well equipped. They're more
+dangerous than you realize.
+		</sp>
+      <sd> The bitter Admiral Motti twists nervously in his chair.
+</sd>
+      <sp spk="MOTTI"> Dangerous to your starfleet, Commander, not to this battle
+station!
+</sp>
+      <sp spk="TAGGE"> The Rebellion will continue to gain a support in the Imperial
+Senate as long as....
+		</sp>
+      <sd> Suddenly all heads turn as Commander Tagge's speech is cut
+	short and the Grand Moff Tarkin, governor of the Imperial
+	outland regions, enters. He is followed by his powerful ally,
+	The Sith Lord, Darth Vader. All of the generals stand and bow
+	before the thin, evil-looking governor as he takes his place
+	at the head of the table. The Dark Lord stands behind him.
+</sd>
+      <sp spk="TARKIN"> The Imperial Senate will no longer be of any concern to us.
+I've just received word that the Emperor has dissolved the council
+permanently. The last remnants of the Old Republic have been swept
+away.
+</sp>
+      <sp spk="TAGGE"> That's impossible! How will the Emperor maintain control
+without the bureaucracy?
+</sp>
+      <sp spk="TARKIN"> The regional governors now have direct control over
+territories. Fear will keep the local systems in line. Fear of this
+battle station.
+</sp>
+      <sp spk="TAGGE"> And what of the Rebellion? If the Rebels have obtained a
+complete technical readout of this station, it is possible, however
+unlikely, that they might find a weakness and exploit it.
+</sp>
+      <sp spk="VADER"> The plans you refer to will soon be back in our hands.
+</sp>
+      <sp spk="MOTTI"> Any attack made by the Rebels against this station would be a
+useless gesture, no matter what technical data they've obtained. This
+station is now the ultimate power in the universe. I suggest we use
+it!
+</sp>
+      <sp spk="VADER"> Don't be too proud of this technological terror you've
+constructed. The ability to destroy a planet is insignificant next to
+the power of the Force.
+</sp>
+      <sp spk="MOTTI"> Don't try to frighten us with your sorcerer's ways, Lord Vader.
+Your sad devotion to that ancient religion has not helped you conjure
+up the stolen data tapes, or given you clairvoyance enough to find the
+Rebel's hidden fort...
+		</sp>
+      <sd> Suddenly Motti chokes and starts to turn blue under Vader's
+	spell.
+</sd>
+      <sp spk="VADER"> I find your lack of faith disturbing.
+</sp>
+      <sp spk="TARKIN"> Enough of this! Vader, release him!
+</sp>
+      <sp spk="VADER"> As you wish.
+</sp>
+      <sp spk="TARKIN"> This bickering is pointless. Lord Vader will provide us with
+the location of the Rebel fortress by the time this station is
+operational. We will then crush the Rebellion with one swift stroke.
+</sp>
+   </scene>
+   <scene n="47">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	The speeder stops before what remains of the huge Jawas
+	Sandcrawler. Luke and Ben walk among the smoldering rubble
+	and scattered bodies.
+</sd>
+      <sp spk="LUKE"> It looks like Sandpeople did this, all right. Look, here are
+Gaffi sticks, Bantha tracks. It's just...I never heard of them hitting
+anything this big before.
+		</sp>
+      <sd> Ben is crouching in the sand studying the tracks.
+</sd>
+      <sp spk="BEN"> They didn't. But we are meant to think they did. These tracks are
+side by side. Sandpeople always ride single file to hide there numbers.
+</sp>
+      <sp spk="LUKE"> These are the same Jawas that sold us Artoo and Threepio.
+</sp>
+      <sp spk="BEN"> And these blast points, too accurate for Sandpeople. Only
+Imperial stormtroopers are so precise.
+</sp>
+      <sp spk="LUKE"> Why would Imperial troops want to slaughter Jawas?
+		</sp>
+      <sd> Luke looks back at the speeder where Artoo and Threepio are
+	inspecting the dead Jawas, and put two and two together.
+</sd>
+      <sp spk="LUKE"> If they traced the robots here, they may have learned who they
+sold them to. And that would lead them home!
+		</sp>
+      <sd> Luke reaches a sudden horrible realization, then races for
+	the speeder and jumps it.
+</sd>
+      <sp spk="BEN"> Wait, Luke! It's too dangerous.
+		</sp>
+      <sd> Luke races off leaving Ben and the two robots alone with
+	the burning Sandcrawler.
+</sd>
+   </scene>
+   <scene n="48">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	Luke races across the wasteland in his battered Landspeeder.
+</sd>
+   </scene>
+   <scene n="49">
+      <sd>EXTERIOR: TATOOINE -- LARS HOMESTEAD.
+	The speeder roars up to the burning homestead. Luke jumps out
+	and runs to the smoking holes that were once his home. Debris
+	is scattered everywhere and it looks as if a great battle has
+	taken place.
+</sd>
+      <sp spk="LUKE"> Uncle Owen! Aunt Beru! Uncle Owen!
+		</sp>
+      <sd> Luke stumbles around in a daze looking for his aunt and
+	uncle. Suddenly he comes upon their smoldering remains. He is
+	stunned, and cannot speak. Hate replaces fear and a new
+	resolve comes over him.
+</sd>
+   </scene>
+   <scene n="50">
+      <sd>EXTERIOR: SPACE.
+	Imperial TIE fighter races toward the Death Star.
+</sd>
+   </scene>
+   <scene n="51">
+      <sd>INTERIOR: DEATH STAR -- DETENTION CORRIDOR.
+	Two stormtroopers open an electronic cell door and allow
+	several Imperial guards to enter. Princess Leia's face is
+	filled with defiance, which slowly gives way to fear as a
+	giant black torture robot enters, followed by Darth Vader.
+</sd>
+      <sp spk="VADER"> And, now Your Highness, we will discuss the location of your
+hidden Rebel base.
+		</sp>
+      <sd> The torture robot gives off a steady beeping sound as it
+	approaches Princess Leia and extends one of its mechanical
+	arms bearing a large hypodermic needle. The door slides shut
+	and the long cell block hallway appears peaceful. The muffled
+	screams of the Rebel princess are barely heard.
+</sd>
+   </scene>
+   <scene n="52">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	There is a large bonfire of Jawa bodies blazing in front of
+	the Sandcrawler as Ben and the robots finish burning the dead.
+	Luke drives up in the speeder and Ben walks over to him.
+</sd>
+      <sp spk="BEN"> There's nothing you could have done, Luke, had you been there.
+You'd have been killed, too, and the droids would be in the hands of
+the Empire.
+</sp>
+      <sp spk="LUKE"> I want to come with you to Alderaan. There's nothing here for me
+now. I want to learn the ways of the Force and become a Jedi like my
+father.
+</sp>
+   </scene>
+   <scene n="53">
+      <sd>EXTERIOR: TATOOINE -- WASTELAND.
+	The Landspeeder with Luke, Artoo, Threepio, and Ben in it
+	zooms across the desert. The speeder stops on a bluff
+	overlooking the spaceport at Mos Eisley. It is a haphazard
+	array of low, grey, concrete structures and semi-domes. A
+	harsh gale blows across the stark canyon floor. Luke adjusts
+	his goggles and walks to the edge of the craggy bluff where
+	Ben is standing.
+</sd>
+      <sp spk="BEN"> Mos Eisley Spaceport. You will never find a more wretched hive of
+scum and villainy. We must be cautious.
+		</sp>
+      <sd> Ben looks over at Luke, who gives the old Jedi a determined
+	smile.
+</sd>
+   </scene>
+   <scene n="54">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	The speeder is stopped on a crowded street by several
+	combat-hardend stormtroopers who look over the two robots. A
+	Trooper questions Luke.
+</sd>
+      <sp spk="TROOPER"> How long have you had these droids?
+</sp>
+      <sp spk="LUKE"> About three or four seasons.
+</sp>
+      <sp spk="BEN"> They're for sale if you want them.
+</sp>
+      <sp spk="TROOPER"> Let me see your identification.
+		</sp>
+      <sd> Luke becomes very nervous as he fumbles to find his ID
+	while Ben speaks to the Trooper in a very controlled voice.
+</sd>
+      <sp spk="BEN"> You don't need to see his identification.
+</sp>
+      <sp spk="TROOPER"> We don't need to see his identification.
+</sp>
+      <sp spk="BEN"> These are not the droids your looking for.
+</sp>
+      <sp spk="TROOPER"> These are not the droids we're looking for.
+</sp>
+      <sp spk="BEN"> He can go about his business.
+</sp>
+      <sp spk="TROOPER"> You can go about your business.
+</sp>
+      <sp spk="BEN"> (to Luke) Move along.
+</sp>
+      <sp spk="TROOPER"> Move along. Move along.
+</sp>
+   </scene>
+   <scene n="55">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	The speeder pulls up in front of a rundown blockhouse cantina
+	on the outskirts of the spaceport. Various strange forms of
+	transport, including several unusual beasts of burden, are
+	parked outside the bar. A Jawa runs up and begins to fondle
+	the speeder.
+</sd>
+      <sp spk="THREEPIO"> I can't abide these Jawas. Disgusting creatures.
+		</sp>
+      <sd> As Luke gets out of the speeder he tries to shoo the Jawa
+	away.
+	 
+</sd>
+      <sp spk="LUKE"> Go on, go on. I can't understand how we got by those troopers. I
+thought we were dead.
+</sp>
+      <sp spk="BEN"> The Force can have a strong influence on the weak-minded. You
+will find it a powerful ally.
+</sp>
+      <sp spk="LUKE"> Do you really think we're going to find a pilot here that'll
+take us to Alderaan?
+</sp>
+      <sp spk="BEN"> Well, most of the best freighter pilots can be found here. Only
+watch your step. This place can be a little rough.
+</sp>
+      <sp spk="LUKE"> I'm ready for anything.
+</sp>
+      <sp spk="THREEPIO"> Come along, Artoo.
+</sp>
+   </scene>
+   <scene n="56">
+      <sd>INTERIOR: TATOOINE -- MOS EISLEY -- CANTINA.
+	The young adventurer and his two mechanical servants follow
+	Ben Kenobi into the smoke-filled cantina. The murky, moldy den
+	is filled with a startling array of weird and exotic alien
+	creatures and monsters at the long metallic bar. At first the
+	sight is horrifying. One-eyed, thousand-eyed, slimy, furry,
+	scaly, tentacled, and clawed creatures huddle over drinks. Ben
+	moves to an empty spot at the bar near a group of repulsive
+	but human scum. A huge, rough-looking Bartender stops Luke and
+	the robots.
+</sd>
+      <sp spk="BARTENDER"> We don't serve their kind here!
+		</sp>
+      <sd> Luke still recovering from the shock of seeing so many
+	outlandish creatures, doesn't quite catch the bartender's
+	drift.
+</sd>
+      <sp spk="LUKE"> What?
+</sp>
+      <sp spk="BARTENDER"> Your droids. They'll have to wait outside. We don't want
+them here.
+		</sp>
+      <sd> Luke looks at old Ben, who is busy talking to one of the
+	Galactic pirates. He notices several of the gruesome creatures
+	along the bar are giving him a very unfriendly glare.
+</sd>
+      <sd> Luke pats Threepio on the shoulder.
+</sd>
+      <sp spk="LUKE"> Listen, why don't you wait out by the speeder. We don't want any
+trouble.
+</sp>
+      <sp spk="THREEPIO"> I heartily agree with you sir.</sp>
+      <sd>Threepio and his stubby partner go outside and most of the
+	creatures at the bar go back to their drinks.
+		</sd>
+      <sd> Ben is standing next to Chewbacca, an eight-foot-tall-
+	savage-looking creature resembling a huge grey bushbaby monkey
+	with fierce baboon-like fangs. His large blue eyes dominate a
+	fur-covered face and soften his otherwise awesome appearance.
+	Over his matted, furry body he wears two chrome bandoliers,
+	and little else. He is a two-hundred-year-old Wookiee and a
+	sight to behold.
+</sd>
+      <sd>Ben speaks to the Wookiee, pointing to Luke several times
+	during his conversation and the huge creature suddenly lets
+	out a horrifying laugh. Luke is more than a little bit
+	disconcerted and pretends not to hear the conversation between
+	Ben and the giant Wookiee.</sd>
+      <sd>&gt;Luke is terrified but tries not to show it. He quietly sips
+	his drink, looking over the crowd for a more sympathetic ear
+	or whatever.</sd>
+      <sd>A large, multiple-eyed Creature gives Luke a rough shove.</sd>
+      <sp spk="CREATURE"> Negola dewaghi wooldugger?!?
+		</sp>
+      <sd> The hideous freak is obviously drunk. Luke tries to ignore
+	the creature and turns back on his drink. A short, grubby
+	Human and an even smaller rodent-like beast join the
+	belligerent monstrosity.
+</sd>
+      <sp spk="HUMAN"> He doesn't like you.
+</sp>
+      <sp spk="LUKE"> I'm sorry.
+</sp>
+      <sp spk="HUMAN"> I don't like you either
+		</sp>
+      <sd> The big creature is getting agitated and yells out some
+	unintelligible gibberish at the now rather nervous, young
+	adventurer.
+</sd>
+      <sp spk="HUMAN"> (continued) Don't insult us. You just watch yourself. We're
+wanted men. I have the death sentence in twelve systems.
+</sp>
+      <sp spk="LUKE"> I'll be careful than.
+</sp>
+      <sp spk="HUMAN"> You'll be dead.
+		</sp>
+      <sd> The rodent lets out a loud grunt and everything at the bar
+	moves away. Luke tries to remain cool but it isn't easy. His
+	three adversaries ready their weapons. Old Ben moves in behind
+	Luke.
+</sd>
+      <sp spk="BEN"> This little one isn't worth the effort. Come let me buy you
+something...
+		</sp>
+      <sd> A powerful blow from the unpleasant creature sends the
+	young would-be Jedi sailing across the room, crashing through
+	tables and breaking a large jug filled with a foul-looking
+	liquid. With a blood curdling shriek, the monster draws a
+	wicked chrome laser pistol from his belt and levels it at old
+	Ben. The bartender panics.
+</sd>
+      <sp spk="BARTENDER"> No blasters! No blaster!
+		</sp>
+      <sd> With astounding agility old Ben's laser sword sparks to
+	life and in a flash an arm lies on the floor. The rodent is
+	cut in two and the giant multiple-eyed creature lies doubled,
+	cut from chin to groin. Ben carefully and precisely turns off
+	his laser sword and replaces it on his utility belt. Luke,
+	shaking and totally amazed at the old man's abilities, attempts
+	to stand. The entire fight has lasted only a matter of seconds.
+	The cantina goes back to normal, although Ben is given a
+	respectable amount of room at the bar. Luke, rubbing his
+	bruised head, approaches the old man with new awe. Ben points
+	the the Wookiee.
+</sd>
+      <sp spk="BEN"> This is Chewbacca. He's first-mate on a ship that might suit our
+needs.
+</sp>
+   </scene>
+   <scene n="57">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Threepio paces in front of the cantina as Artoo carries on an
+	electronic conversation with another little red astro-droid. A
+	creature comes out of the cantina and approaches two
+	stormtroopers in the street.
+</sd>
+      <sp spk="THREEPIO"> I don't like the look of this.
+</sp>
+   </scene>
+   <scene n="58">
+      <sd>INTERIOR: TATOOINE -- MOS EISLEY -- CANTINA.
+	Strange creatures play exotic big band music on odd-looking
+	instruments as Luke, still giddy, downs a fresh drink and
+	follows Ben and Chewbacca to a booth where Han Solo is
+	sitting. Han is a tough, roguish starpilot about thirty years
+	old. A mercenary on a starship, he is simple, sentimental, and
+	cocksure.
+</sd>
+      <sp spk="HAN"> Han Solo. I'm captain of the Millennium Falcon. Chewie here tells
+me you're looking for passage to the Alderaan system.
+</sp>
+      <sp spk="BEN"> Yes, indeed. If it's a fast ship.
+</sp>
+      <sp spk="HAN"> Fast ship? You've never heard of the Millennium Falcon?
+</sp>
+      <sp spk="BEN"> Should I have?
+</sp>
+      <sp spk="HAN"> It's the ship that made the Kessel run in less than twelve
+parsecs!
+		</sp>
+      <sd> Ben reacts to Solo's stupid attempt to impress them with
+	obvious misinformation.
+</sd>
+      <sp spk="HAN"> (continued) I've outrun Imperial starships, not the local
+bulk-cruisers, mind you. I'm talking about the big Corellian ships
+now. She's fast enough for you, old man. What's the cargo?
+</sp>
+      <sp spk="BEN"> Only passengers. Myself, the boy, two droids, and no questions
+asked.
+</sp>
+      <sp spk="HAN"> What is it? Some kind of local trouble?
+</sp>
+      <sp spk="BEN"> Let's just say we'd like to avoid any Imperial entanglements.
+</sp>
+      <sp spk="HAN"> Well, that's the trick, isn't it? And it's going to cost you
+something extra. Ten thousand in advance.
+</sp>
+      <sp spk="LUKE"> Ten thousand? We could almost buy our own ship for that!
+</sp>
+      <sp spk="HAN"> But who's going to fly it, kid! You?
+</sp>
+      <sp spk="LUKE"> You bet I could. I'm not such a bad pilot myself! We don't have
+to sit here and listen...
+</sp>
+      <sp spk="BEN"> We haven't that much with us. But we could pay you two thousand
+now, plus fifteen when we reach Alderaan.
+</sp>
+      <sp spk="HAN"> Seventeen, huh!
+		</sp>
+      <sd> Han ponders this for a few moments.
+</sd>
+      <sp spk="HAN"> Okay. You guys got yourself a ship. We'll leave as soon as you're
+ready. Docking bay Ninety-four.
+</sp>
+      <sp spk="BEN"> Ninety-four.
+</sp>
+      <sp spk="HAN"> Looks like somebody's beginning to take an interest in your
+handiwork.
+		</sp>
+      <sd> Ben and Luke turn around to see four Imperial stormtroopers
+	looking at the dead bodies and asking the bartenders some
+	questions. The bartender points to the booth.
+</sd>
+      <sp spk="TROOPER"> All right, we'll check it out.
+		</sp>
+      <sd> The stormtroopers look over at the booth but Luke and Ben
+	are gone. The bartender shrugs his shoulders in puzzlement.
+</sd>
+      <sp spk="HAN"> Seventeen thousand! Those guys must really be desperate. This
+could really save my neck. Get back to the ship and get her ready.
+</sp>
+   </scene>
+   <scene n="59">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+</sd>
+      <sp spk="BEN"> You'll have to sell your speeder.
+</sp>
+      <sp spk="LUKE"> That's okay. I'm never coming back to this planet again.
+</sp>
+   </scene>
+   <scene n="60">
+      <sd>INTERIOR: MOS EISLEY -- CANTINA.
+	As Han is about to leave, Greedo, a slimy green-faced alien 
+	with a short trunk-nose, pokes a gun in his side. The creature
+	speaks in a foreign tongue translated into English subtitles.
+</sd>
+      <sp spk="GREEDO"> Going somewhere, Solo?
+</sp>
+      <sp spk="HAN"> Yes, Greedo. As a matter of fact, I was just going to see your
+boss. Tell Jabba that I've got his money.
+		</sp>
+      <sd> Han sits down and the alien sits across from him holding
+	the gun on him.
+</sd>
+      <sp spk="GREEDO"> It's too late. You should have paid him when you had the
+chance. Jabba's put a price on your head, so large that every bounty
+hunter in the galaxy will be looking for you. I'm lucky I found you
+first.
+</sp>
+      <sp spk="HAN"> Yeah, but this time I got the money.
+</sp>
+      <sp spk="GREEDO"> If you give it to me, I might forget I found you.
+</sp>
+      <sp spk="HAN"> I don't have it with me. Tell Jabba...
+</sp>
+      <sp spk="GREEDO"> Jabba's through with you. He has no time for smugglers who
+drop their shipments at the first sign of an Imperial cruiser.
+</sp>
+      <sp spk="HAN"> Even I get boarded sometimes. Do you think I had a choice?
+	
+		</sp>
+      <sd> Han Solo slowly reaches for his gun under the table.
+</sd>
+      <sp spk="GREEDO"> You can tell that to Jabba. He may only take your ship.
+</sp>
+      <sp spk="HAN"> Over my dead body.
+</sp>
+      <sp spk="GREEDO"> That's the idea. I've been looking forward to killing you for
+a long time.
+</sp>
+      <sp spk="HAN"> Yes, I'll bet you have.
+		</sp>
+      <sd> Suddenly the slimy alien disappears in a blinding flash of
+	light. Han pulls his smoking gun from beneath the table as the
+	other patron look on in bemused amazement. Han gets up and
+	starts out of the cantina, flipping the bartender some coins
+	as he leaves.
+</sd>
+      <sp spk="HAN"> Sorry about the mess.
+</sp>
+   </scene>
+   <scene n="61">
+      <sd>EXTERIOR: SPACE.
+	Several TIE fighters approach the Death Star.
+</sd>
+   </scene>
+   <scene n="62">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+</sd>
+      <sp spk="VADER"> Her resistance to the mind probe is considerable. It will be
+some time before we can extract any information from her.
+		</sp>
+      <sd> An Imperial Officer interrupts the meeting.
+</sd>
+      <sp spk="IMPERIAL OFFICER"> The final check-out is complete. All systems are
+operational. What course shall we set?
+</sp>
+      <sp spk="TARKIN"> Perhaps she would respond to an alternative form of
+persuasion.
+</sp>
+      <sp spk="VADER"> What do you mean?
+</sp>
+      <sp spk="TARKIN"> I think it is time we demonstrate the full power of this
+station. (to soldier) Set your course for Princess Leia's home planet
+of Alderaan.
+</sp>
+      <sp spk="TROOPER"> With pleasure.
+</sp>
+   </scene>
+   <scene n="63">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Four heavily-armed stormtroopers move menacingly along a
+	narrow slum alleyway crowed with darkly clad creatures hawking
+	exotic goods in the dingy little stalls. Men, monsters, and
+	robots crouch in the waste-filled doorways, whispering and
+	hiding from the hot winds.
+</sd>
+      <sp spk="THREEPIO"> Lock the door, Artoo.
+		</sp>
+      <sd> One of the troopers checks a tightly locked door and moves
+	on down the alleyway. The door slides open a crack and
+	Threepio peeks out. Artoo is barely visible in the background.
+</sd>
+      <sp spk="TROOPER"> All right, check that side of the street. It's secure. Move
+on to the next door.
+		</sp>
+      <sd> The door opens, Threepio moves into the doorway.
+</sd>
+      <sp spk="THREEPIO"> I would much rather have gone with Master Luke than stay
+here with you. I don't know what all the trouble is about, but I'm
+sure it must be your fault.
+		</sp>
+      <sd> Artoo makes beeping sounds.
+</sd>
+      <sp spk="THREEPIO"> You watch your language!
+</sp>
+   </scene>
+   <scene n="64">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET -- ALLEYWAY -- USED SPEEDER LOT.
+	Ben and Luke are standing in a sleazy used speeder lot,
+	talking with a tall, grotesque, insect-like used speeder
+	dealer. Strange exotic bodies and spindly-legged beasts pass
+	by as the insect concludes the sale by giving Luke some coins.
+</sd>
+      <sp spk="LUKE"> He says it's the best he can do. Since the XP-38 came out,
+they're just not in demand.
+</sp>
+      <sp spk="BEN"> It will be enough.
+		</sp>
+      <sd> Ben and Luke leave the speeder lot and walk down the dusty
+	alleyway past a small robot herding a bunch of anteater-like
+	creatures. Luke turns and gives one last forlorn look at his
+	faithful speeder as he rounds a corner. A darkly clad creature
+	moves out of the shadows as they pass and watches them as they
+	disappear down another alley.
+</sd>
+      <sp spk="BEN"> If the ship's as fast as he's boasting, we ought to do well.
+</sp>
+   </scene>
+   <scene n="65">
+      <sd>INTERIOR: DOCKING BAY 94 -- DAY.
+	Jabba the Hut and a half-dozen grisly alien pirates and purple
+	creatures stand in the middle of the docking bay. Jabba is the
+	grossest of the slavering hulks and his scarred face is a grim
+	testimonial to his prowess as a vicious killer. He is a fat,
+	slug-like creature with eyes on extended feelers and a huge
+	ugly mouth.
+</sd>
+      <sp spk="JABBA"> Come on out, Solo!
+		</sp>
+      <sd> A voice from directly behind the pirates startles them and
+	they turn around to see Han Solo and the giant Wookiee,
+	Chewbacca, standing behind them with no weapons in sight.
+</sd>
+      <sp spk="HAN"> I've been waiting for you, Jabba.
+</sp>
+      <sp spk="JABBA"> I expected you would be.
+</sp>
+      <sp spk="HAN"> I'm not the type to run.
+</sp>
+      <sp spk="JABBA"> (fatherly-smooth) Han, my boy, there are times when you
+disappoint me...why haven't you paid me? And why did you have to fry
+poor Greedo like that...after all we've been through together.
+</sp>
+      <sp spk="HAN"> You sent Greedo to blast me.
+</sp>
+      <sp spk="JABBA"> (mock surprise) Han, why you're the best smuggler in the
+business. You're too valuable to fry. He was only relaying my concern
+at your delays. He wasn't going to blast you.
+</sp>
+      <sp spk="HAN"> I think he thought he was. Next time don't send one of those
+twerps. If you've got something to say to me, come see me yourself.
+</sp>
+      <sp spk="JABBA"> Han, Han! If only you hadn't had to dump that shipment of
+spice...you understand I just can't make an exception. Where would I
+be if every pilot who smuggled for me dumped their shipment at the
+first sign of an Imperial starship? It's not good business.
+</sp>
+      <sp spk="HAN"> You know, even I get boarded sometimes, Jabba. I had no choice,
+but I've got a charter now and I can pay you back, plus a little
+extra. I just need some more time.
+</sp>
+      <sp spk="JABBA"> (to his men) Put your blasters away. Han, my boy, I'm only
+doing this because you're the best and I need you. So, for an extra,
+say twenty percent I'll give you a little more time...but this is it.
+If you disappoint me again, I'll put a price on your head so large you
+won't be able to go near a civilized system for the rest of your short
+life.
+</sp>
+      <sp spk="HAN"> Jabba, I'll pay you because it's my pleasure.
+</sp>
+   </scene>
+   <scene n="66">
+      <sd>EXTERIOR: DOCKING PORT ENTRY -- ALLEYWAY.
+	Chewbacca waits restlessly at the entrance to Docking Bay 94.
+	Ben, Luke, and the robots make their way up the street.
+	Chewbacca jabbers excitedly and signals for them to hurry. The
+	darkly clad creature has followed them from the speeder lot.
+	He stops in a nearby doorway and speaks into a small
+	transmitter.
+</sd>
+   </scene>
+   <scene n="67">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94
+	Chewbacca leads the group into a giant dirt pit that is Docking
+	Bay 94. Resting in the middle of the huge hole is a large,
+	round, beat-up, pieced-together hunk of junk that could only
+	loosely be called a starship.
+</sd>
+      <sp spk="LUKE"> What a piece of junk.
+		</sp>
+      <sd> The tall figure of Han Solo comes down the boarding ramp.
+</sd>
+      <sp spk="HAN"> She'll make point five beyond the speed of light. She may not
+look like much, but she's got it where it counts, kid. I've added some
+special modifications myself.
+		</sp>
+      <sd> Luke scratches his head. It's obvious he isn't sure about
+	all this. Chewbacca rushes up the ramp and urges the others to
+	follow.
+</sd>
+      <sp spk="HAN"> We're a little rushed, so if you'll hurry aboard we'll get out of
+here.
+		</sp>
+      <sd> The group rushes up the gang plank, passing a grinning Han
+	Solo.
+</sd>
+   </scene>
+   <scene n="68">
+      <sd>INTERIOR: MILLENNIUM FALCON.
+	Chewbacca settles into the pilot's chair and starts the mighty
+	engines of the starship.
+</sd>
+   </scene>
+   <scene n="69">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94.
+	Luke, Ben, Threepio, and Artoo move toward the Millennium
+	Falcon passing Solo.
+</sd>
+      <sp spk="THREEPIO"> Hello, sir.
+</sp>
+   </scene>
+   <scene n="70">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREET.
+	Eight Imperial stormtroopers rush up to the darkly clad
+	creature.
+</sd>
+      <sp spk="TROOPER"> Which way?
+		</sp>
+      <sd> The darkly clad creature points to the door of the docking
+	bay.
+</sd>
+      <sp spk="TROOPER"> All right, men. Load your weapons!
+</sp>
+   </scene>
+   <scene n="71">
+      <sd>INTERIOR: MOS EISLEY SPACEPORT -- DOCKING BAY 94.
+	The troops hold their guns at the ready and charge down the
+	docking bay entrance.
+</sd>
+      <sp spk="TROOPER"> Stop that ship!
+		</sp>
+      <sd> Han Solo looks up and sees the Imperial stormtroopers
+	rushing into the docking bay. Several of the troopers fire at
+	Han as he ducks into the spaceship.
+</sd>
+      <sp spk="TROOPER"> Blast 'em!
+		</sp>
+      <sd> Han draws his laser pistol and pops off a couple of shots
+	which force the stormtroopers to dive for safety. The
+	pirateship engines whine as Han hits the release button that
+	slams the overhead entry shut.
+</sd>
+   </scene>
+   <scene n="72">
+      <sd>INTERIOR: MILLENNIUM FALCON.
+</sd>
+      <sp spk="HAN"> Chewie, get us out of here!
+		</sp>
+      <sd> The group straps in for take off.
+</sd>
+      <sp spk="THREEPIO"> Oh, my. I'd forgotten how much I hate space travel.
+</sp>
+   </scene>
+   <scene n="73">
+      <sd>EXTERIOR: TATOOINE -- MOS EISLEY -- STREETS.
+	The half-dozen stormtroopers at a check point hear the general
+	alarm and look to the sky as the huge starship rises above the
+	dingy slum dwellings and quickly disappears into the morning
+	sky.
+</sd>
+   </scene>
+   <scene n="74">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han climbs into the pilot's chair next to Chewbacca, who
+	chatters away as he points to something on the radar scope.
+</sd>
+   </scene>
+   <scene n="75">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	The Corellian pirateship zooms from Tatooine into space.
+</sd>
+   </scene>
+   <scene n="76">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han frantically types information into the ship's computer.
+	Little Artoo appears momentarily at the cockpit doorway, makes
+	a few beeping remarks, then scurries away.
+</sd>
+      <sp spk="HAN"> It looks like an Imperial cruiser. Our passengers must be hotter
+than I thought. Try and hold them off. Angle the deflector shield
+while I make the calculations for the jump to light speed.
+</sp>
+   </scene>
+   <scene n="77">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	The Millennium Falcon pirateship races away from the yellow
+	planet, Tatooine. It is followed by two huge Imperial
+	stardestroyers.
+</sd>
+   </scene>
+   <scene n="78">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Over the shoulders of Chewbacca and Han, we can see the galaxy
+	spread before them. Luke and Ben make their way into the
+	cramped cockpit where Han continues his calculation.
+</sd>
+      <sp spk="HAN"> Stay sharp! There are two more coming in; they're going to try to
+cut us off.
+</sp>
+      <sp spk="LUKE"> Why don't you outrun them? I thought you said this thing was
+fast.
+</sp>
+      <sp spk="HAN"> Watch your mouth, kid, or you're going to find yourself floating
+home. We'll be safe enough once we make the jump to hyperspace.
+Besides, I know a few maneuvers. We'll lose them!
+</sp>
+   </scene>
+   <scene n="79">
+      <sd>EXTERIOR: SPACE -- PLANET TATOOINE.
+	Imperial cruisers fire at the pirateship.
+</sd>
+   </scene>
+   <scene n="80">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The ship shudders as an explosion flashes outside the window.
+</sd>
+      <sp spk="HAN"> Here's where the fun begins!
+</sp>
+      <sp spk="BEN"> How long before you can make the jump to light speed?
+</sp>
+      <sp spk="HAN"> It'll take a few moments to get the coordinates from the
+navi-computer.</sp>
+      <sd>The ship begins to rock violently as lasers hit it.
+</sd>
+      <sp spk="LUKE"> Are you kidding? At the rate they're gaining...
+</sp>
+      <sp spk="HAN"> Traveling through hyperspace isn't like dusting crops, boy!
+Without precise calculations we could fly right through a star or
+bounce too close to a supernova and that'd end your trip real quick,
+wouldn't it?
+		</sp>
+      <sd> The ship is now constantly battered with laserfire as a red
+	warning light begins to flash.
+</sd>
+      <sp spk="LUKE"> What's that flashing?
+</sp>
+      <sp spk="HAN"> We're losing our deflector shield. Go strap yourself in, I'm
+going to make the jump to light speed.
+		</sp>
+      <sd> The galaxy brightens and they move faster, almost as if
+	crashing a barrier. Stars become streaks as the pirateship
+	makes the jump to hyperspace.
+</sd>
+   </scene>
+   <scene n="81">
+      <sd>EXTERIOR: SPACE.
+	The Millennium Falcon zooms into infinity in less than a
+	second.
+</sd>
+   </scene>
+   <scene n="82">
+      <sd>EXTERIOR: DEATH STAR.
+	Alderaan looms behind the Death Star battlestation.
+</sd>
+   </scene>
+   <scene n="83">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Admiral Motti enters the quiet control room and bows before
+	Governor Tarkin, who stands before the huge wall screen
+	displaying a small green planet.
+</sd>
+      <sp spk="MOTTI"> We've entered the Alderaan system.
+		</sp>
+      <sd> Vader and two stormtroopers enter with Princess Leia. Her
+	hands are bound.
+</sd>
+      <sp spk="LEIA"> Governor Tarkin, I should have expected to find you holding
+Vader's leash. I recognized your foul stench when I was brought on
+board.
+</sp>
+      <sp spk="TARKIN"> Charming to the last. You don't know how hard I found it
+signing the order to terminate your life!
+</sp>
+      <sp spk="LEIA"> I surprised you had the courage to take the responsibility
+yourself!
+</sp>
+      <sp spk="TARKIN"> Princess Leia, before your execution I would like you to be my
+guest at a ceremony that will make this battle station operational. No
+star system will dare oppose the Emperor now.
+</sp>
+      <sp spk="LEIA"> The more you tighten your grip, Tarkin, the more star systems
+will slip through your fingers.
+</sp>
+      <sp spk="TARKIN"> Not after we demonstrate the power of this station. In a way,
+you have determined the choice of the planet that'll be destroyed
+first. Since you are reluctant to provide us with the location of the
+Rebel base, I have chosen to test this station's destructive power...
+on your home planet of Alderaan.
+</sp>
+      <sp spk="LEIA"> No! Alderaan is peaceful. We have no weapons. You can't
+possibly...
+</sp>
+      <sp spk="TARKIN"> You would prefer another target? A military target? Then name
+the system!
+		</sp>
+      <sd> Tarkin waves menacingly toward Leia.
+</sd>
+      <sp spk="TARKIN"> I grow tired of asking this. So it'll be the last time. Where
+is the Rebel base?
+		</sp>
+      <sd> Leia overhears an intercom voice announcing the approach to
+	Alderaan.
+</sd>
+      <sp spk="LEIA"> (softly) Dantooine.
+		</sp>
+      <sd> Leia lowers her head.
+</sd>
+      <sp spk="LEIA"> They're on Dantooine.
+</sp>
+      <sp spk="TARKIN"> There. You see Lord Vader, she can be reasonable. (addressing
+Motti) Continue with the operation. You may fire when ready.
+</sp>
+      <sp spk="LEIA"> What?
+</sp>
+      <sp spk="TARKIN"> You're far too trusting. Dantooine is too remote to make an
+effective demonstration. But don't worry. We will deal with your Rebel
+friends soon enough. 
+</sp>
+      <sp spk="LEIA"> No!
+</sp>
+   </scene>
+   <scene n="84">
+      <sd>INTERIOR: DEATH STAR -- BLAST CHAMBER.
+</sd>
+      <sp spk="VADER"> Commence primary ignition.
+		</sp>
+      <sd> A button is pressed which switches on a panel of lights. A
+	hooded Imperial soldier reaches overhead and pulls a lever.
+	Another lever is pulled. Vader reaches for still another lever
+	and a bank of lights on a panel and wall light up. A huge beam
+	of light emanates from within a cone-shaped area and converges
+	into a single laser beam out toward Alderaan. The small green
+	planet of Alderaan is blown into space dust.
+</sd>
+   </scene>
+   <scene n="85">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Ben watches Luke practice the lightsaber with a small "seeker"
+	robot. Ben suddenly turns away and sits down. He falters,
+	seems almost faint.
+</sd>
+      <sp spk="LUKE"> Are you all right? What's wrong?
+</sp>
+      <sp spk="BEN"> I felt a great disturbance in the Force...as if millions of
+voices suddenly cried out in terror and were suddenly silenced. I fear
+something terrible has happened.
+		</sp>
+      <sd> Ben rubs his forehead. He seems to drift into a trance. Then
+	he fixes his gaze on Luke.
+</sd>
+      <sp spk="BEN"> You'd better get on with your exercises.
+		</sp>
+      <sd> Han Solo enters the room.
+</sd>
+      <sp spk="HAN"> Well, you can forget your troubles with those Imperial slugs. I
+told you I'd outrun 'em.
+		</sp>
+      <sd> Luke is once again practicing with the lightsaber.
+</sd>
+      <sp spk="HAN"> Don't everyone thank me at once.
+		</sp>
+      <sd> Threepio watches Chewbacca and Artoo who are engrossed in a
+	game in which three-dimensional holographic figures move along
+	a chess-type board.
+</sd>
+      <sp spk="HAN"> Anyway, we should be at Alderaan about oh-two-hundred hours.
+		</sp>
+      <sd> Chewbacca and the two robots sit around the lighted table
+	covered with small holographic monsters. Each side of the
+	table has a small computer monitor embedded in it. Chewbacca
+	seems very pleased with himself as he rests his lanky fur-
+	covered arms over his head.
+</sd>
+      <sp spk="THREEPIO"> Now be careful, Artoo.
+		</sp>
+      <sd> Artoo immediately reaches up and taps the computer with his
+	stubby claw hand, causing one of the holographic creatures to
+	walk to the new square. A sudden frown crosses Chewbacca's
+	face and he begins yelling gibberish at the tiny robot.
+	Threepio intercedes on behalf of his small companion and
+	begins to argue with the huge Wookiee.
+</sd>
+      <sp spk="THREEPIO"> He made a fair move. Screaming about it won't help you.
+</sp>
+      <sp spk="HAN"> (interrupting) Let him have it. It's not wise to upset a Wookiee.
+</sp>
+      <sp spk="THREEPIO"> But sir, nobody worries about upsetting a droid.
+</sp>
+      <sp spk="HAN"> That's 'cause droids don't pull people's arms out of their socket
+when they lose. Wookiees are known to do that.
+</sp>
+      <sp spk="THREEPIO"> I see your point, sir. I suggest a new strategy, Artoo. Let
+the Wookiee win.
+		</sp>
+      <sd> Luke stands in the middle of the small hold area; he seems
+	frozen in place. A humming lightsaber is held high over his
+	head. Ben watches him from the corner, studying his movements.
+	Han watches with a bit of smugness.
+</sd>
+      <sp spk="BEN"> Remember, a Jedi can feel the Force flowing through him.
+</sp>
+      <sp spk="LUKE"> You mean it controls your actions?
+</sp>
+      <sp spk="BEN"> Partially. But it also obeys your commands.
+		</sp>
+      <sd> Suspended at eye level, about ten feet in front of Luke, a
+	"seeker", a chrome baseball-like robot covered with antennae,
+	hovers slowly in a wide arc. The ball floats to one side of
+	the youth then the other. Suddenly it makes a lightning-swift
+	lunge and stops within a few feet of Luke's face. Luke doesn't
+	move and the ball backs off. It slowly moves behind the boy,
+	then makes another quick lunge, this time emitting a blood red
+	laser beam as it attacks. It hits Luke in the leg causing him
+	to tumble over. Han lets loose with a burst of laughter.
+</sd>
+      <sp spk="HAN"> Hokey religions and ancient weapons are no match for a good
+blaster at your side, kid.
+</sp>
+      <sp spk="LUKE"> You don't believe in the Force, do you?
+</sp>
+      <sp spk="HAN"> Kid, I've flown from one side of this galaxy to the other. I've
+seen a lot of strange stuff, but I've never seen anything to make me
+believe there's one all-powerful force controlling everything. There's
+no mystical energy field that controls my destiny.
+		</sp>
+      <sd> Ben smiles quietly
+</sd>
+      <sp spk="HAN"> It's all a lot of simple tricks and nonsense.
+</sp>
+      <sp spk="BEN"> I suggest you try it again, Luke.
+		</sp>
+      <sd> Ben places a large helmet on Luke's head which covers his
+	eyes.
+</sd>
+      <sp spk="BEN"> This time, let go your conscious self and act on instinct.
+</sp>
+      <sp spk="LUKE"> (laughing) With the blast shield down, I can't even see. How am
+I supposed to fight?
+</sp>
+      <sp spk="BEN"> Your eyes can deceive you. Don't trust them.
+		</sp>
+      <sd> Han skeptically shakes his head as Ben throws the seeker
+	into the air. The ball shoots straight up in the air, then
+	drops like a rock. Luke swings the lightsaber around blindly
+	missing the seeker, which fires off a laserbolt which hits
+	Luke square on the seat of the pants. He lets out a painful
+	yell and attempts to hit the seeker.
+</sd>
+      <sp spk="BEN"> Stretch out with your feelings.
+		</sp>
+      <sd> Luke stands in one place, seemingly frozen. The seeker
+	makes a dive at Luke and, incredibly, he managed to deflect
+	the bolt. The ball ceases fire and moves back to its original
+	position.
+</sd>
+      <sp spk="BEN"> You see, you can do it.
+</sp>
+      <sp spk="HAN"> I call it luck. 
+</sp>
+      <sp spk="BEN"> In my experience, there's no such thing as luck.
+</sp>
+      <sp spk="HAN"> Look, going good against remotes is one thing. Going good against
+the living? That's something else.
+		</sp>
+      <sd> Solo notices a small light flashing on the far side of the
+	control panel.
+</sd>
+      <sp spk="HAN"> Looks like we're coming up on Alderaan.
+		</sp>
+      <sd> Han and Chewbacca head back to the cockpit.
+</sd>
+      <sp spk="LUKE"> You know, I did feel something. I could almost see the remote.
+</sp>
+      <sp spk="BEN"> That's good. You have taken your first step into a larger world.
+</sp>
+   </scene>
+   <scene n="86">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Imperial Officer Cass stands before Governor Tarkin and the
+	evil Dark Lord Darth Vader.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="OFFICER CASS"> Our scout ships have reached Dantooine. They found the
+remains of a Rebel base, but they estimate that it has been deserted
+for some time. They are now conducting an extensive search of the
+surrounding systems.
+</sp>
+      <sp spk="TARKIN"> She lied! She lied to us!
+</sp>
+      <sp spk="VADER"> I told you she would never consciously betray the Rebellion.
+</sp>
+      <sp spk="TARKIN"> Terminate her...immediately!
+</sp>
+   </scene>
+   <scene n="87">
+      <sd>EXTERIOR: HYPERSPACE.
+	The pirateship is just coming out of hyperspace; a strange
+	surreal light show surrounds the ship.
+</sd>
+   </scene>
+   <scene n="88">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="HAN"> Stand by, Chewie, here we go. Cut in the sublight engines.
+		</sp>
+      <sd> Han pulls back on a control lever. Outside the cockpit
+	window stars begin streaking past, seem to decrease in speed,
+	then stop. Suddenly the starship begins to shudder and
+	violently shake about. Asteroids begin to race toward them,
+	battering the sides of the ship.
+</sd>
+      <sp spk="HAN"> What the...? Aw, we've come out of hyperspace into a meteor
+shower. Some kind of asteroid collision. It's not on any of the
+charts.
+		</sp>
+      <sd> The Wookiee flips off several controls and seems very cool
+	in the emergency. Luke makes his way into the bouncing
+	cockpit.
+</sd>
+      <sp spk="LUKE"> What's going on?
+</sp>
+      <sp spk="HAN"> Our position is correct, except...no, Alderaan!
+</sp>
+      <sp spk="LUKE"> What do you mean? Where is it?
+</sp>
+      <sp spk="HAN"> Thats what I'm trying to tell you, kid. It ain't there. It's been
+totally blown away.
+</sp>
+      <sp spk="LUKE"> What? How?
+		</sp>
+      <sd> Ben moves into the cockpit behind Luke as the ship begins
+	to settle down.
+</sd>
+      <sp spk="BEN"> Destroyed...by the Empire!
+</sp>
+      <sp spk="HAN"> The entire starfleet couldn't destroy the whole planet. It'd take
+a thousand ships with more fire power than I've...
+		</sp>
+      <sd> A signal starts flashing on the control panel and a muffled
+	alarm starts humming.
+</sd>
+      <sp spk="HAN"> There's another ship coming in.
+</sp>
+      <sp spk="LUKE"> Maybe they know what happened.
+</sp>
+      <sp spk="BEN"> It's an Imperial fighter.
+		</sp>
+      <sd> Chewbacca barks his concern. A huge explosion bursts
+	outside the cockpit window, shaking the ship violently. A
+	tiny, finned Imperial TIE fighter races past the cockpit
+	window.
+</sd>
+      <sp spk="LUKE"> It followed us!
+</sp>
+      <sp spk="BEN"> No. It's a short range fighter.
+</sp>
+      <sp spk="HAN"> There aren't any bases around here. Where did it come from?
+</sp>
+   </scene>
+   <scene n="89">
+      <sd>EXTERIOR: SPACE.
+	The fighter races past the Corellian pirateship.
+</sd>
+   </scene>
+   <scene n="90">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> It sure is leaving in a big hurry. If they identify us, we're in
+big trouble.
+</sp>
+      <sp spk="HAN"> Not if I can help it. Chewie...jam it's transmissions.
+</sp>
+      <sp spk="BEN"> It'd be as well to let it go. It's too far out of range.
+</sp>
+      <sp spk="HAN"> Not for long...
+</sp>
+   </scene>
+   <scene n="91">
+      <sd>EXTERIOR: SPACE.
+	The pirateship zooms over the camera and away into the
+	vastness of space after the Imperial TIE fighter.
+</sd>
+   </scene>
+   <scene n="92">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The tension mounts as the pirateship gains on the tiny fighter.
+	In the distance, one of the stars becomes brighter until it is
+	obvious that the TIE ship is heading for it. Ben stands behind
+	Chewbacca.
+</sd>
+      <sp spk="BEN"> A fighter that size couldn't get this deep into space on its own.
+</sp>
+      <sp spk="LUKE"> It must have gotten lost, been part of a convoy or something.
+</sp>
+      <sp spk="HAN"> Well, he ain't going to be around long enough to tell anyone
+about us.
+</sp>
+   </scene>
+   <scene n="93">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter is losing ground to the larger pirateship as
+	they race toward camera and disappear over head.
+</sd>
+   </scene>
+   <scene n="94">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	The distant star can be distinguished as a small moon or
+	planet.
+</sd>
+      <sp spk="LUKE"> Look at him. He's headed for that small moon.
+</sp>
+      <sp spk="HAN"> I think I can get him before he gets there...he's almost in
+range.
+		</sp>
+      <sd> The small moon begins to take on the appearance of a
+	monstrous spherical battle station.
+</sd>
+      <sp spk="BEN"> That's no moon! It's a space station.
+</sp>
+      <sp spk="HAN"> It's too big to be a space station.
+</sp>
+      <sp spk="LUKE"> I have a very bad feeling about this.
+</sp>
+      <sp spk="HAN"> Yeah, I think your right. Full reverse! Chewie, lock in the
+auxiliary power.
+		</sp>
+      <sd> The pirateship shudders and the TIE fighter accelerates
+	away toward the gargantuan battle station.
+</sd>
+      <sp spk="LUKE"> Why are we still moving towards it?
+</sp>
+      <sp spk="HAN"> We're caught in a tractor beam! It's pulling us in!
+</sp>
+      <sp spk="LUKE"> But there's gotta be something you can do!
+</sp>
+      <sp spk="HAN"> There's nothin' I can do about it, kid. I'm in full power. I'm
+going to have to shut down. But they're not going to get me without a
+fight!
+		</sp>
+      <sd> Ben Kenobi puts a hand on his shoulder.
+</sd>
+      <sp spk="BEN"> You can't win. But there are alternatives to fighting.
+</sp>
+   </scene>
+   <scene n="95">
+      <sd>INTERIOR: MILLENNIUM FALCON -- DEATH STAR.
+	As the battered pirate starship is towed closer to the awesome
+	metal moon, the immense size of the massive battle station
+	becomes staggering. Running along the equator of the gigantic
+	sphere is a mile-high band of huge docking ports into which
+	the helpless pirateship is dragged.
+</sd>
+   </scene>
+   <scene n="96">
+      <sd>EXTERIOR: DEATH STAR -- HUGE PORT DOORS.
+	The helpless Millennium Falcon is pulled past a docking port
+	control room and huge laser turret cannons.
+</sd>
+      <sp spk="VOICE OVER DEATH STAR INTERCOM"> Clear Bay twenty-three-seven. We are
+opening the magnetic field.
+</sp>
+   </scene>
+   <scene n="97">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY 2037.
+	The pirateship is pulled in through port doors of the Death
+	Star, coming to rest in a huge hangar. Thirty stormtroopers
+	stand at attention in a central assembly area.
+</sd>
+      <sp spk="OFFICER"> To you stations!
+</sp>
+      <sp spk="OFFICER"> (to another officer) Come with me.
+</sp>
+   </scene>
+   <scene n="98">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Stormtroopers run to their posts.
+</sd>
+   </scene>
+   <scene n="99">
+      <sd>INTERIOR: DEATH STAR -- HANGAR 2037.
+	A line of stormtroopers march toward the pirateship in
+	readiness to board it, while other troopers stand with weapons
+	ready to fire.
+</sd>
+      <sp spk="OFFICER"> Close all outboard shields! Close all outboard shields!
+</sp>
+   </scene>
+   <scene n="100">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+ 
+	Tarkin pushes a button and responds to the intercom buzz.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="VOICE"> (over intercom) We've captured a freighter entering the remains
+of the Alderaan system. It's markings match those of a ship that
+blasted its way out of Mos Eisley.
+</sp>
+      <sp spk="VADER"> They must be trying to return the stolen plans to the princess.
+She may yet be of some use to us.
+</sp>
+   </scene>
+   <scene n="101">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY 2037.
+	Vader and a commander approach the troops as an Officer and
+	several heavily armed troops exit the spacecraft.
+</sd>
+      <sp spk="VOICE"> (over intercom) Unlock one-five-seven and nine. Release
+charges.
+</sp>
+      <sp spk="OFFICER"> (to Vader) There's no one on board, sir. According to the
+log, the crew abandoned ship right after takeoff. It must be a decoy,
+sir. Several of the escape pods have been jettisoned.
+</sp>
+      <sp spk="VADER"> Did you find any droids?
+</sp>
+      <sp spk="OFFICER"> No, sir. If there were any on board, they must also have
+jettisoned.
+</sp>
+      <sp spk="VADER"> Send a scanning crew on board. I want every part of this ship
+checked.
+</sp>
+      <sp spk="OFFICER"> Yes, sir.
+</sp>
+      <sp spk="VADER"> I sense something...a presence I haven't felt since...
+		</sp>
+      <sd> Vader turns quickly and exits the hangar.
+</sd>
+      <sp spk="OFFICER"> Get me a scanning crew in here on the double. I want every
+part of this ship checked!
+</sp>
+   </scene>
+   <scene n="102">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HALLWAY.
+	A trooper runs through the hallway heading for the exit. In a
+	few moments all is quiet. The muffled sounds of a distant
+	officer giving orders finally fade. Two floor panels suddenly
+	pop up revealing Han Solo and Luke. Ben Kenobi sticks his head
+	out of a third locker.
+</sd>
+      <sp spk="LUKE"> Boy, it's lucky you had these compartments.
+</sp>
+      <sp spk="HAN"> I use them for smuggling. I never thought I'd be smuggling myself
+in them. This is ridiculous. Even if I could take off, I'd never get
+past the tractor beam.
+</sp>
+      <sp spk="BEN"> Leave that to me!
+</sp>
+      <sp spk="HAN"> Damn fool. I knew that you were going to say that!
+</sp>
+      <sp spk="BEN"> Who's the more foolish...the fool or the fool who follows him?
+		</sp>
+      <sd> Han shakes his head, muttering to himself. Chewbacca
+	agrees.
+</sd>
+   </scene>
+   <scene n="103">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	The crewmen carry a heavy box on board the ship, past the two
+	stormtroopers guarding either side of the ramp.
+</sd>
+      <sp spk="TROOPER"> The ship's all yours. If the scanners pick up anything,
+report it immediately. All right, let's go.
+		</sp>
+      <sd> The crewmen enter the pirateship and a loud crashing sound
+	is followed by a voice calling to the guard below.
+</sd>
+      <sp spk="HAN'S VOICE"> Hey down there, could you give us a hand with this?
+		</sp>
+      <sd> The stormtroopers enter the ship and a quick round of
+	gunfire is heard.
+</sd>
+   </scene>
+   <scene n="104">
+      <sd>INTERIOR: DEATH STAR -- FORWARD BAY -- COMMAND OFFICE.
+	In a very small command office near the entrance to the
+	pirateship, a Gantry Officer looks out his window and notices
+	the guards are missing. He speaks into the comlink.
+</sd>
+      <sp spk="GANTRY OFFICER"> TX-four-one-two. Why aren't you at your post?
+</sp>
+      <sp spk="TX"> four-one-two, do you copy? 
+		</sp>
+      <sd> A stormtrooper comes down the ramp of the pirateship and
+	waves to the gantry officer, pointing to his ear indicating
+	his comlink is not working. The gantry officer shakes his head
+	in disgust and heads for the door, giving his aide an annoyed
+	look.
+</sd>
+      <sp spk="GANTRY OFFICER"> Take over. We've got a bad transmitter. I'll see what
+I can do.
+		</sp>
+      <sd> As the officer approaches the door, it slides open
+	revealing the towering Chewbacca. The gantry officer, in a
+	momentary state of shock, stumbles backward. With a bone-
+	chilling howl, the giant Wookiee flattens the officer with one
+	blow. The aide immediately reaches for his pistol, but is
+	blasted by Han, dressed as an Imperial stormtrooper. Ben and
+	the robots enter the room quickly followed by Luke, also
+	dressed as a stormtrooper. Luke quickly removes his helmet.
+</sd>
+      <sp spk="LUKE"> You know, between his howling and your blasting everything in
+sight, it's a wonder the whole station doesn't know we're here.
+</sp>
+      <sp spk="HAN"> Bring them on! I prefer a straight fight to all this sneaking
+around.
+</sp>
+      <sp spk="THREEPIO"> We found the computer outlet, sir.
+		</sp>
+      <sd> Ben feeds some information into the computer and a map of
+	the city appears on the monitor. He begins to inspect it
+	carefully. Threepio and Artoo look over the control panel.
+	Artoo finds something that makes him whistle wildly.
+</sd>
+      <sp spk="BEN"> Plug in. He should be able to interpret the entire Imperial
+computer network.
+		</sp>
+      <sd> Artoo punches his claw arm into the computer socket and the
+	vast Imperial brain network comes to life, feeding information
+	to the little robot. After a few moments, he beeps something.
+</sd>
+      <sp spk="THREEPIO"> He says he's found the main computer to power the tractor
+beam that's holding the ship here. He'll try to make the precise
+location appear on the monitor.
+		</sp>
+      <sd> The computer monitor flashes readouts.
+</sd>
+      <sp spk="THREEPIO"> The tractor beam is coupled to the main reactor in seven
+locations. A power loss at one of the terminals will allow the ship to
+leave.
+		</sp>
+      <sd> Ben studies the data on the monitor readout.
+</sd>
+      <sp spk="BEN"> I don't think you boys can help. I must go alone.
+</sp>
+      <sp spk="HAN"> Whatever you say. I've done more that I bargained for on this
+trip already.
+</sp>
+      <sp spk="LUKE"> I want to go with you.
+</sp>
+      <sp spk="BEN"> Be patient, Luke. Stay and watch over the droids.
+</sp>
+      <sp spk="LUKE"> But he can...
+</sp>
+      <sp spk="BEN"> They must be delivered safely or other star systems will suffer
+the same fate as Alderaan. Your destiny lies along a different path
+than mine. The Force will be with you...always!
+		</sp>
+      <sd> Ben adjusts the lightsaber on his belt and silently steps
+	out of the command office, then disappears down a long grey
+	hallway. Chewbacca barks a comment and Han shakes his head in
+	agreement.
+</sd>
+      <sp spk="HAN"> Boy you said it, Chewie.
+		</sp>
+      <sd> Han looks at Luke.
+</sd>
+      <sp spk="HAN"> Where did you dig up that old fossil?
+</sp>
+      <sp spk="LUKE"> Ben is a great man.
+</sp>
+      <sp spk="HAN"> Yeah, great at getting us into trouble.
+</sp>
+      <sp spk="LUKE"> I didn't hear you give any ideas...
+</sp>
+      <sp spk="HAN"> Well, anything would be better than just hanging around waiting
+for him to pick us up...
+</sp>
+      <sp spk="LUKE"> Who do you think...
+		</sp>
+      <sd> Suddenly Artoo begins to whistle and beep a blue streak.
+	Luke goes over to him.
+</sd>
+      <sp spk="LUKE"> What is it?
+</sp>
+      <sp spk="THREEPIO"> I'm afraid I'm not quite sure, sir. He says "I found her",
+and keeps repeating, "She's here."
+</sp>
+      <sp spk="LUKE"> Well, who...who has he found?
+		</sp>
+      <sd> Artoo whistles a frantic reply.
+</sd>
+      <sp spk="THREEPIO"> Princess Leia.
+</sp>
+      <sp spk="LUKE"> The princess? She's here?
+</sp>
+      <sp spk="HAN"> Princess? What's going on?
+</sp>
+      <sp spk="THREEPIO"> Level five. Detention block A A-twenty-three. I'm afraid
+she's scheduled to be terminated.
+</sp>
+      <sp spk="LUKE"> Oh, no! We've got to do something.
+</sp>
+      <sp spk="HAN"> What are you talking about?
+</sp>
+      <sp spk="LUKE"> The droid belongs to her. She's the one in the message.. We've
+got to help her.
+</sp>
+      <sp spk="HAN"> Now, look, don't get any funny ideas. The old man wants us to
+wait right here.
+</sp>
+      <sp spk="LUKE"> But he didn't know she was here. Look, will you just find a way
+back into the detention block?
+</sp>
+      <sp spk="HAN"> I'm not going anywhere.
+</sp>
+      <sp spk="LUKE"> They're going to execute her. Look, a few minutes ago you said
+you didn't want to just wait here to be captured. Now all you want to
+do is stay. 
+</sp>
+      <sp spk="HAN"> Marching into the detention area is not what I had in mind.
+</sp>
+      <sp spk="LUKE"> But they're going to kill her!
+</sp>
+      <sp spk="HAN"> Better her than me...
+</sp>
+      <sp spk="LUKE"> She's rich.
+		</sp>
+      <sd> Chewbacca growls.
+</sd>
+      <sp spk="HAN"> Rich?
+</sp>
+      <sp spk="LUKE"> Yes. Rich, powerful! Listen, if you were to rescue her, the
+reward would be...
+</sp>
+      <sp spk="HAN"> What?
+</sp>
+      <sp spk="LUKE"> Well more wealth that you can imagine.
+</sp>
+      <sp spk="HAN"> I don't know, I can imagine quite a bit!
+</sp>
+      <sp spk="LUKE"> You'll get it!
+</sp>
+      <sp spk="HAN"> I better!
+</sp>
+      <sp spk="LUKE"> You will...
+</sp>
+      <sp spk="HAN"> All right, kid. But you'd better be right about this.
+		</sp>
+      <sd> Han looks at Chewie, who grunts a short grunt.
+</sd>
+      <sp spk="LUKE"> All right.
+</sp>
+      <sp spk="HAN"> What's your plan?
+</sp>
+      <sp spk="LUKE"> Uh...Threepio, hand me those binders there will you?
+		</sp>
+      <sd> Luke moves toward Chewbacca with electronic cuffs.
+</sd>
+      <sp spk="LUKE"> Okay. Now, I'm going to put these on you.
+		</sp>
+      <sd> Chewie lets out a hideous growl.
+</sd>
+      <sp spk="LUKE"> Okay. Han, you put these on.
+		</sp>
+      <sd> Luke sheepishly hands the binders to Han.
+</sd>
+      <sp spk="HAN"> Don't worry, Chewie. I think I know what he has in mind.
+		</sp>
+      <sd> The Wookiee has a worried and frightened look on his face
+	as Han binds him with the electronic cuffs.
+</sd>
+      <sp spk="THREEPIO"> Master Luke, sir! Pardon me for asking...but, ah...what
+should Artoo and I do if we're discovered here?
+</sp>
+      <sp spk="LUKE"> Lock the door!
+</sp>
+      <sp spk="HAN"> And hope they don't have blasters.
+</sp>
+      <sp spk="THREEPIO"> That isn't very reassuring.
+		</sp>
+      <sd> Luke and Han put on their armored stormtrooper helmets and
+	start off into the giant Imperial Death Star.
+</sd>
+   </scene>
+   <scene n="105">
+      <sd>INTERIOR: DEATH STAR -- DETENTION AREA -- ELEVATOR TUBE.
+	Han and Luke try to look inconspicuous in their armored suits
+	as they wait for a vacuum elevator to arrive. Troops,
+	bureaucrats, and robots bustle about, ignoring the trio
+	completely. Only a few give the giant Wookiee a curious
+	glance.
+		 Finally a small elevator arrives and the trio enters.
+</sd>
+      <sp spk="LUKE"> I can't see a thing in this helmet.</sp>
+      <sd>A bureaucrat races to get aboard also, but is signaled away by
+	Han. The door to the pod-like vehicle slides closed and the
+	elevator car takes off through a vacuum tube.
+</sd>
+   </scene>
+   <scene n="106">
+      <sd>INTERIOR: DEATH STAR -- MAIN HALLWAY.
+	Several Imperial officers walk through the wide main
+	passageway. They pass several stormtroopers and a robot
+	similar to Threepio but with an insect face. At the far end of
+	the hallway, a passing flash of Ben Kenobi appears, then
+	disappears down a small hallway. His appearance is so fleeting
+	that it is hard to tell if he is real or just an illusion. No
+	one in the hallway seems to notice him.
+</sd>
+   </scene>
+   <scene n="107">
+      <sd>INTERIOR: DEATH STAR -- INTERIOR ELEVATOR -- DETENTION SECURITY AREA.
+	Luke and Han step forward to exit the elevator, but the door
+	slides open behind them. The giant Wookiee and his two guards
+	enter the old grey security station. Guards and laser gates
+	are everywhere. Han whispers to Luke under his breath.
+</sd>
+      <sp spk="HAN"> This is not going to work.
+</sp>
+      <sp spk="LUKE"> Why didn't you say so before?
+</sp>
+      <sp spk="HAN"> I did say so before!
+</sp>
+   </scene>
+   <scene n="108">
+      <sd>INTERIOR: DETENTION AREA.
+	Elevator doors open. A tall, grim looking Officer approaches
+	the trio.
+</sd>
+      <sp spk="OFFICER"> Where are you taking this...thing?
+		</sp>
+      <sd> Chewie growls a bit at the remark but Han nudges him to
+	shut up.
+</sd>
+      <sp spk="LUKE"> Prisoner transfer from Block one-one-three-eight.
+</sp>
+      <sp spk="OFFICER"> I wasn't notified. I'll have to clear it.
+		</sp>
+      <sd> The officer goes back to his console and begins to punch in
+	the information. There are only three other troopers in the
+	area. Luke and Han survey the situation, checking all of the
+	alarms, laser gates, and camera eyes. Han unfastens one of
+	Chewbacca's electronic cuffs and shrugs to Luke.
+</sd>
+      <sd> Suddenly Chewbacca throws up his hands and lets out with
+	one of his ear-piercing howls. He grabs Han's laser rifle.
+</sd>
+      <sp spk="HAN"> Look out! He's loose!
+</sp>
+      <sp spk="LUKE"> He's going to pull us all apart.
+</sp>
+      <sp spk="HAN"> Go get him!
+		</sp>
+      <sd> The startled guards are momentarily dumbfounded. Luke and
+	Han have already pulled out their laser pistols and are
+	blasting away at the terrifying Wookiee. Their barrage of
+	laserfire misses Chewbacca, but hits the camera eyes, laser
+	gate controls, and the Imperial guards. The officer is the
+	last of the guards to fall under the laserfire just as he is
+	about to push the alarm system. Han rushes to the comlink
+	system, which is screeching questions about what is going on.
+	He quickly checks the computer readout.
+</sd>
+      <sp spk="HAN"> We've got to find out which cell this princess of yours is in.
+Here it is...cell twenty-one-eight-seven. You go get her. I'll hold
+them here.</sp>
+      <sd>Luke races down one of the cell corridors. Han speaks into the
+	buzzing comlink.
+</sd>
+      <sp spk="HAN"> (sounding official) Everything is under control. Situation
+normal.
+</sp>
+      <sp spk="INTERCOM VOICE"> What happened?
+</sp>
+      <sp spk="HAN"> (getting nervous) Uh...had a slight weapons malfunction. But, uh,
+everything's perfectly all right now. We're fine. We're all fine here,
+now, thank you. How are you?
+</sp>
+      <sp spk="INTERCOM VOICE"> We're sending a squad up.
+</sp>
+      <sp spk="HAN"> Uh, uh, negative. We had a reactor leak here now. Give us a few
+minutes to lock it down. Large leak...very dangerous.
+</sp>
+      <sp spk="INTERCOM VOICE"> Who is this? What's your operating number?
+		</sp>
+      <sd> Han blasts the comlink and it explodes.
+</sd>
+      <sp spk="HAN"> Boring conversation anyway. (yelling down the hall) Luke! We're
+going to have company!
+</sp>
+   </scene>
+   <scene n="109">
+      <sd>INTERIOR: DEATH STAR -- CELL ROW.
+	Luke stops in front of one of the cells and blasts the door
+	away with a laser pistol. When the smoke clears, Luke sees the
+	dazzling young princess-senator. She had been sleeping and is
+	now looking at him with an uncomprehending look on her face.
+	Luke is stunned by her incredible beauty and stands staring at
+	her with his mouth hanging open.
+</sd>
+      <sp spk="LEIA"> (finally) Aren't you a little short to be a stormtrooper?
+		</sp>
+      <sd> Luke takes off his helmet, coming out of it.
+</sd>
+      <sp spk="LUKE"> What? Oh...the uniform. I'm Luke Skywalker. I'm here to rescue
+you. 
+</sp>
+      <sp spk="LEIA"> You're who?
+</sp>
+      <sp spk="LUKE"> I'm here to rescue you. I've got your R2 unit. I'm here with Ben
+Kenobi.
+</sp>
+      <sp spk="LEIA"> Ben Kenobi is here! Where is he?
+</sp>
+      <sp spk="LUKE"> Come on!
+</sp>
+   </scene>
+   <scene n="110">
+      <sd>INTERIOR: DEATH STAR -- CONFERENCE ROOM.
+	Darth Vader paces the room as Governor Tarkin sits at the far
+	end of the conference table.
+</sd>
+      <sp spk="VADER"> He is here...
+</sp>
+      <sp spk="TARKIN"> Obi-Wan Kenobi! What makes you think so?
+</sp>
+      <sp spk="VADER"> A tremor in the Force. The last time I felt it was in the
+presence of my old master.
+</sp>
+      <sp spk="TARKIN"> Surely he must be dead by now.
+</sp>
+      <sp spk="VADER"> Don't underestimate the power of the Force.
+</sp>
+      <sp spk="TARKIN"> The Jedi are extinct, their fire has gone out of the universe.
+You, my friend, are all that's left of their religion.
+		</sp>
+      <sd> There is a quiet buzz on the comlink.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="INTERCOM VOICE"> Governor Tarkin, we have an emergency alert in
+detention block A A-twenty-three.
+</sp>
+      <sp spk="TARKIN"> The princess! Put all sections on alert!
+</sp>
+      <sp spk="VADER"> Obi-Wan is here. The Force is with him.
+</sp>
+      <sp spk="TARKIN"> If you're right, he must not be allowed to escape.
+</sp>
+      <sp spk="VADER"> Escape is not his plan. I must face him alone.
+</sp>
+   </scene>
+   <scene n="111">
+      <sd>INTERIOR: DEATH STAR -- DETENTION AREA -- HALLWAY.
+	An ominous buzzing sound is heard on the other side of the
+	elevator door.
+</sd>
+      <sp spk="HAN"> Chewie!</sp>
+      <sd>Chewbacca responds with a growling noise.
+</sd>
+      <sp spk="HAN"> Get behind me! Get behind me!
+		</sp>
+      <sd> A series of explosions knock a hole in the elevator door
+	through which several Imperial troops begin to emerge.
+</sd>
+      <sd> Han and Chewie fire laser pistols at them through the smoke
+	and flame. They turn and run down the cell hallway, meeting up
+	with Luke and Leia rushing toward them.
+</sd>
+      <sp spk="HAN"> Can't get out that way.
+</sp>
+      <sp spk="LEIA"> Looks like you managed to cut off our only escape route.
+</sp>
+      <sp spk="HAN"> (sarcastically) Maybe you'd like it back in your cell, Your
+Highness.
+		</sp>
+      <sd> Luke takes a small comlink transmitter from his belt as
+	they continue to exchange fire with stormtroopers making their
+	way down the corridor.
+</sd>
+      <sp spk="LUKE"> See-Threepio! See-Threepio!
+</sp>
+      <sp spk="THREEPIO"> (over comlink) Yes sir?
+</sp>
+      <sp spk="LUKE"> We've been cut off! Are there any other ways out of the cell
+bay?...What was that? I didn't copy!
+</sp>
+   </scene>
+   <scene n="112">
+      <sd>INTERIOR: DEATH STAR -- MAIN BAY GANTRY -- CONTROL TOWER.
+	Threepio paces the control center as little Artoo beeps and
+	whistles a blue streak. Threepio yells into the small comlink
+	transmitter.
+</sd>
+      <sp spk="THREEPIO"> I said, all systems have been alerted to your presence, sir.
+The main entrance seems to be the only way in or out; all other
+information on your level is restricted.
+		</sp>
+      <sd> Someone begins banging on the door.
+</sd>
+      <sp spk="TROOPER VOICE"> Open up in there!
+</sp>
+      <sp spk="THREEPIO"> Oh, no!
+</sp>
+   </scene>
+   <scene n="113">
+      <sd>INTERIOR: DEATH STAR -- DETENTION CORRIDOR.
+	Luke and Leia crouch together in an alcove for protection as
+	they continue to exchange fire with troops. Han and Chewbacca
+	are barely able to keep the stormtroopers at bay at the far
+	and of the hallway. The laserfire is very intense, and smoke
+	fills the narrow cell corridor.
+</sd>
+      <sp spk="LUKE"> There isn't any other way out.
+</sp>
+      <sp spk="HAN"> I can't hold them off forever! Now what?
+</sp>
+      <sp spk="LEIA"> This is some rescue. When you came in here, didn't you have a
+plan for getting out?
+</sp>
+      <sp spk="HAN"> (pointing to Luke) He's the brains, sweetheart.
+		</sp>
+      <sd> Luke manages a sheepish grin and shrugs his shoulders.
+</sd>
+      <sp spk="LUKE"> Well, I didn't...
+		</sp>
+      <sd> The princess grabs Luke's gun and fires at a small grate in
+	the wall next to Han, almost frying him.
+</sd>
+      <sp spk="HAN"> What the hell are you doing?
+</sp>
+      <sp spk="LEIA"> Somebody has to save our skins. Into the garbage chute, wise
+guy.
+		</sp>
+      <sd> She jumps through the narrow opening as Han and Chewbacca
+	look on in amazement. Chewbacca sniffs the garbage chute and
+	says something.
+</sd>
+      <sp spk="HAN"> Get in there you big furry oaf! I don't care what you smell! Get
+in there and don't worry about it.
+		</sp>
+      <sd> Han gives him a kick and the Wookiee disappears into the
+	tiny opening. Luke and Han continue firing as they work their
+	way toward the opening.
+</sd>
+      <sp spk="HAN"> Wonderful girl! Either I'm going to kill her or I'm beginning to
+like her. Get in there!
+		</sp>
+      <sd> Luke ducks laserfire as he jumps into the darkness. Han
+	fires off a couple of quick blasts creating a smokey cover,
+	then slides into the chute himself and is gone.
+</sd>
+   </scene>
+   <scene n="114">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	Han tumbles into the large room filled with garbage and muck.
+	Luke is already stumbling around looking for an exit. He finds
+	a small hatchway and struggles to get it open. It won't budge.
+</sd>
+      <sp spk="HAN"> (sarcastically) Oh! The garbage chute was a really wonderful
+idea. What an incredible smell you've discovered! Let's get out of
+here! Get away from there...
+</sp>
+      <sp spk="LUKE"> No! wait!
+		</sp>
+      <sd> Han draws his laser pistol and fires at the hatch. The
+	laserbolt ricochets wildly around the small metal room.
+	Everyone dives for cover in the garbage as the bolt explodes
+	almost on top of them. Leia climbs out of the garbage with a
+	rather grim look on her face.
+</sd>
+      <sp spk="LUKE"> Will you forget it? I already tried it. It's magnetically
+sealed!
+</sp>
+      <sp spk="LEIA"> Put that thing away! You're going to get us all killed.
+</sp>
+      <sp spk="HAN"> Absolutely, Your Worship. Look, I had everything under control
+until you led us down here. You know, it's not going to take them long
+to figure out what happened to us.
+</sp>
+      <sp spk="LEIA"> It could be worst...
+		</sp>
+      <sd> A loud, horrible, inhuman moan works its way up from the
+	murky depths. Chewbacca lets out a terrified howl and begins
+	to back away. Han and Luke stand fast with their laser pistols
+	drawn. The Wookiee is cowering near one of the walls.
+</sd>
+      <sp spk="HAN"> It's worst.
+</sp>
+      <sp spk="LUKE"> There's something alive in here!
+</sp>
+      <sp spk="HAN"> That's your imagination.
+</sp>
+      <sp spk="LUKE"> Something just moves past my leg! Look! Did you see that?
+</sp>
+      <sp spk="HAN"> What?
+</sp>
+      <sp spk="LUKE"> Help!
+		</sp>
+      <sd> Suddenly Luke is yanked under the garbage.
+</sd>
+      <sp spk="HAN"> Luke! Luke! Luke!
+		</sp>
+      <sd> Solo tries to get to Luke. Luke surfaces with a gasp of air
+	and thrashing of limbs. A membrane tentacle is wrapped around
+	his throat.
+</sd>
+      <sp spk="LEIA"> Luke!
+		</sp>
+      <sd> Leia extends a long pipe toward him.
+</sd>
+      <sp spk="LEIA"> Luke, Luke, grab a hold of this.
+</sp>
+      <sp spk="LUKE"> Blast it, will you! My gun's jammed.
+</sp>
+      <sp spk="HAN"> Where?
+</sp>
+      <sp spk="LUKE"> Anywhere! Oh!!
+		</sp>
+      <sd> Solo fires his gun downward. Luke is pulled back into the
+	muck by the slimy tentacle.
+</sd>
+      <sp spk="HAN"> Luke! Luke!
+		</sp>
+      <sd> Suddenly the walls of the garbage receptacle shudder and
+	move in a couple of inches. Then everything is deathly quiet.
+	Han and Leia give each other a worried look as Chewbacca howls
+	in the corner. With a rush of bubbles and muck Luke suddenly
+	bobs to the surface.
+</sd>
+      <sp spk="LEIA"> Grab him!
+		</sp>
+      <sd> Luke seems to be released by the thing.
+</sd>
+      <sp spk="LEIA"> What happened?
+</sp>
+      <sp spk="LUKE"> I don't know, it just let go of me and disappeared...
+</sp>
+      <sp spk="HAN"> I've got a very bad feeling about this.
+		</sp>
+      <sd> Before anyone can say anything the walls begin to rumble
+	and edge toward the Rebels.
+</sd>
+      <sp spk="LUKE"> The walls are moving!
+</sp>
+      <sp spk="LEIA"> Don't just stand there. Try to brace it with something.
+		</sp>
+      <sd> They place poles and long metal beams between the closing
+	walls, but they are simply snapped and bent as the giant
+	trashmasher rumbles on. The situation doesn't look too good.
+</sd>
+      <sp spk="LUKE"> Wait a minute!
+		</sp>
+      <sd> Luke pulls out his comlink.
+</sd>
+      <sp spk="LUKE"> Threepio! Come in Threepio! Threepio! Where could he be?
+</sp>
+   </scene>
+   <scene n="115">
+      <sd>INTERIOR: DEATH STAR -- MAIN GANTRY -- COMMAND OFFICE.
+	A soft buzzer and the muted voice of Luke calling out for
+	See-Threepio can be heard on Threepio's hand comlink, which is
+	sitting on the deserted computer console. Artoo and Threepio
+	are nowhere in sight. Suddenly there is a great explosion and
+	the door of the control tower flies across the floor. Four
+	armed stormtroopers enter the chamber.
+</sd>
+      <sp spk="FIRST TROOPER"> Take over! (pointing to the dead officer) See to him!
+Look there!
+		</sp>
+      <sd> A trooper pushes a button and the supply cabinet door
+	slides open. See-Threepio and Artoo-Detoo are inside. Artoo
+	follows his bronze companion out into the office.
+</sd>
+      <sp spk="THREEPIO"> They're madmen! They're heading for the prison level. If you
+hurry, you might catch them.
+</sp>
+      <sp spk="FIRST OFFICER"> (to his troops) Follow me! You stand guard.
+		</sp>
+      <sd> The troops hustle off down the hallway, leaving a guard to
+	watch over the command office.
+</sd>
+      <sp spk="THREEPIO"> (to Artoo) Come on!
+		</sp>
+      <sd> The guard aims a blaster at them.
+</sd>
+      <sp spk="THREEPIO"> Oh! All this excitement has overrun the circuits of my
+counterpart here. If you don't mind, I'd like to take him down to
+maintenance.
+</sp>
+      <sp spk="TROOPER"> All right.
+		</sp>
+      <sd> The guard nods and Threepio, with little Artoo in tow,
+	hurries out the door.
+</sd>
+   </scene>
+   <scene n="116">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	As the walls rumble closed, the room gets smaller and smaller.
+Chewie is whining and trying to hold a wall back with his giant paws.
+Han is leaning back against the other wall. Garbage is snapping and
+popping. Luke is trying to reach Threepio.
+</sd>
+      <sp spk="LUKE"> Threepio! Come in, Threepio! Threepio!
+		</sp>
+      <sd> Han and Leia try to brace the contracting walls with a
+	pole. Leia begins to sink into the trash.
+</sd>
+      <sp spk="HAN"> Get to the top!
+</sp>
+      <sp spk="LEIA"> I can't 
+</sp>
+      <sp spk="LUKE"> Where could he be? Threepio! Threepio, will you come in?
+</sp>
+   </scene>
+   <scene n="117">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO"> They aren't here! Something must have happened to them. See
+if they've been captured.
+		</sp>
+      <sd> Little Artoo carefully plugs his claw arm into a new wall
+	socket and a complex array of electronic sounds spew from the
+	tiny robot.
+</sd>
+      <sp spk="THREEPIO"> Hurry!
+</sp>
+   </scene>
+   <scene n="118">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	The walls are only feet apart. Leia and Han are braced against
+	the walls. The princess is frightened. They look at each
+	other. Leia reaches out and takes Han's hand and she holds it
+	tightly. She's terrified and suddenly groans as she feels the
+	first crushing pressure against her body.
+</sd>
+      <sp spk="HAN"> One thing's for sure. We're all going to be a lot thinner! (to
+Leia) Get on top of it!
+</sp>
+      <sp spk="LEIA"> I'm trying!
+</sp>
+   </scene>
+   <scene n="119">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO"> (to Artoo) Thank goodness, they haven't found them! Where
+could they be?
+	
+		</sp>
+      <sd> Artoo frantically beeps something to See-Threepio.
+</sd>
+      <sp spk="THREEPIO"> Use the comlink? Oh, my! I forgot I turned it off!
+</sp>
+   </scene>
+   <scene n="120">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	Meanwhile, Luke is lying on his side, trying to keep his head
+	above the rising ooze. Luke's comlink begins to buzz and he
+	rips it off his belt.
+</sd>
+   </scene>
+   <scene n="121">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+	Muffled sounds of Luke's voice over the comlink can be heard,
+	but not distinctly.
+</sd>
+      <sp spk="THREEPIO"> Are you there, sir?
+</sp>
+   </scene>
+   <scene n="122">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+</sd>
+      <sp spk="LUKE"> Threepio!
+</sp>
+   </scene>
+   <scene n="123">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="THREEPIO"> We've had some problems...
+</sp>
+      <sp spk="LUKE"> (over comlink) Will you shut up and listen to me? Shut down all
+garbage mashers on the detention level, will you? Do you copy?
+</sp>
+   </scene>
+   <scene n="124">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+</sd>
+      <sp spk="LUKE"> Shut down all the garbage mashers on the detention level.
+</sp>
+   </scene>
+   <scene n="125">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="LUKE"> (over comlink) Shut down all the garbage mashers on the
+detention level.
+</sp>
+      <sp spk="THREEPIO"> (to Artoo) No. Shut them all down! Hurry!
+		</sp>
+      <sd> Threepio holds his head in agony as he hears the incredible
+	screaming and hollering from Luke's comlink.
+</sd>
+      <sp spk="THREEPIO"> Listen to them! They're dying, Artoo! Curse my metal body! I
+wasn't fast enough. It's all my fault! My poor master!
+</sp>
+      <sp spk="LUKE"> (over comlink) Threepio, we're all right!
+</sp>
+   </scene>
+   <scene n="126">
+      <sd>INTERIOR: DEATH STAR -- GARBAGE ROOM.
+	The screaming and hollering is the sound of joyous relief. The
+	walls have stopped moving. Han, Chewie and Leia embrace in the
+	background.
+</sd>
+      <sp spk="LUKE"> We're all right. You did great.
+		</sp>
+      <sd> Luke moves to the pressure sensitive hatch, looking for a
+	number.
+</sd>
+      <sp spk="LUKE"> Hey...hey, open the pressure maintenance hatch on unit number...
+where are we?
+</sp>
+   </scene>
+   <scene n="127">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY -- SERVICE PANEL.
+</sd>
+      <sp spk="HAN"> (over comlink) Three-two-six-eight-two-seven.
+</sp>
+   </scene>
+   <scene n="128">
+      <sd>INTERIOR: DEATH STAR -- TRACTOR BEAM -- POWER GENERATOR TRENCH.
+	Ben enters a humming service trench that powers the huge
+	tractor beam. The trench seems to be a hundred miles deep. The
+	clacking sound of huge switching devices can be heard. The old
+	Jedi edges his his way along a narrow ledge leading to a
+	control panel that connects two large cables. He carefully
+	makes several adjustments in the computer terminal, and
+	several lights on the board go from red to blue.
+</sd>
+   </scene>
+   <scene n="129">
+      <sd>INTERIOR: DEATH STAR -- UNUSED HALLWAY.
+	The group exits the garbage room into a dusty, unused hallway.
+	Han and Luke remove the trooper suits and strap on the blaster
+	belts.
+</sd>
+      <sp spk="HAN"> If we can just avoid any more female advice, we ought to be able
+to get out of here.
+		</sp>
+      <sd> Luke smiles and scratches his head as he takes a blaster
+	from Solo.
+</sd>
+      <sp spk="LUKE"> Well, let's get moving!
+		</sp>
+      <sd> Chewie begins growling and points to the hatch to the
+	garbage room, as he runs away and then stops howling.
+</sd>
+      <sp spk="HAN"> (to Chewie) Where are you going?
+		</sp>
+      <sd> The Dia Nogu bangs against the hatch and a long, slimy
+	tentacle works its way out of the doorway searching for a
+	victim. Han aims his pistol.
+</sd>
+      <sp spk="LEIA"> No, wait. They'll hear!
+		</sp>
+      <sd> Han fires at the doorway. The noise of the blast echoes
+	relentlessly throughout the empty passageway. Luke simply
+	shakes his head in disgust.
+</sd>
+      <sp spk="HAN"> (to Chewie) Come here, you big coward!
+		</sp>
+      <sd> Chewie shakes his head "no."
+</sd>
+      <sp spk="HAN"> Chewie! Come here!
+</sp>
+      <sp spk="LEIA"> Listen. I don't know who you are, or where you came from, but
+from now on, you do as I tell you. Okay?
+		</sp>
+      <sd> Han is stunned at the command of the petite young girl.
+</sd>
+      <sp spk="HAN"> Look, Your Worshipfulness, let's get one thing straight! I take
+orders from one person! Me!
+</sp>
+      <sp spk="LEIA"> It's a wonder you're still alive. (looking at Chewie) Will
+somebody get this big walking carpet out of my way?
+		</sp>
+      <sd> Han watches her start away. He looks at Luke.
+</sd>
+      <sp spk="HAN"> No reward is worth this.
+		</sp>
+      <sd> They follow her, moving swiftly down the deserted corridor.
+</sd>
+   </scene>
+   <scene n="130">
+      <sd>INTERIOR: DEATH STAR -- POWER TRENCH.
+	Suddenly a door behind Ben slides open and a detachment of
+	stormtroopers marches to the power trench. Ben instantly slips
+	into the shadows as an Officer moves to within a few feet of
+	him.
+</sd>
+      <sp spk="OFFICER"> Secure this area until the alert is canceled.
+</sp>
+      <sp spk="FIRST TROOPER"> Give me regular reports.
+		</sp>
+      <sd> All but two of the stormtroopers leave.
+</sd>
+      <sp spk="FIRST TROOPER"> Do you know what's going on?
+</sp>
+      <sp spk="SECOND TROOPER"> Maybe it's another drill.
+		</sp>
+      <sd> Ben moves around the tractor beam, watching the
+	stormtroopers as they turn their backs to him. Ben gestures
+	with his hand toward them, as the troops think they hear
+	something in the other hallway. With the help of the Force,
+	Ben deftly slips past the troopers and into the main hallway.
+</sd>
+      <sp spk="SECOND TROOPER"> What was that?
+</sp>
+      <sp spk="FIRST TROOPER"> Oh, it's nothing. Don't worry about it.
+</sp>
+   </scene>
+   <scene n="131">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Luke, Han, Chewbacca, and Leia run down an empty hallway and
+	stop before a bay window overlooking the pirateship. Troopers
+	are milling about the ship. Luke takes out his pocket comlink.
+</sd>
+      <sp spk="HAN"> (looking at his ship) There she is.
+</sp>
+      <sp spk="LUKE"> See-Threepio, do you copy?
+</sp>
+      <sp spk="THREEPIO"> (voice) For the moment. Uh, we're in the main hangar across
+from the ship.
+</sp>
+      <sp spk="LUKE"> We're right above you. Stand by.
+		</sp>
+      <sd> Han is watching the dozen or so troops moving in and out of
+	the pirateship. Leia moves towards Han, touches his arm and
+	points out the window to the ship.
+</sd>
+      <sp spk="LEIA"> You came in that thing? You're braver that I thought.
+</sp>
+      <sp spk="HAN"> Nice! Come on!
+		</sp>
+      <sd> Han gives her a dirty look, and they start off down the
+	hallway. They round a corner and run right into twenty
+	Imperial stormtroopers heading toward them. Both groups are
+	taken by surprise and stop in their tracks.
+</sd>
+      <sp spk="FIRST TROOPER"> It's them! Blast them!
+		</sp>
+      <sd> Before even thinking, Han draws his laser pistol and
+	charges the troops, firing. His blaster knocks one of the
+	stormtroopers into the air. Chewie follows his captain down
+	the corridor, stepping over the fallen trooper on the floor.
+</sd>
+      <sp spk="HAN"> (to Luke and Leia) Get back to the ship!
+</sp>
+      <sp spk="LUKE"> Where are you going? Come back!
+		</sp>
+      <sd> Han has already rounded a corner and does not hear.
+</sd>
+      <sp spk="LEIA"> He certainly has courage.
+</sp>
+      <sp spk="LUKE"> What good will it do us if he gets himself killed? Come on!
+		</sp>
+      <sd> Luke is furious but doesn't have time to think about it for
+	muted alarms begin to go off down on the hangar deck. Luke and
+	Leia start off toward the starship hangar.
+</sd>
+   </scene>
+   <scene n="132">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Han chases the stormtroopers down a long subhallway. He is
+	yelling and brandishing his laser pistol. The troops reach a
+	dead end and are forced to turn and fight. Han stops a few
+	feet from them and assumes a defensive position. The troops
+	begin to raise their laser guns. Soon all ten troopers are
+	moving into an attack position in front of the lone
+	starpirate. Han's determined look begins to fade as the troops
+	begin to advance. Solo jumps backward as they fire at him.
+</sd>
+   </scene>
+   <scene n="133">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Chewbacca runs down the subhallway in a last-ditch attempt to
+	save his bold captain. Suddenly he hears the firing of laser
+	guns and yelling. Around the corner shoots Han, pirate
+	extraordinaire, running for his life, followed by a host of
+	furious stormtroopers. Chewbacca turns and starts running the
+	other way also.
+</sd>
+   </scene>
+   <scene n="134">
+      <sd>INTERIOR: DEATH STAR -- SUBHALLWAY.
+	Luke fires his laser pistol wildly as he and Leia rush down a
+	narrow subhallway, chased by several stormtroopers. They
+	quickly reach the end of the subhallway and race through an
+	open hatchway.
+</sd>
+   </scene>
+   <scene n="135">
+      <sd>INTERIOR: DEATH STAR -- CENTRAL CORE SHAFT.
+	Luke and Leia race through the hatch onto a narrow bridge that
+	spans a huge, deep shaft that seems to go into infinity. The
+	bridge has been retracted into the wall of the shaft, and Luke
+	almost rushes into the abyss. He loses his balance off the end
+	of the bridge as Leia, behind him, takes hold of his arm and
+	pulls him back.
+</sd>
+      <sp spk="LUKE"> (gasping) I think we took a wrong turn.
+		</sp>
+      <sd> Blasts from the stormtroopers' laser guns explode nearby
+	reminding them of the oncoming danger. Luke fires back at the
+	advancing troops. Leia reaches over and hits a switch that
+	pops the hatch door shut with a resounding boom, leaving them
+	precariously perched on a short piece of bridge overhang.
+	Laserfire from the troopers continues to hit the steel door.
+</sd>
+      <sp spk="LEIA"> There's no lock!
+		</sp>
+      <sd> Luke blasts the controls with his laser pistol.
+</sd>
+      <sp spk="LUKE"> That oughta hold it for a while.
+</sp>
+      <sp spk="LEIA"> Quick, we've got to get across. Find the control that extends
+the bridge.
+</sp>
+      <sp spk="LUKE"> Oh, I think I just blasted it.
+		</sp>
+      <sd> Luke looks at the blasted bridge control while the
+	stormtroopers on the opposite side of the door begin making
+	ominous drilling and pounding sounds.
+</sd>
+      <sp spk="LEIA"> They're coming through!
+		</sp>
+      <sd> Luke notices something on his stormtrooper belt, when
+	laserfire hits the wall behind him. Luke aims his laser pistol
+	at a stormtrooper perched on a higher bridge overhang across
+	the abyss from them. They exchange fire. Two more troops
+	appear on another overhang, also firing. A trooper is hit, and
+	grabs at his chest.
+</sd>
+      <sd> Another trooper standing on the bridge overhang is hit by
+	Luke's laserfire, and plummets down the shaft. Troopers move
+	back off the bridge; Luke hands the gun to Leia.
+</sd>
+      <sp spk="LUKE"> Here, hold this.
+		</sp>
+      <sd> Luke pulls a thin nylon cable from his trooper utility
+	belt. It has a grappler hook on it. A trooper appears on a
+	bridge overhang and fires at Luke and Leia. As Luke works with
+	the rope, Leia returns the laser volley. Another trooper
+	appears and fires at them, as Leia returns his fire as well.
+	Suddenly, the hatch door begins to open, revealing the feet of
+	more troops.
+</sd>
+      <sp spk="LEIA"> Here they come!
+		</sp>
+      <sd> Leia hits one of the stormtroopers on the bridge above, and
+	he falls into the abyss. Luke tosses the rope across the gorge
+	and it wraps itself around an outcropping of pipes. He tugs on
+	the rope to make sure it is secure, then grabs the princess in
+	his arms. Leia looks at Luke, then kisses him quickly on the
+	lips. Luke is very surprised.
+</sd>
+      <sp spk="LEIA"> For luck!
+		</sp>
+      <sd> Luke pushes off and they swing across the treacherous abyss
+	to the corresponding hatchway on the opposite side. Just as
+	Luke and Leia reach the far side of the canyon, the
+	stormtroopers break through the hatch and begin to fire at
+	the escaping duo. Luke returns the fire before ducking into
+	the tiny subhallway.
+</sd>
+   </scene>
+   <scene n="136">
+      <sd>INTERIOR: DEATH STAR -- NARROW PASSAGEWAY.
+	Ben hides in the shadows of the narrow passageway as several
+	stormtroopers rush past him in the main hallway. He checks to
+	make sure they're gone, then runs down the hallway in the
+	opposite direction. Darth Vader appears at the far end of the
+	hallway and starts after the old Jedi.
+</sd>
+   </scene>
+   <scene n="137">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	Threepio looks around at the troops milling about the
+	pirateship entry ramp.
+</sd>
+      <sp spk="THREEPIO"> Where could they be?
+		</sp>
+      <sd> Artoo, plugged into the computer socket, turns his dome
+	left and right, beeping a response.
+</sd>
+   </scene>
+   <scene n="138">
+      <sd>INTERIOR: DEATH STAR -- CORRIDOR -- BLAST SHIELDS DOOR.
+	Han and Chewbacca run down a long corridor with several
+	troopers hot on their trail.
+</sd>
+      <sp spk="TROOPER"> Close the blast doors!
+		</sp>
+      <sd> At the end of the hallway, blast doors begin to close in
+	front of them. The young starpilot and his furry companion
+	race past the huge doors just as they are closing, and manage
+	to get off a couple off laserblasts at the pursuing troops
+	before the doors slam shut.
+</sd>
+      <sp spk="TROOPER"> Open the blast doors! Open the blast doors!
+</sp>
+   </scene>
+   <scene n="139">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY LEADING TO MAIN FORWARD BAY.
+	Ben hurries along one of the tunnels leading to the hangar
+	where the pirateship waits. Just before he reaches the hangar,
+	Darth Vader steps into view at the end of the tunnel, not ten
+	feet away. Vader lights his saber. Ben also ignites his and
+	steps slowly forward.
+</sd>
+      <sp spk="VADER"> I've been waiting for you, Obi-Wan. We meet again, at last. The
+circle is now complete.
+		</sp>
+      <sd> Ben Kenobi moves with elegant ease into a classical
+	offensive position. The fearsome Dark Knight takes a defensive
+	stance.
+</sd>
+      <sp spk="VADER"> When I left you, I was but the learner; now I am the master.
+</sp>
+      <sp spk="BEN"> Only a master of evil, Darth.
+		</sp>
+      <sd> The two Galactic warriors stand perfectly still for a few
+	moments, sizing each other up and waiting for the right
+	moment. Ben seems to be under increasing pressure and strain,
+	as if an invisible weight were being placed upon him. He
+	shakes his head and, blinking, tries to clear his eyes. 
+</sd>
+      <sd> Ben makes a sudden lunge at the huge warrior but is checked
+	by a lightning movement of The Sith. A masterful slash stroke
+	by Vader is blocked by the old Jedi. Another of the Jedi's
+	blows is blocked, then countered. Ben moves around the Dark
+	Lord and starts backing into the massive starship hangar. The
+	two powerful warriors stand motionless for a few moments with
+	laser swords locked in mid-air, creating a low buzzing sound.
+</sd>
+      <sp spk="VADER"> Your powers are weak, old man.
+</sp>
+      <sp spk="BEN"> You can't win, Darth. If you strike me down, I shall become more
+powerful than you can possibly imagine.
+		</sp>
+      <sd> Their lightsabers continue to meet in combat.
+</sd>
+   </scene>
+   <scene n="140">
+      <sd>INTERIOR: DEATH STAR -- MAIN FORWARD BAY.
+	Han Solo and Chewbacca, their weapons in hand, lean back
+	against the wall surveying the forward bay, watching the
+	Imperial stormtroopers make their rounds of the hangar.
+</sd>
+      <sp spk="HAN"> Didn't we just leave this party?
+		</sp>
+      <sd> Chewbacca growls a reply, as Luke and the princess join
+	them.
+</sd>
+      <sp spk="HAN"> What kept you?
+</sp>
+      <sp spk="LEIA"> We ran into some old friends.
+</sp>
+      <sp spk="LUKE"> Is the ship all right?
+</sp>
+      <sp spk="HAN"> Seems okay, if we can get to it. Just hope the old man got the
+tractor beam out of commission.
+</sp>
+   </scene>
+   <scene n="141">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Vader and Ben Kenobi continue their powerful duel. As they hit
+	their lightsabers together, lightning flashes on impact.
+	Troopers look on in interest as the old Jedi and Dark Lord of
+	The Sith fight. Suddenly Luke spots the battle from his
+	group's vantage point.
+</sd>
+      <sp spk="LUKE"> Look!
+		</sp>
+      <sd> Luke, Leia, Han, and Chewie look up and see Ben and Vader
+	emerging from the hallways on the far side of the docking bay.
+</sd>
+   </scene>
+   <scene n="142">
+      <sd>INTERIOR: DEATH STAR -- DOCKING BAY.
+	Threepio and Artoo-Detoo are in the center of the Death Star's
+	Imperial docking bay.
+</sd>
+      <sp spk="THREEPIO"> Come on, Artoo, we're going!
+		</sp>
+      <sd> Threepio ducks out of sight as the seven stormtroopers who
+	were guarding the starship rush past them heading towards Ben
+	and The Sith Knight. He pulls on Artoo.
+</sd>
+   </scene>
+   <scene n="143">
+      <sd>INTERIOR: DEATH STAR -- HALLWAY.
+	Solo, Chewie, Luke, and Leia tensely watch the duel. The
+	troops rush toward the battling knights.
+</sd>
+      <sp spk="HAN"> Now's our chance! Go!</sp>
+      <sd>They start for the Millennium Falcon. Ben sees the troops
+	charging toward him and realizes that he is trapped. Vader
+	takes advantage of Ben's momentary distraction and brings his
+	mighty lightsaber down on the old man. Ben manages to deflect
+	the blow and swiftly turns around.
+		</sd>
+      <sd> The old Jedi Knight looks over his shoulder at Luke, lifts
+	his sword from Vader's then watches his opponent with a serene
+	look on his face.
+</sd>
+      <sd> Vader brings his sword down, cutting old Ben in half. Ben's
+	cloak falls to the floor in two parts, but Ben is not in it.
+	Vader is puzzled at Ben's disappearance and pokes at the empty
+	cloak. As the guards are distracted, the adventurers and the
+	robots reach the starship. Luke sees Ben cut in two and starts
+	for him. Aghast, he yells out.
+</sd>
+      <sp spk="LUKE"> No!
+		</sp>
+      <sd> The stormtroopers turn toward Luke and begin firing at him.
+	The robots are already moving up the ramp into the Millennium
+	Falcon, while Luke, transfixed by anger and awe, returns their
+	fire. Solo joins in the laserfire. Vader looks up and advances
+	toward them, as one of his troopers is struck down.
+</sd>
+      <sp spk="HAN"> (to Luke) Come on!
+</sp>
+      <sp spk="LEIA"> Come on! Luke, its too late!
+</sp>
+      <sp spk="HAN"> Blast the door! Kid!
+		</sp>
+      <sd> Luke fires his pistol at the door control panel, and it
+	explodes. The door begins to slide shut. Three troopers charge
+	forward firing laser bolts, as the door slides to a close
+	behind them, shutting Vader and the other troops out of the
+	docking bay. A stormtrooper lies dead at the feet of his
+	onrushing compatriots. Luke starts for the advancing troops,
+	as Solo and Leia move up the ramp into the pirateship. He
+	fires, hitting a stormtrooper, who crumbles to the floor.
+</sd>
+      <sp spk="BEN'S VOICE"> Run, Luke! Run!
+		</sp>
+      <sd> Luke looks around to see where the voice came from. He
+	turns toward the pirateship, ducking Imperial gunfire from the
+	troopers and races into the ship.
+</sd>
+   </scene>
+   <scene n="144">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han pulls back on the controls and the ship begins to move. The
+	dull thud of laser bolts bouncing off the outside of the ship
+	as Chewie adjusts his controls.
+</sd>
+      <sp spk="HAN"> I hope the old man got that tractor beam out if commission, or
+this is going to be a real short trip. Okay, hit it!
+		</sp>
+      <sd> Chewbacca growls in agreement.
+</sd>
+   </scene>
+   <scene n="145">
+      <sd>EXTERIOR: MILLENNIUM FALCON.
+	The Millennium Falcon powers away from the Death Star docking
+	bay, makes a spectacular turn and disappears into the vastness
+	of space.
+</sd>
+   </scene>
+   <scene n="146">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Luke, saddened by the loss of Obi-Wan Kenobi, stares off
+	blankly as the robots look on. Leia puts a blanket around him
+	protectively, and Luke turns and looks up at her. She sits
+	down beside him.
+</sd>
+   </scene>
+   <scene n="147">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Solo spots approaching enemy ships.
+</sd>
+      <sp spk="HAN"> (to Chewie) We're coming up on the sentry ships. Hold 'em off!
+Angle the deflector shields while I charge up the main guns!
+</sp>
+   </scene>
+   <scene n="148">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CENTRAL HOLD AREA.
+	Luke looks downward sadly, shaking his head back and forth, as
+	the princess smiles comfortingly at him.
+</sd>
+      <sp spk="LUKE"> I can't believe he's gone.
+		</sp>
+      <sd> Artoo-Detoo beeps a reply.
+</sd>
+      <sp spk="LEIA"> There wasn't anything you could have done.
+		</sp>
+      <sd> Han rushes into the hold area where Luke is sitting with
+	the princess.
+</sd>
+      <sp spk="HAN"> (to Luke) Come on, buddy, we're not out of this yet!
+</sp>
+   </scene>
+   <scene n="149">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Solo climbs into his attack position in the topside gunport.
+</sd>
+   </scene>
+   <scene n="150">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HOLD AREA.
+	Luke gets up and moves out toward the gunports as Leia heads
+	for the cockpit.
+</sd>
+   </scene>
+   <scene n="151">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Luke climbs down the ladder into the gunport cockpit, settling
+	into one of the two main laser cannons mounted in large
+	rotating turrets on either side of the ship.
+</sd>
+   </scene>
+   <scene n="152">
+      <sd>INTERIOR: MILLENNIUM FALCON -- SOLO'S GUNPORT.
+	Han adjusts his headset as he sits before the controls of his
+	laser cannon, then speaks into the attached microphone.
+</sd>
+      <sp spk="HAN"> (to Luke) You in, kid? Okay, stay sharp!
+</sp>
+   </scene>
+   <scene n="153">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS -- COCKPIT.
+	Chewbacca and Princess Leia search the heavens for attacking
+	TIE fighters. The Wookiee pulls back on the speed controls as
+	the ship bounces slightly.
+</sd>
+   </scene>
+   <scene n="154">
+      <sd>INTERIOR: MILLENNIUM FALCON -- SOLO'S GUNPORT -- COCKPIT.
+	Computer graphic readouts form on Solo's target screen, as Han
+	reaches for controls.
+</sd>
+   </scene>
+   <scene n="155">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT -- COCKPIT.
+	Luke sits in readiness for the attack, his hand on the laser
+	cannon's control button.
+</sd>
+   </scene>
+   <scene n="156">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Chewbacca spots the enemy ships and barks.
+</sd>
+      <sp spk="LEIA"> (into intercom) Here they come!
+</sp>
+   </scene>
+   <scene n="157">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- POV (POINT OF VIEW) -- SPACE.
+	The Imperial TIE fighters move towards the Millennium Falcon,
+	one each veering off to the left and right of the pirateship.
+</sd>
+   </scene>
+   <scene n="158">
+      <sd>INTERIOR: TIE FIGHTER -- COCKPIT.
+	The stars whip past behind the Imperial pilot as he adjusts
+	his maneuvering joy stick.
+</sd>
+   </scene>
+   <scene n="159">
+      <sd>EXTERIOR: MILLENNIUM FALCON -- IN SPACE.
+	The TIE fighter races past the Falcon, firing laser beams as
+	it passes.
+</sd>
+   </scene>
+   <scene n="160">
+      <sd>INTERIOR: MILLENNIUM FALCON -- HOLD AREA.
+	Threepio is seated in the hold area, next to Artoo-Detoo. The
+	pirateship bounces and vibrates as the power goes out in the
+	room and then comes back on.
+</sd>
+   </scene>
+   <scene n="161">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- GUNPORTS.
+	A TIE fighter maneuvers in front of Han, who follows it and
+	fires at it with the laser cannon. Luke does likewise, as the
+	fighter streaks into view. The ship has suffered a minor hit,
+	and bounces slightly. 
+</sd>
+   </scene>
+   <scene n="162">
+      <sd>EXTERIOR: SPACE.
+	Two TIE fighters dive down toward the pirateship.
+</sd>
+   </scene>
+   <scene n="163">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires at an unseen fighter.
+</sd>
+      <sp spk="LUKE"> They're coming in too fast!
+</sp>
+   </scene>
+   <scene n="164">
+      <sd>EXTERIOR: SPACE -- MILLENNIUM FALCON/TIE FIGHTERS.
+	Pan with pirateship as two TIE fighters charge through the
+	background. Laserbolts streak from all the craft.
+</sd>
+   </scene>
+   <scene n="165">
+      <sd>INTERIOR: MILLENNIUM FALCON -- CHEWBACCA.
+	The ship shudders as a laserbolt hits very close to the
+	cockpit. The Wookiee chatters something to Leia.
+</sd>
+   </scene>
+   <scene n="166">
+      <sd>EXTERIOR: TIE FIGHTER -- SPACE.
+	Full shot of a TIE fighter as it moves fast through the frame,
+	firing on the pirate starship.
+</sd>
+   </scene>
+   <scene n="167">
+      <sd>EXTERIOR: SPACE -- TIE FIGHTERS.
+	The two TIE fighters fire a barrage of laserbeams at the
+	pirateship.
+</sd>
+   </scene>
+   <scene n="168">
+      <sd>INTERIOR: MILLENNIUM FALCON -- MAIN PASSAGEWAY.
+	A laserbolt streaks into the side of the pirateship. The ship
+	lurches violently, throwing poor Threepio into a cabinet fill
+	of small computer chips.
+</sd>
+      <sp spk="THREEPIO"> Oooh!
+</sp>
+   </scene>
+   <scene n="169">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT -- GUNPORTS.
+	Leia watches the computer readout as Chewbacca manipulates the
+	ship's controls.
+</sd>
+      <sp spk="LEIA"> We've lost lateral controls.
+</sp>
+      <sp spk="HAN"> Don't worry, she'll hold together.
+		</sp>
+      <sd> An enemy laserbolt hits the pirateship's control panel,
+	causing it to blow out in a shower of sparks.
+</sd>
+      <sp spk="HAN"> (to ship) You hear me, baby? Hold together!
+		</sp>
+      <sd> Artoo-Detoo advances toward the smoking sparking control
+	panel, dousing the inferno by spraying it with fire retardant
+	beeping all the while.
+</sd>
+   </scene>
+   <scene n="170">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Luke swivels in his gun mount, following the TIE fighter with
+	his laser cannon.
+</sd>
+   </scene>
+   <scene n="171">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Solo aims his laser cannon at the enemy fighter.
+</sd>
+   </scene>
+   <scene n="172">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter streaks in front of the starship.
+</sd>
+   </scene>
+   <scene n="173">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Leia watches the TIE fighter ship fly over.
+</sd>
+   </scene>
+   <scene n="174">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter heads right for the pirateship, then zooms
+	overhead.
+</sd>
+   </scene>
+   <scene n="175">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke follows the TIE fighter across his field of view, firing
+	laserbeams from his cannon.
+</sd>
+   </scene>
+   <scene n="176">
+      <sd>EXTERIOR: TIE FIGHTER.
+	A TIE fighter dives past the pirateship.
+</sd>
+   </scene>
+   <scene n="177">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires at a TIE fighter. At his port, Han follows a
+	fighter in his sights, releasing a blast of laserfire. He
+	connects, and the fighter explodes into fiery dust. Han laughs
+	victoriously.
+</sd>
+   </scene>
+   <scene n="178">
+      <sd>EXTERIOR: SPACE.
+	Two TIE fighters move toward and over the Millennium Falcon,
+	unleashing a barrage of laserbolts at the ship.
+</sd>
+   </scene>
+   <scene n="179">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Another TIE fighter moves in on the pirateship and Luke,
+	smiling, fires the laser cannon at it, scoring a spectacular
+	direct hit.
+</sd>
+      <sp spk="LUKE"> Got him! I got him!
+		</sp>
+      <sd> Han turns and gives Luke a victory wave which Luke
+	gleefully returns.
+</sd>
+      <sp spk="HAN"> Great kid! Don't get cocky.
+		</sp>
+      <sd> Han turns back to his laser cannon.
+</sd>
+   </scene>
+   <scene n="180">
+      <sd>EXTERIOR: SPACE.
+	Two more TIE fighters cross in front of the pirateship.
+</sd>
+   </scene>
+   <scene n="181">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT
+	While Chewbacca manipulates the controls, Leia turns, looking
+	over her shoulder out the ports.
+</sd>
+      <sp spk="LEIA"> There are still two more of them out there!
+</sp>
+   </scene>
+   <scene n="182">
+      <sd>EXTERIOR: SPACE.
+	A TIE fighter moves up over the pirateship, firing laserblasts
+	at it.
+</sd>
+   </scene>
+   <scene n="183">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke and Han look into their respective projected target
+	screens. An Imperial fighter crosses Solo's port, and Han
+	swivels in his chair, following it with blasts from his laser
+	cannon. Another fighter crosses Luke's port, and he reacts in
+	a like manner, the glow of his target screen lighting his
+	face.
+</sd>
+   </scene>
+   <scene n="184">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter zooms toward the pirateship, firing
+	destructive blasts at it.
+</sd>
+   </scene>
+   <scene n="185">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORTS.
+	Luke fires a laserblast at the approaching enemy fighter, and
+	it bursts into a spectacular explosion. Luke's projected
+	screen gives a readout of the hit. The pirateship bounces
+	slightly as it is struck by the enemy fire.
+</sd>
+   </scene>
+   <scene n="186">
+      <sd>EXTERIOR: SPACE -- TIE FIGHTER.
+	The last of the attacking Imperial TIE fighters looms in,
+	firing upon the Falcon.
+</sd>
+   </scene>
+   <scene n="187">
+      <sd>INTERIOR: MILLENNIUM FALCON -- GUNPORT.
+	Solo swivels behind his cannon, his aim describing the arc of
+	the TIE fighter. The fighter comes closer, firing at the
+	pirateship, but a well-aimed blast from Solo's laser cannon
+	hits the attacker, which blows up in a small atomic shower of
+	burning fragments.
+</sd>
+      <sp spk="LUKE"> (laughing) That's it! We did it!
+		</sp>
+      <sd> The princess jumps up and gives Chewie a congratulatory
+	hug.
+</sd>
+      <sp spk="LEIA"> We did it!
+</sp>
+   </scene>
+   <scene n="188">
+      <sd>INTERIOR: MILLENNIUM FALCON -- PASSAGEWAY.
+	Threepio lies on the floor of the ship, completely tangled in
+	the smoking, sparking wires.
+</sd>
+      <sp spk="THREEPIO"> Help! I think I'm melting! (to Artoo) This is all your
+fault.
+		</sp>
+      <sd> Artoo turns his dome from side to side, beeping in
+	response.
+</sd>
+   </scene>
+   <scene n="189">
+      <sd>EXTERIOR: SPACE -- MILLENNIUM FALCON.
+	The victorious Millennium Falcon moves off majestically
+	through space.
+</sd>
+   </scene>
+   <scene n="190">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Darth Vader strides into the control room, where Tarkin is
+	watching the huge view screen. A sea of stars is before him.
+</sd>
+      <sp spk="TARKIN"> Are they away?
+</sp>
+      <sp spk="VADER"> They have just made the jump into hyperspace.
+</sp>
+      <sp spk="TARKIN"> You're sure the homing beacon is secure aboard their ship? I'm
+taking an awful risk, Vader. This had better work.
+</sp>
+   </scene>
+   <scene n="191">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han, removes his gloves and smiling, is at the controls of the
+	ship. Chewie moves into the aft section to check the damage.
+	Leia is seated near Han.
+</sd>
+      <sp spk="HAN"> Not a bad bit of rescuing, huh? You know, sometimes I even amaze
+myself.
+</sp>
+      <sp spk="LEIA"> That doesn't sound too hard. Besides, they let us go. It's the
+only explanation for the ease of our escape.
+</sp>
+      <sp spk="HAN"> Easy...you call that easy?
+</sp>
+      <sp spk="LEIA"> Their tracking us!
+</sp>
+      <sp spk="HAN"> Not this ship, sister.
+		</sp>
+      <sd> Frustrated, Leia shakes her head.
+</sd>
+      <sp spk="LEIA"> At least the information in Artoo is still intact.
+</sp>
+      <sp spk="HAN"> What's so important? What's he carrying?
+</sp>
+      <sp spk="LEIA"> The technical readouts of that battle station. I only hope that
+when the data is analyzed, a weakness can be found. It's not over yet!
+</sp>
+      <sp spk="HAN"> It is for me, sister! Look, I ain't in this for your revolution,
+and I'm not in it for you, Princess. I expect to be well paid. I'm in
+it for the money!
+</sp>
+      <sp spk="LEIA"> You needn't worry about your reward. If money is all that you
+love, then that's what you'll receive!
+		</sp>
+      <sd> She angrily turns, and as she starts out of the cockpit,
+	passes Luke coming in.
+</sd>
+      <sp spk="LEIA"> Your friend is quite a mercenary. I wonder if he really cares
+about anything...or anyone.
+</sp>
+      <sp spk="LUKE"> I care!
+		</sp>
+      <sd> Luke, shaking his head, sits in the copilot seat. He and
+	Han stare out at the vast blackness of space.
+</sd>
+      <sp spk="LUKE"> So...what do you think of her, Han?
+</sp>
+      <sp spk="HAN"> I'm trying not to, kid!
+</sp>
+      <sp spk="LUKE"> (under his breath) Good...
+</sp>
+      <sp spk="HAN"> Still, she's got a lot of spirit. I don't know, what do you
+think? Do you think a princess and a guy like me...
+</sp>
+      <sp spk="LUKE"> No!
+		</sp>
+      <sd> Luke says it with finality and looks away. Han smiles at
+	young Luke's jealousy.
+</sd>
+   </scene>
+   <scene n="192">
+      <sd>EXTERIOR: SPACE AROUND FOURTH MOON OF YAVIN.
+	The battered pirateship drifts into orbit around the planet
+	Yavin and proceeds to one of its tiny green moons.
+</sd>
+   </scene>
+   <scene n="193">
+      <sd>EXTERIOR: FOURTH MOON OF YAVIN.
+	The pirateship soars over the dense jungle.
+</sd>
+   </scene>
+   <scene n="194">
+      <sd>EXTERIOR: MASSASSI OUTPOST.
+	An alert guard, his laser gun in hand, scans the countryside.
+	He sets the gun down and looks toward the temple, barely
+	visible in the foliage.
+</sd>
+   </scene>
+   <scene n="195">
+      <sd>EXTERIOR: MASSASSI OUTPOST -- JUNGLE TEMPLE.
+	Rotting in a forest of gargantuan trees, an ancient temple
+	lies shrouded in an eerie mist. The air is heavy with the
+	fantastic cries of unimaginable creatures. Han, Luke and the
+	others are greeted by the Rebel troops.
+		 Luke and the group ride into the massive temple on an
+	armored military speeder.
+</sd>
+   </scene>
+   <scene n="196">
+      <sd>INTERIOR: MASSASSI -- MAIN HANGAR DECK.
+	The military speeder stops in a huge spaceship hangar, set up
+	in the interior of the crumbling temple. Willard, the
+	commander of the Rebel forces, rushes up to the group and
+	gives Leia a big hug. Every one is pleased to see her.
+</sd>
+      <sp spk="WILLARD"> (holding Leia) You're safe! We had feared the worst.
+		</sp>
+      <sd> Willard composes himself, steps back and bows formally.
+</sd>
+      <sp spk="WILLARD"> When we heard about Alderaan, we were afraid that you were...
+lost along with your father.
+</sp>
+      <sp spk="LEIA"> We don't have time for our sorrows, Commander. The battle
+station has surely tracked us here (looking pointedly to Han). It's
+the only explanation for the ease of our escape. You must use the
+information in this R2 unit to plan the attack. It is our only hope.
+</sp>
+   </scene>
+   <scene n="197">
+      <sd>EXTERIOR: SPACE.
+	The surface of the Death Star ominously approaches the red
+	planet Yavin.
+</sd>
+   </scene>
+   <scene n="198">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grand Moff Tarkin and Lord Vader are interrupted in their
+	discussion by the buzz of the comlink. Tarkin moves to answer
+	the call.
+</sd>
+      <sp spk="TARKIN"> Yes.
+</sp>
+      <sp spk="DEATH STAR INTERCOM VOICE"> We are approaching the planet Yavin. The
+Rebel base is on a moon on the far side. We are preparing to orbit the
+planet.
+</sp>
+   </scene>
+   <scene n="199">
+      <sd>EXTERIOR: YAVIN -- JUNGLE.
+	A lone guard stands in a tower high above the Yavin landscape,
+	surveying the countryside. A mist hangs over the jungle of
+	twisted green.
+</sd>
+   </scene>
+   <scene n="200">
+      <sd>INTERIOR: MASSASSI -- WAR ROOM BRIEFING AREA.
+	Dodonna stands before a large electronic wall display. Leia
+	and several other senators are to one side of the giant
+	readout. The low-ceilinged room is filled with starpilots,
+	navigators, and a sprinkling of R2-type robots. Everyone is
+	listening intently to what Dodonna is saying. Han and
+	Chewbacca are standing near the back.
+</sd>
+      <sp spk="DODONNA"> The battle station is heavily shielded and carries a
+firepower greater than half the star fleet. It's defenses are designed
+around a direct large-scale assault. A small one-man fighter should be
+able to penetrate the outer defense.
+		</sp>
+      <sd> Gold Leader, a rough looking man in his early thirties,
+	stands and addresses Dodonna.
+</sd>
+      <sp spk="GOLD LEADER"> Pardon me for asking, sir, but what good are snub
+fighters going to be against that?
+</sp>
+      <sp spk="DODONNA"> Well, the Empire doesn't consider a small one-man fighter to
+be any threat, or they'd have a tighter defense. An analysis of the
+plans provided by Princess Leia has demonstrated a weakness in the
+battle station.
+		</sp>
+      <sd> Artoo-Detoo stands next to a similar robot, makes beeping
+	sounds, and turns his head from right to left.
+</sd>
+      <sp spk="DODONNA"> The approach will not be easy. You are required to maneuver
+straight down this trench and skim the surface to this point. The
+target area is only two meters wide. It's a small thermal exhaust
+port, right below the main port. The shaft leads directly to the
+reactor system. A precise hit will start a chain reaction which should
+destroy the station.
+		</sp>
+      <sd> A murmer of disbelief runs through the room.
+</sd>
+      <sp spk="DODONNA"> Only a precise hit will set up a chain reaction. The shaft is
+ray-shielded, so you'll have to use proton torpedoes.
+		</sp>
+      <sd> Luke is sitting next to Wedge Antilles, a hotshot pilot
+	about sixteen years old.
+</sd>
+      <sp spk="WEDGE"> That's impossible, even for a computer.
+</sp>
+      <sp spk="LUKE"> It's not impossible. I used to bull's-eye womp rats in my
+T-sixteen back home. They're not much bigger than two meters.
+</sp>
+      <sp spk="DODONNA"> Man your ships! And may the Force be with you!
+		</sp>
+      <sd> The group rises and begins to leave.
+</sd>
+   </scene>
+   <scene n="201">
+      <sd>EXTERIOR: SPACE.
+	The Death Star begins to move around the planet toward the
+	tiny green moon.
+</sd>
+   </scene>
+   <scene n="202">
+      <sd>INTERIOR: DEATH STAR.
+	Tarkin and Vader watch the computer projected screen with
+	interest, as a circle of lights intertwines around one another
+	on the screen showing it's position in relation to Yavin and
+	the forth moon.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Orbiting the planet at maximum velocity.
+The moon with the Rebel base will be in range in thirty minutes.
+</sp>
+      <sp spk="VADER"> This will be a day long remembered. It has seen the end of
+Kenobi and it will soon see the end of the Rebellion.
+</sp>
+   </scene>
+   <scene n="203">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN HANGAR DECK.
+	Luke, Threepio and little Artoo enter the huge spaceship
+	hangar and hurry along a long line of gleaming spacefighters.
+	Flight crews rush around loading last-minute armaments and
+	unlocking power couplings. In an area isolated from this
+	activity Luke finds Han and Chewbacca loading small boxes onto
+	an armored speeder.
+</sd>
+      <sp spk="MAN'S VOICE"> (over loudspeaker) All flight trooper, man your stations.
+All flight troops, man your stations.
+		</sp>
+      <sd> Han is deliberately ignoring the activity of the fighter
+	pilots' preparation. Luke is quite saddened at the sight of
+	his friend's departure.
+</sd>
+      <sp spk="LUKE"> So...you got your reward and you're just leaving then?
+</sp>
+      <sp spk="HAN"> That's right, yeah! I got some old debts I've got to pay off with
+this stuff. Even if I didn't, you don't think I'd be fool enough to
+stick around here, do you? Why don't you come with us? You're pretty
+good in a fight. I could use you.
+</sp>
+      <sp spk="LUKE"> (getting angry) Come on! Why don't you take a look around? You
+know what's about to happen, what they're up against. They could use a
+good pilot like you. You're turning your back on them.
+</sp>
+      <sp spk="HAN"> What good's a reward if you ain't around to use it? Besides,
+attacking that battle station ain't my idea of courage. It's more like
+suicide.
+</sp>
+      <sp spk="LUKE"> All right. Well, take care of yourself, Han. I guess that's
+what you're best at, isn't it?
+		</sp>
+      <sd> Luke goes off and Han hesitates, then calls to him.
+</sd>
+      <sp spk="HAN"> Hey, Luke...may the Force be with you!
+		</sp>
+      <sd> Luke turns and sees Han wink at him. Luke lifts his hand in
+	a small wave and then goes off. 
+</sd>
+      <sd> Han turns to Chewie who growls at his captain,
+</sd>
+      <sp spk="HAN"> What're you lookin' at? I know what I'm doing.
+</sp>
+   </scene>
+   <scene n="204">
+      <sd>INTERIOR: MAIN HANGAR DECK -- LUKE'S SHIP.
+	Luke, Leia, and Dodonna meet under a huge space fighter.
+</sd>
+      <sp spk="LEIA"> What's wrong?
+</sp>
+      <sp spk="LUKE"> Oh, it's Han! I don't know, I really thought he'd change his
+mind. 
+</sp>
+      <sp spk="LEIA"> He's got to follow his own path. No one can choose it for him.
+</sp>
+      <sp spk="LUKE"> I only wish Ben were here.
+		</sp>
+      <sd> Leia gives Luke a little kiss, turns, and goes off. As Luke
+	heads for his ship, another pilot rushes up to him and grabs
+	his arm.
+</sd>
+      <sp spk="BIGGS"> Luke! I don't believe it! How'd you get here...are you going
+out with us?!
+</sp>
+      <sp spk="LUKE"> Biggs! Of course, I'll be up there with you! Listen, have I got
+some stories to tell...
+		</sp>
+      <sd> Red Leader, a rugged handsome man in his forties, comes up
+	behind Luke and Biggs. He has the confident smile of a born
+	leader.
+</sd>
+      <sp spk="RED LEADER"> Are you...Luke Skywalker? Have you been checked out on the
+Incom T-sixty-five?
+</sp>
+      <sp spk="BIGGS"> Sir, Luke is the best bushpilot in the outer rim territories.
+		</sp>
+      <sd> Red Leader pats Luke on the back as they stop in front of
+	his fighter.
+</sd>
+      <sp spk="RED LEADER"> I met your father once when I was just a boy, he was a
+great pilot. You'll do all right. If you've got half of your father's
+skill, you'll do better than all right.
+</sp>
+      <sp spk="LUKE"> Thank you, sir. I'll try.
+		</sp>
+      <sd> Red Leader hurries to his own ship.
+</sd>
+      <sp spk="BIGGS"> I've got to get aboard. Listen, you'll tell me your stories
+when we come back. All right?
+</sp>
+      <sp spk="LUKE"> I told you I'd make it someday, Biggs.
+</sp>
+      <sp spk="BIGGS"> (going off) You did, all right. It's going to be like old
+times, Luke. We're a couple of shooting stars that'll never be
+stopped!
+		</sp>
+      <sd> Luke laughs and shakes his head in agreement. He heads for
+	his ship.
+</sd>
+      <sd> As Luke begins to climb up the ladder into his sleek,
+	deadly spaceship, the crew chief, who is working on the craft,
+	points to little Artoo, who is being hoisted into a socket on
+	the back of the fighter.
+</sd>
+      <sp spk="CHIEF"> This R2 unit of your seems a bit beat up. Do you want a new
+one?
+</sp>
+      <sp spk="LUKE"> Not on your life! That little droid and I have been through a
+lot together. (to Artoo) You okay, Artoo?
+		</sp>
+      <sd> The crewmen lower Artoo-Detoo into the craft. Now a part of
+	the exterior shell of the starship, the little droid beeps
+	that he is fine.
+</sd>
+      <sd> Luke climbs up into the cockpit of his fighter and puts an
+	his helmet. Threepio looks on from the floor of the massive
+	hangar as the crewmen secure his little electronic partner
+	into Luke's X-wing. It's an emotional-filled moment as Artoo
+	beeps good-bye.
+</sd>
+      <sp spk="CHIEF"> Okay, easy she goes!
+</sp>
+      <sp spk="THREEPIO"> Hang on tight,Artoo, you've got to come back.
+		</sp>
+      <sd> Artoo beeps in agreement.
+</sd>
+      <sp spk="THREEPIO"> You wouldn't want my life to get boring, would you?
+		</sp>
+      <sd> Artoo whistles his reply.
+</sd>
+      <sd> All final preparations are made for the approaching battle.
+	The hangar is buzzing with the last minute activity as the
+	pilots and crewmen alike make their final adjustments. The hum
+	of activity is occasionally trespassed by the distorted voice
+	of the loudspeaker issuing commands. Coupling hoses are
+	disconnected from the ships as they are fueled. Cockpit
+	shields roll smoothly into place over each pilot. A signalman,
+	holding red guiding lights, directs the ships. Luke, a trace
+	of a smile gracing his lips, peers about through his goggles.
+</sd>
+      <sp spk="BEN'S VOICE"> Luke, the Force will be with you.
+		</sp>
+      <sd> Luke is confused at the voice and taps his headphones.
+</sd>
+   </scene>
+   <scene n="205">
+      <sd>EXTERIOR: MASSASSI OUTPOST -- JUNGLE.
+	All that can be seen of the fortress is a lone guard standing
+	on a small pedestal jutting out above the dense jungle. The
+	muted gruesome crying sounds that naturally permeate this
+	eerie purgatory are overwhelmed by the thundering din of ion
+	rockets as four silver starships catapult from the foliage in
+	a tight formation and disappears into the morning cloud cover.
+</sd>
+   </scene>
+   <scene n="206">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	The princess, Threepio, and a field commander sit quietly
+	before the giant display showing the planet Yavin and its four
+	moons. The red dot that represents the Death Star moves ever
+	closer to the system. A series of green dots appear around the
+	fourth moon. A din of indistinct chatter fills the war room.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE"> Stand-by alert. Death Star approaching.
+Estimated time to firing range, fifteen minutes.
+</sp>
+   </scene>
+   <scene n="207">
+      <sd>EXTERIOR: SPACE.
+	The Death Star slowly moves behind the massive yellow surface
+	of Yavin in the foreground, as many X-wing fighters flying in
+	formation zoom toward us and out of the frame.
+</sd>
+   </scene>
+   <scene n="208">
+      <sd>EXTERIOR: SPACE -- ANOTHER ANGLE.
+	Light from a distant sun creates an eerie atmospheric glow
+	around a huge planet, Yavin. Rebel fighters flying in
+	formation settle ominously in the foreground and very slowly
+	pull away.
+</sd>
+   </scene>
+   <scene n="209">
+      <sd>INTERIOR: RED LEADER STARSHIP -- COCKPIT.
+	Red Leader lowers his visor and adjusts his gun sights,
+	looking to each side at his wing men.
+</sd>
+      <sp spk="RED LEADER"> All wings report in.
+</sp>
+   </scene>
+   <scene n="210">
+      <sd>INTERIOR: ANOTHER COCKPIT.
+	One of the Rebel fighters checks in through his mike.
+</sd>
+      <sp spk="RED TEN"> Red Ten standing by.
+</sp>
+   </scene>
+   <scene n="211">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs checks his fighter's controls, alert and ready for
+	combat.
+</sd>
+      <sp spk="RED SEVEN"> (over Biggs' headset) Red Seven standing by.
+</sp>
+      <sp spk="BIGGS"> Red Three standing by.
+</sp>
+   </scene>
+   <scene n="212">
+      <sd>INTERIOR: PORKINS' COCKPIT.
+</sd>
+      <sp spk="PORKINS"> Red Six standing by.
+</sp>
+      <sp spk="RED NINE"> (over headset) Red Nine standing by.
+</sp>
+   </scene>
+   <scene n="213">
+      <sd>INTERIOR: WEDGE'S FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="WEDGE"> Red Two standing by.
+</sp>
+   </scene>
+   <scene n="214">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED ELEVEN"> (over headset) Red Eleven standing by.
+</sp>
+      <sp spk="LUKE"> Red Five standing by.
+</sp>
+   </scene>
+   <scene n="215">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER
+	Artoo-Detoo, in position outside of the fighter, turns his
+	head from side to side and makes beeping sounds.
+</sd>
+   </scene>
+   <scene n="216">
+      <sd>INTERIOR: RED LEADER'S FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Lock S-foils in attack position.
+</sp>
+   </scene>
+   <scene n="217">
+      <sd>EXTERIOR: SPACE.
+	The group of X-wing fighters move in formation toward the
+	Death Star, unfolding the wings and locking them in the "X"
+	position.
+</sd>
+   </scene>
+   <scene n="218">
+      <sd>INTERIOR: BIGGS' COCKPIT
+</sd>
+      <sp spk="READ LEADER"> (over headset) We're passing through their magnetic
+field.
+</sp>
+   </scene>
+   <scene n="219">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Hold tight!
+</sp>
+   </scene>
+   <scene n="220">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke adjusts his controls as he concentrates on the
+	approaching Death Star. The ship begins to be buffeted
+	slightly.
+</sd>
+      <sp spk="RED LEADER"> (over headset) Switch your deflectors on.
+</sp>
+   </scene>
+   <scene n="221">
+      <sd>INTERIOR: ANOTHER COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> (over headset) Double front!
+</sp>
+   </scene>
+   <scene n="222">
+      <sd>EXTERIOR: SPACE.
+	The fighters, now X-shaped darts, move in formation. The Death
+	Star now appears to be a small moon growing rapidly in size as
+	the Rebel fighters approach. Complex patterns on the metallic
+	surface begin to become visible. A large dish antenna is built
+	into the surface on one side.
+</sd>
+   </scene>
+   <scene n="223">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge is amazed and slightly frightened at the awesome
+	spectacle.
+</sd>
+      <sp spk="WEDGE"> Look at the size of that thing!
+</sp>
+      <sp spk="RED LEADER"> (over headset) Cut the chatter, Red Two.
+</sp>
+   </scene>
+   <scene n="224">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Accelerate to attack speed. This is it, boys!
+</sp>
+   </scene>
+   <scene n="225">
+      <sd>EXTERIOR: SPACE.
+	As the fighters move closer to the Death Star, the awesome
+	size of the gargantuan Imperial fortress is revealed. Half of
+	the deadly space station is in shadow and this area sparkles
+	with thousands of small lights running in thin lines and
+	occasionally grouped in large clusters; somewhat like a city
+	at night as seen from a weather satellite.
+</sd>
+   </scene>
+   <scene n="226">
+      <sd>INTERIOR: GOLD LEADER'S COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> Red Leader, this is Gold Leader.
+</sp>
+      <sp spk="RED LEADER"> (over headset) I copy, Gold Leader.
+</sp>
+      <sp spk="GOLD LEADER"> We're starting for the target shaft now.
+</sp>
+   </scene>
+   <scene n="227">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks around at his wingmen; the Death Star looming
+	in from behind. Two Y-wing fighters bob back and forth in the
+	background. He moves his computer targeting device into
+	position.
+</sd>
+      <sp spk="RED LEADER"> We're in position. I'm going to cut across the axis and
+try and draw their fire.
+</sp>
+   </scene>
+   <scene n="228">
+      <sd>EXTERIOR: SPACE.
+	Two squads of Rebel fighters peel off. The X-wings dive
+	towards the Death Star surface. A thousand lights glow across
+	the dark grey expanse of the huge station.
+</sd>
+   </scene>
+   <scene n="229">
+      <sd>INTERIOR: DEATH STAR.
+	Alarm sirens scream as soldiers scramble to large turbo-
+	powered laser gun emplacements. Electronic drivers rotate the
+	huge guns into position as crew adjust their targeting
+	devices.
+</sd>
+   </scene>
+   <scene n="230">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Laserbolts streak through the star-filled night. The Rebel
+	X-wing fighters move in toward the Imperial base, as the Death
+	Star aims its massive laser guns at the Rebel forces and
+	fires.
+</sd>
+   </scene>
+   <scene n="231">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia listens to the battle over the intercom.
+	Threepio is at her side.
+</sd>
+      <sp spk="WEDGE"> (over war room speaker system) Heavy fire, boss! Twenty-degrees.
+</sp>
+      <sp spk="RED LEADER"> (over speaker) I see it. Stay low.
+</sp>
+   </scene>
+   <scene n="232">
+      <sd>EXTERIOR: SPACE.
+	An X-wing zooms across the surface of the Death Star.
+</sd>
+   </scene>
+   <scene n="233">
+      <sd>INTERIOR: DEATH STAR.
+	Technical crews scurry here and there loading last-minute
+	armaments and unlocking power cables.
+</sd>
+   </scene>
+   <scene n="234">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge maneuvers his fighter toward the menacing Death Star.
+</sd>
+   </scene>
+   <scene n="235">
+      <sd>EXTERIOR: SPACE.
+	X-wings continue in their attack course on the Death Star.
+</sd>
+   </scene>
+   <scene n="236">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke nosedives radically, starting his attack on the monstrous
+	fortress. The Death Star surface streaks past the cockpit
+	window.
+</sd>
+      <sp spk="LUKE"> This is Red Five; I'm going in!
+</sp>
+   </scene>
+   <scene n="237">
+      <sd>EXTERIOR: SPACE.
+	Luke's X-wing races toward the Death Star. Laserbolts streak
+	from Luke's weapons, creating a huge fireball explosion on the
+	dim surface.
+</sd>
+   </scene>
+   <scene n="238">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Terror crosses Luke's face as he realizes he won't be able to
+	pull out in time to avoid the fireball.
+</sd>
+      <sp spk="BIGGS"> (over headset) Luke, pull up!
+</sp>
+   </scene>
+   <scene n="239">
+      <sd>EXTERIOR: SURFACE OF DEATH STAR.
+	Luke's ship emerges from the fireball, with the leading edges
+	of his wings slightly scorched.
+</sd>
+   </scene>
+   <scene n="240">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+</sd>
+      <sp spk="BIGGS"> Are you all right?
+</sp>
+   </scene>
+   <scene n="241">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke adjusts his controls and breathes a sigh of relief. Flak
+	bursts outside the cockpit window.
+</sd>
+      <sp spk="LUKE"> I got a little cooked, but I'm okay.
+</sp>
+   </scene>
+   <scene n="242">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Rebel fighters continue to strafe the Death Star's surface
+	with laserbolts.
+</sd>
+   </scene>
+   <scene n="243">
+      <sd>INTERIOR: DEATH STAR.
+	Walls buckle and cave in. Troops and equipment are blown in
+	all directions. Stormtroopers stagger out of the rubble.
+	Standing in the middle of the chaos, a vision of calm and
+	foreboding, is Darth Vader. One of his Astro-Officers rushes
+	up to him.
+</sd>
+      <sp spk="ASTRO-OFFICER"> We count thirty Rebel ships, Lord Vader. But they're so
+small they're evading our turbo-lasers!
+</sp>
+      <sp spk="VADER"> We'll have to destroy them ship to ship. Get the crews to their
+fighters.
+</sp>
+   </scene>
+   <scene n="244">
+      <sd>INTERIOR: DEATH STAR.
+	Smoke belches from the giant laser guns as they wind up their
+	turbine generators to create sufficient power. The crew rushes
+	about preparing for another blast. Even the troopers head gear
+	is not adequate to protect them from the overwhelming noise of
+	the monstrous weapon. One troopers bangs his helmet with his
+	hand in an attempt to stop the ringing.
+</sd>
+   </scene>
+   <scene n="245">
+      <sd>INTERIOR: READ LEADER'S X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	Red Leader flies through a heavy hail of flak.
+</sd>
+      <sp spk="RED LEADER"> Luke, let me know when you're going in.
+</sp>
+   </scene>
+   <scene n="246">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	The Red Leader's X-wing flies past Luke as he puts his nose
+	down and starts his attack dive.
+</sd>
+      <sp spk="LUKE"> I'm on my way in now...
+</sp>
+      <sp spk="RED LEADER"> Watch yourself! There's a lot of fire coming from the
+right side of that deflection tower.
+</sp>
+      <sp spk="LUKE"> I'm on it.
+</sp>
+   </scene>
+   <scene n="247">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke flings his X-wing into a twisting dive across the horizon
+	and down onto the dim grey surface.
+</sd>
+   </scene>
+   <scene n="248">
+      <sd>EXTERIOR: LUKE'S X-WING TRAVELING.
+	A shot hurls from Luke's guns. Laserbolts streak toward the
+	onrushing Death Star surface. Several small radar emplacements
+	erupt in flame. Laserfire erupts from a protruding tower on
+	the surface.
+</sd>
+   </scene>
+   <scene n="249">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	The blurry Death Star surface races past the cockpit window as
+	a big smile sweeps across Luke's face at the success of his
+	run. Flak thunders on all sides of him.
+</sd>
+   </scene>
+   <scene n="250">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The Death Star superstructure races past Luke as he maneuvers
+	his craft through a wall of laserfire and peels away from the
+	surface towards the heavens.
+</sd>
+   </scene>
+   <scene n="251">
+      <sd>INTERIOR: DEATH STAR.
+	The thunder and smoke of the big guns reverberate throughout
+	the massive structure. Many soldiers rush about in the smoke
+	and chaos, silhouetted by the almost continual flash of
+	explosions.
+</sd>
+   </scene>
+   <scene n="252">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs dives through a forest of radar domes, antennae, and gun
+	towers as he shoots low across the Death Star surface. A dense
+	barrage of laserfire streaks by on all sides.
+</sd>
+   </scene>
+   <scene n="253">
+      <sd>INTERIOR: DEATH STAR.
+	Imperial star pilots dash in unison to a line of small
+	auxiliary hatches that lead to Imperial TIE fighters.
+</sd>
+   </scene>
+   <scene n="254">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia, surrounded by her generals and aides, paces
+	nervously before a lighted computer table. On all sides
+	technicians work in front of many lighted glass walls. Dodonna
+	watches quietly from one corner. One of the officers working
+	over a screen speaks into his headset.
+</sd>
+      <sp spk="CONTROL OFFICER"> Squad leaders, we've picked up a new group of
+signals. Enemy fighters coming your way.
+</sp>
+   </scene>
+   <scene n="255">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT -- TRAVELING.
+	Luke looks around to see if he can spot the approaching
+	Imperial fighters.
+</sd>
+      <sp spk="LUKE"> My scope's negative. I don't see anything.
+</sp>
+   </scene>
+   <scene n="256">
+      <sd>INTERIOR: RED LEADER'S X-WING -- COCKPIT -- TRAVELING.
+	The Death Star's surface sweeps past as Red Leader searches
+	the sky for the Imperial fighters. Flak pounds at his ship.
+</sd>
+      <sp spk="RED LEADER"> Keep up your visual scanning. With all this jamming,
+they'll be on top of you before your scope can pick them up.
+</sp>
+   </scene>
+   <scene n="257">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Silhouetted against the rim lights of the Death Star horizon,
+	four ferocious Imperial TIE ships dive on the Rebel fighters.
+	Two of the TIE fighters peel off and drop out of frame. Pan
+	with the remaining two TIE ships.
+</sd>
+   </scene>
+   <scene n="258">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs panics when he discovers a TIE ship on his tail. The
+	horizon in the background twists around as he peels off,
+	hoping to lose the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="259">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Biggs! You've picked one up...watch it!
+</sp>
+      <sp spk="BIGGS"> I can't see it! Where is he?!
+</sp>
+   </scene>
+   <scene n="260">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs zooms off the surface and into space, closely followed
+	by an Imperial TIE fighter. The TIE ship fires several
+	laserbolts at Biggs, but misses.
+</sd>
+   </scene>
+   <scene n="261">
+      <sd>INTERIOR: BIGGS' COCKPIT -- TRAVELING.
+	Biggs see the TIE ship behind him and swings around, trying to
+	avoid him.
+</sd>
+      <sp spk="BIGGS"> He's on me tight, I can't shake him...I can't shake him.
+</sp>
+   </scene>
+   <scene n="262">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs, flying at high altitude, peels off and dives toward the
+	Death Star surface, but he is unable to lose the TIE fighter,
+	who sticks close to his tail.
+</sd>
+   </scene>
+   <scene n="263">
+      <sd>INTERIOR: X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	Luke is flying upside down. He rotates his ship around to
+	normal attitude as he comes out of his dive.
+</sd>
+      <sp spk="LUKE"> Hang on, Biggs, I'm coming in.
+</sp>
+   </scene>
+   <scene n="264">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Biggs and the tailing TIE ship dive for the surface, now
+	followed by a fast-gaining Luke. After Biggs dives out of
+	sight, Luke chases the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="265">
+      <sd>EXTERIOR: SURFACE AROUND THE DEATH STAR.
+	In the foreground, the Imperial fighter races across the Death
+	Star's surface, closely followed by Luke in the background.
+</sd>
+   </scene>
+   <scene n="266">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT -- TRAVELING.
+	There is a shot from Luke's X-wing of the TIE ship exploding
+	in a mass of flames.
+</sd>
+      <sp spk="LUKE"> Got him!
+</sp>
+   </scene>
+   <scene n="267">
+      <sd>INTERIOR: DEATH STAR.
+	Darth Vader strides purposefully down a Death Star corridor,
+	flanked by Imperial stormtroopers.
+</sd>
+      <sp spk="VADER"> Several fighters have broken off from the main group. Come with
+me!
+</sp>
+   </scene>
+   <scene n="268">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	A concerned Princess Leia, Threepio, Dodonna, and other
+	officers of the Rebellion stand around the huge round readout
+	screen, listening to the ship-to-ship communication on the
+	room's loudspeaker.
+</sd>
+      <sp spk="BIGGS"> (over speaker) Pull in! Luke...pull in!
+</sp>
+      <sp spk="WEDGE"> (over speaker) Watch your back, Luke!
+</sp>
+      <sd>INTERIOR LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="WEDGE"> (over headset) Watch your back! Fighter's above you, coming in!
+</sp>
+   </scene>
+   <scene n="269">
+      <sd>EXTERIOR: SPACE.
+	Luke's ship soars away from the Death Star's surface as he
+	spots the tailing TIE fighter.
+</sd>
+   </scene>
+   <scene n="270">
+      <sd>INTERIOR: TIE FIGHTER'S COCKPIT.
+	The TIE pilot takes aim at Luke's X-wing.
+</sd>
+   </scene>
+   <scene n="271">
+      <sd>EXTERIOR: SPACE.
+	The Imperial TIE fighter pilot scores a hit on Luke's ship.
+	Fire breaks out on the right side of the X-wing.
+</sd>
+   </scene>
+   <scene n="272">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks out of his cockpit at the flames on his ship.
+</sd>
+      <sp spk="LUKE"> I'm hit, but not bad.
+</sp>
+   </scene>
+   <scene n="273">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Smoke pours out from behind Artoo-Detoo.
+</sd>
+      <sp spk="LUKE'S VOICE"> Artoo, see what you can do with it. Hang on back there.</sp>
+      <sd>Green laserfire moves past the beeping little robot as his
+	head turns.
+</sd>
+   </scene>
+   <scene n="274">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke nervously works his controls.
+</sd>
+      <sp spk="RED LEADER"> (over headset) Red Six...
+</sp>
+   </scene>
+   <scene n="275">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	In the war room, Leia stands frozen as she listens and worries
+	about Luke.
+</sd>
+      <sp spk="RED LEADER"> (over speaker) Can you see Red Five?
+</sp>
+      <sp spk="RED TEN"> (over speaker) There's a heavy fire zone on this side. Red
+Five, where are you?
+</sp>
+   </scene>
+   <scene n="276">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke spots the TIE fighter behind him and soars away from the
+	Death Star surface.
+</sd>
+      <sp spk="LUKE"> I can't shake him!
+</sp>
+   </scene>
+   <scene n="277">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship soars closer to the surface of the Death Star, an
+	Imperial TIE fighter closing in on him in hot pursuit.
+</sd>
+   </scene>
+   <scene n="278">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	The Death Star whips below Wedge.
+</sd>
+      <sp spk="WEDGE"> I'm on him, Luke!
+</sp>
+   </scene>
+   <scene n="279">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+</sd>
+      <sp spk="WEDGE"> (over headset) Hold on!
+</sp>
+   </scene>
+   <scene n="280">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Wedge dives across the horizon toward Luke and the TIE
+	fighter.
+</sd>
+   </scene>
+   <scene n="281">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge moves his X-wing in rapidly.
+</sd>
+   </scene>
+   <scene n="282">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke reacts frantically.
+</sd>
+      <sp spk="LUKE"> Blast it! Wedge where are you?
+</sp>
+   </scene>
+   <scene n="283">
+      <sd>INTERIOR: TIE FIGHTER -- COCKPIT.
+	The fighter pilot watches Wedge's X-wing approach. Another
+	X-wing joins him, and both unleash a volley of laserfire on
+	the Imperial fighter.
+</sd>
+   </scene>
+   <scene n="284">
+      <sd>EXTERIOR: SPACE.
+	The TIE fighter explodes, filling the screen with white light.
+	Luke's ship can be seen far in the distance.
+</sd>
+   </scene>
+   <scene n="285">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks about in relief.
+</sd>
+      <sp spk="LUKE"> Thanks, Wedge.
+</sp>
+   </scene>
+   <scene n="286">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia, Threepio, Dodonna and other Rebel officers are listening
+	to the Rebel Fighter's radio transmissions over the war room
+	intercom.
+</sd>
+      <sp spk="BIGGS"> (over speaker) Good shooting, Wedge!
+</sp>
+      <sp spk="GOLD LEADER"> (over speaker) Red Leader...
+</sp>
+   </scene>
+   <scene n="287">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader peels off and starts toward the long trenches at
+	the Death Star surface pole.
+</sd>
+      <sp spk="GOLD LEADER"> This is Gold Leader. We're starting out attack run.
+</sp>
+   </scene>
+   <scene n="288">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Y-wing fighters of the Gold group dive out of the stars
+	toward the Death Star surface.
+</sd>
+   </scene>
+   <scene n="289">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others are grouped around the screen, as
+	technicians move about attending to their duties.
+</sd>
+      <sp spk="RED LEADER"> (over speaker) I copy, Gold Leader. Move into position.
+</sp>
+   </scene>
+   <scene n="290">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Imperial TIE ships in precise formation dive toward the
+	Death Star surface.
+</sd>
+   </scene>
+   <scene n="291">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Darth Vader calmly adjusts his control stick as the stars whip
+	past in the window above his head.
+</sd>
+      <sp spk="VADER"> Stay in attack formation!
+</sp>
+   </scene>
+   <scene n="292">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Technicians are seated at the computer readout table.
+</sd>
+      <sp spk="GOLD LEADER"> (over speaker) The exhaust post is...
+</sp>
+   </scene>
+   <scene n="293">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> ...marked and locked in!
+</sp>
+   </scene>
+   <scene n="294">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Gold Leader approaches the surface and pulls out to skim the
+	surface of the huge station. The ship moves into a deep
+	trench, firing laserbolts. The surface streaks past as
+	laserfire is returned by the Death Star.
+</sd>
+   </scene>
+   <scene n="295">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT -- TRAVELING.
+	Gold Five is a pilot in his early fifties with a very battered
+	helmet that looks like it's been through many battles. He
+	looks around to see if enemy ships are near. His fighter is
+	buffeted by Imperial flak.
+</sd>
+   </scene>
+   <scene n="296">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader races down the enormous trench that leads to the
+	exhaust port. Laserbolts blast toward him in increasing
+	numbers, occasionally exploding near the ship causing it to
+	bounce about.
+</sd>
+      <sp spk="GOLD LEADER"> Switch power to front deflector screens.
+</sp>
+   </scene>
+   <scene n="297">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three Y-wing skim the Death Star surface deep in the trench,
+	as laserbolts streak past on all sides.
+</sd>
+   </scene>
+   <scene n="298">
+      <sd>EXTERIOR: DEATH STAR SURFACE -- GUN EMPLACEMENTS.
+	An exterior surface gun blazes away at the oncoming Rebel
+	fighters.
+</sd>
+   </scene>
+   <scene n="299">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> How many guns do you think, Gold Five.
+</sp>
+   </scene>
+   <scene n="300">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+</sd>
+      <sp spk="GOLD FIVE"> (over speaker) I'd say about twenty guns. Some on the
+surface, some on the towers.
+		</sp>
+      <sd> Leia, Threepio, and the technicians view the projected
+	target screen, as red and blue target lights glow. The red
+	target near the center blinks on and off.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE"> (over speaker) Death Star will be in range in
+five minutes. 
+</sp>
+   </scene>
+   <scene n="301">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+		 The three Y-wing fighters race toward camera and zoom
+	overhead through a hail of laserfire.
+</sd>
+   </scene>
+   <scene n="302">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+		 Gold Leader pulls his computer targeting device down in
+	front of his eye. Laserbolts continue to batter the Rebel
+	craft.
+</sd>
+      <sp spk="GOLD LEADER"> Switching to targeting computer.
+</sp>
+   </scene>
+   <scene n="303">
+      <sd>INTERIOR: GOLD TWO'S Y-WING -- COCKPIT.
+		 Gold Two, a younger pilot about Luke's age, pulls down his
+	targeting eye viewer and adjusts it. His ship shudders under
+	intense laser barrage.
+</sd>
+      <sp spk="GOLD TWO"> Computer's locked. Getting a signal.
+		</sp>
+      <sd> As the fighters begin to approach the target area, suddenly
+	all the laserfire stops. An eerie clam clings over the trench
+	as the surface whips past in a blur.
+</sd>
+      <sp spk="GOLD TWO"> The guns...they've stopped!
+</sp>
+   </scene>
+   <scene n="304">
+      <sd>EXTERIOR: GOLD FIVE'S COCKPIT.
+	Gold Five looks behind him.
+</sd>
+      <sp spk="GOLD FIVE"> Stabilize your read deflectors. Watch for enemy fighters.
+</sp>
+   </scene>
+   <scene n="305">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD LEADER"> They've coming in! Three marks at two ten.
+</sp>
+   </scene>
+   <scene n="306">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three Imperial TIE ships, Darth Vader in the center flanked by
+	two wingmen, dive in precise formation almost vertically
+	toward the Death Star surface.
+</sd>
+   </scene>
+   <scene n="307">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Darth Vader calmly adjusts his control stick as the stars zoom
+	by.
+</sd>
+      <sp spk="VADER"> I'll take them myself! Cover me!
+</sp>
+      <sp spk="WINGMAN'S VOICE"> (over speaker) Yes, sir.
+</sp>
+   </scene>
+   <scene n="308">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Three TIE fighters zoom across the surface of the Death Star.
+</sd>
+   </scene>
+   <scene n="309">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader lines up Gold Two in his targeting computer. Vader's
+	hands grip the control stick as he presses the button.
+</sd>
+   </scene>
+   <scene n="310">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT
+	The cockpit explodes around Gold Two. His head falls forward.
+</sd>
+   </scene>
+   <scene n="311">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	As Gold Two's ship explodes, debris is flung out into space.
+</sd>
+   </scene>
+   <scene n="312">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader looks over his shoulder at the scene.
+</sd>
+   </scene>
+   <scene n="313">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The three TIE fighters race along in the trench in a tight
+	formation.
+</sd>
+   </scene>
+   <scene n="314">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader panics.
+</sd>
+      <sp spk="GOLD LEADER"> (into mike) I can't maneuver!
+</sp>
+   </scene>
+   <scene n="315">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	Gold Five, the old veteran, trys to calm Gold Leader.
+</sd>
+      <sp spk="GOLD FIVE"> Stay on target.
+</sp>
+   </scene>
+   <scene n="316">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	The Death Star races by outside the cockpit window as he
+	adjusts his targeting device.
+</sd>
+      <sp spk="GOLD LEADER"> We're too close.
+</sp>
+   </scene>
+   <scene n="317">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	The older pilot remains calm.
+</sd>
+      <sp spk="GOLD FIVE"> Stay on target!
+</sp>
+   </scene>
+   <scene n="318">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Now he's really panicked.
+</sd>
+      <sp spk="GOLD LEADER"> Loosen up!
+</sp>
+   </scene>
+   <scene n="319">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader calmly adjusts his targeting computer and pushes the
+	fire button.
+</sd>
+   </scene>
+   <scene n="320">
+      <sd>INTERIOR: GOLD LEADER'S Y-WING -- COCKPIT.
+	Gold Leader's ship is hit by Vader's laser.
+</sd>
+   </scene>
+   <scene n="321">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Gold Leader explodes in a ball of flames, throwing debris in
+	all directions.
+</sd>
+   </scene>
+   <scene n="322">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+	Gold Five moves in on the exhaust port.
+</sd>
+      <sp spk="GOLD FIVE"> Gold Five to Red Leader...
+</sp>
+   </scene>
+   <scene n="323">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks over his shoulder at the action outside of his
+	cockpit.
+</sd>
+      <sp spk="GOLD FIVE"> (over headset) Lost Tiree, lost Dutch.
+</sp>
+   </scene>
+   <scene n="324">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> I copy, Gold Five.
+</sp>
+   </scene>
+   <scene n="325">
+      <sd>INTERIOR: GOLD FIVE'S Y-WING -- COCKPIT.
+</sd>
+      <sp spk="GOLD FIVE"> They came from behind....
+</sp>
+   </scene>
+   <scene n="326">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	One of the engines explodes on Gold Five's Y-wing fighter,
+	blazing out of control. He dives past the horizon toward the
+	Death Star's surface, passing a TIE fighter during his
+	descent. Gold Five, a veteran of countless campaigns, spins
+	toward his death.
+</sd>
+   </scene>
+   <scene n="327">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks nervously about him at the explosive battle.
+</sd>
+   </scene>
+   <scene n="328">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grant Moff Tarkin and a Chief Officer stand in the Death
+	Star's control room.
+</sd>
+      <sp spk="OFFICER"> We've analyzed their attack, sir, and there is a danger.
+Should I have your ship standing by?
+</sp>
+      <sp spk="TARKIN"> Evacuate? In out moment of triumph? I think you overestimate
+their chances!
+		</sp>
+      <sd> Tarkin turns to the computer readout screen. Flames move
+	around the green disk at the center of the screen, as numbers
+	read across the bottom.
+</sd>
+      <sp spk="VOICE"> (over speaker) Rebel base, three minutes and closing.
+</sp>
+   </scene>
+   <scene n="329">
+      <sd>INTERIOR: READ LEADER'S COCKPIT.
+	Red Leader looks over at his wingmen.
+</sd>
+      <sp spk="RED LEADER"> Red Group, this is Red Leader.
+</sp>
+   </scene>
+   <scene n="330">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Dodonna moves to the intercom as he fiddles with the computer
+	keys.
+</sd>
+      <sp spk="RED LEADER"> (over speaker) Rendezvous at mark six point one.
+</sp>
+      <sp spk="WEDGE"> (over speaker) This is Red Two. Flying toward you.
+</sp>
+      <sp spk="BIGGS"> (over speaker) Red Three, standing by.
+</sp>
+   </scene>
+   <scene n="331">
+      <sd>INTERIOR: RED LEADER'S COCKPIT:
+</sd>
+      <sp spk="DODONNA"> (over headset) Red Leader, this is Base One. Keep half your
+group out of range for the next run.
+</sp>
+   </scene>
+   <scene n="332">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="RED LEADER'S VOICE"> (over headset) Copy, Base One. Luke, take Red Two
+and Three. Hold up here and wait for my signal...to start your run.
+		</sp>
+      <sd> Luke nods his head.
+</sd>
+   </scene>
+   <scene n="333">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The X-wing fighters of Luke, Biggs, and Wedge fly in formation
+	high above the Death Star's surface.
+</sd>
+   </scene>
+   <scene n="334">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke peers out from his cockpit.
+</sd>
+   </scene>
+   <scene n="335">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Two X-wings move across the surface of the Death Star. Red
+	Leader's X-wing drops down to the surface leading to the
+	exhaust port.
+</sd>
+   </scene>
+   <scene n="336">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks around to watch for the TIE fighters. He
+	begins to perspire.
+</sd>
+      <sp spk="RED LEADER"> This is it!
+</sp>
+   </scene>
+   <scene n="337">
+      <sd>EXTERIOR: SPACE.
+	Red Leader roams down the trench of the Death Star as lasers
+	streak across the black heavens.
+</sd>
+   </scene>
+   <scene n="338">
+      <sd>EXTERIOR: DEATH STAR SURFACE -- GUN EMPLACEMENTS.
+	A huge remote-control laser cannon fires at the approaching
+	Rebel fighters.
+</sd>
+   </scene>
+   <scene n="339">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The Rebel fighters evade the Imperial laser blasts.
+</sd>
+   </scene>
+   <scene n="340">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten looks around for the Imperial fighters.
+</sd>
+      <sp spk="RED TEN"> We should be able to see it by now.
+</sp>
+   </scene>
+   <scene n="341">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	From the cockpits of the Rebel pilots, the surface of the
+	Death Star streaks by, with Imperial laserfire shooting toward
+	them.
+</sd>
+   </scene>
+   <scene n="342">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Keep your eyes open for those fighters!
+</sp>
+   </scene>
+   <scene n="343">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+</sd>
+      <sp spk="RED TEN"> There's too much interference!
+</sp>
+   </scene>
+   <scene n="344">
+      <sd>EXTERIOR: SPACE -- DEATH STAR TRENCH.
+	Three X-wing fighters move in formation down the Death Star
+	trench.
+</sd>
+      <sp spk="RED TEN'S VOICE"> Red Five, can you see them from where you are?
+</sp>
+   </scene>
+   <scene n="345">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks down at the Death Star surface below.
+</sd>
+      <sp spk="LUKE"> No sign of any...wait!
+</sp>
+   </scene>
+   <scene n="346">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten looks up and sees the Imperial fighters.
+</sd>
+      <sp spk="LUKE"> (over headset) Coming in point three five.
+</sp>
+      <sp spk="RED TEN"> I see them.
+</sp>
+   </scene>
+   <scene n="347">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three TIE fighters, Vader flanked by two wingmen, dive in a
+	tight formation. The sun reflects off their dominate solar
+	fins as they loop toward the Death Star's surface.
+</sd>
+   </scene>
+   <scene n="348">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader pulls his targeting device in front of his eyes and
+	makes several adjustments.
+</sd>
+      <sp spk="RED LEADER"> I'm in range.
+</sp>
+   </scene>
+   <scene n="349">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Red Leader's X-wing moves up the Death Star trench.
+</sd>
+   </scene>
+   <scene n="350">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> Target's coming up!
+		</sp>
+      <sd> Red Leader looks at his computer target readout screen. He
+	then looks into his targeting device.
+</sd>
+      <sp spk="RED LEADER"> Just hold them off for a few seconds.
+</sp>
+   </scene>
+   <scene n="351">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control lever and dives on the X-wing
+	fighters.
+</sd>
+      <sp spk="VADER"> Close up formation.
+</sp>
+   </scene>
+   <scene n="352">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	The three TIE fighters move in formation across the Death Star
+	surface.
+</sd>
+   </scene>
+   <scene n="353">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+		 Red Leader lines up his target on the targeting device
+	cross hairs.
+</sd>
+   </scene>
+   <scene n="354">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader and his wingmen zoom down the trench.
+</sd>
+   </scene>
+   <scene n="355">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader rapidly approaches the two X-wings of Red Ten and Red
+	Twelve. Vader's laser cannon flashes below the view of the
+	front porthole. the X-wings show in the center of Vader's
+	computer screen.
+</sd>
+   </scene>
+   <scene n="356">
+      <sd>EXTERIOR: SPACE.
+	Red Twelve's X-wing fighter is hit by Vader's laserfire, and
+	it explodes into flames against the trench.
+</sd>
+   </scene>
+   <scene n="357">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten works at his controls furiously, trying to avoid
+	Vader's fighter behind him.
+</sd>
+      <sp spk="RED TEN"> You'd better let her loose.
+</sp>
+   </scene>
+   <scene n="358">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader is concentrating on his targeting device.
+</sd>
+      <sp spk="RED LEADER"> Almost there!
+</sp>
+   </scene>
+   <scene n="359">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Red Ten panics.
+</sd>
+      <sp spk="RED TEN"> I can't hold them!
+</sp>
+   </scene>
+   <scene n="360">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader and his wingmen whip through the trench in pursuit of
+	the Rebel fighters.
+</sd>
+   </scene>
+   <scene n="361">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader cooly pushes the fire button on his control stick.
+</sd>
+   </scene>
+   <scene n="362">
+      <sd>INTERIOR: RED TEN'S COCKPIT.
+	Darth Vader's well-aimed laserfire proves to be unavoidable,
+	and strikes Red Ten's ship. Red Ten screams in anguish and
+	pain.
+</sd>
+   </scene>
+   <scene n="363">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.  
+	Red Ten's ship explodes and bursts into flames.
+</sd>
+   </scene>
+   <scene n="364">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Grimly, Red Leader takes careful aim and watches his computer
+	targeting device, which shows the target lined up in the cross
+	hairs, and fires.
+</sd>
+   </scene>
+   <scene n="365">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="RED LEADER"> It's away!
+</sp>
+   </scene>
+   <scene n="366">
+      <sd>INTERIOR: DEATH STAR.   
+	An armed Imperial stormtrooper is knocked to the floor from
+	the attack explosion. Other troopers scurrying about the
+	corridors are knocked against the wall and lose their balance.
+</sd>
+   </scene>
+   <scene n="367">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare at the computer screen.
+</sd>
+      <sp spk="RED NINE'S VOICE"> (over speaker) It's a hit!
+</sp>
+      <sp spk="RED LEADER"> (over speaker) Negative.
+</sp>
+   </scene>
+   <scene n="368">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader looks back at the receding Death Star. Tiny
+	explosions are visible in the distance.
+</sd>
+      <sp spk="RED LEADER"> Negative! It didn't go in. It just impacted on the
+surface.
+</sp>
+   </scene>
+   <scene n="369">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR -- TIE FIGHTER.
+	Darth Vader peels off in pursuit as Red Leader's X-wing passes
+	the Death Star horizon.
+</sd>
+   </scene>
+   <scene n="370">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader swings his ship around for the next kill.
+</sd>
+   </scene>
+   <scene n="371">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+</sd>
+      <sp spk="LUKE"> (over headset) Red Leader, we're right above you. Turn to
+point...
+</sp>
+   </scene>
+   <scene n="372">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke tries to spot Red Leader. He looks down at the Death Star
+	surface.
+</sd>
+      <sp spk="LUKE"> ...oh-five; we'll cover for you.
+</sp>
+      <sp spk="RED LEADER"> (over headset) Stay there...
+</sp>
+   </scene>
+   <scene n="373">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	A wary Red Leader looks about nervously.
+</sd>
+      <sp spk="RED LEADER"> ...I just lost my starboard engine.
+</sp>
+   </scene>
+   <scene n="374">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks excitedly toward Red Leader's X-wing.
+</sd>
+      <sp spk="RED LEADER"> (over headset) Get set to make your attack run.
+</sp>
+   </scene>
+   <scene n="375">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's gloved hands make contact with the control sticks, and
+	he presses their firing buttons.
+</sd>
+   </scene>
+   <scene n="376">
+      <sd>INTERIOR: RED LEADER'S COCKPIT.
+	Red Leader fights to gain control of his ship.
+</sd>
+   </scene>
+   <scene n="377">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Laserbolts are flung from Vader's TIE fighter, connecting with
+	Red Leader's Rebel X-wing fighter. Red Leader buys it,
+	creating a tremendous explosion far below. He screams and is
+	destroyed.
+</sd>
+   </scene>
+   <scene n="378">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks out the window of his X-wing at the explosion far
+	below. For the first time, he feels the helplessness of his
+	situation.
+</sd>
+   </scene>
+   <scene n="379">
+      <sd>INTERIOR: DEATH STAR.
+	Grand Moff Tarkin casts a sinister eye at the computer screen.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, one minute and closing.
+</sp>
+   </scene>
+   <scene n="380">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Dodonna and Princess Leia, with Threepio beside them, listen
+	intently to the talk between the pilots. The room is grim
+	after Red Leader's death. Princess Leia nervously paces the
+	room.
+</sd>
+      <sp spk="LUKE"> (over speaker) Biggs, Wedge, let's close it up. We're going in.
+We're going in full throttle.
+</sp>
+   </scene>
+   <scene n="381">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	The horizon twists as Wedge begins to pull out.
+</sd>
+      <sp spk="WEDGE"> Right with you, boss.
+</sp>
+   </scene>
+   <scene n="382">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.  
+	The two X-wings peel off against a background of stars and
+	dive toward the Death Star.
+</sd>
+   </scene>
+   <scene n="383">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+</sd>
+      <sp spk="BIGGS"> Luke, at that speed will you be able to pull out in time?
+</sp>
+   </scene>
+   <scene n="384">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> It'll be just like Beggar's Canyon back home.
+</sp>
+   </scene>
+   <scene n="385">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The three X-wings move in, unleashing a barrage of laserfire.
+	Laserbolts are returned from the Death Star.
+</sd>
+   </scene>
+   <scene n="386">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Luke's lifelong friend struggles with his controls.
+</sd>
+      <sp spk="BIGGS"> We'll stay back far enough to cover you.
+</sp>
+   </scene>
+   <scene n="387">
+      <sd>INTERIOR: LUKE'S COCKPIT.
+	Flak and laserbolts flash outside Luke's cockpit window.
+</sd>
+      <sp spk="WEDGE"> (over headset) My scope shows the tower, but I can't see the
+exhaust port! Are you sure the computer can hit it?
+</sp>
+   </scene>
+   <scene n="388">
+      <sd>EXTERIOR: DEATH STAR -- GUN EMPLACEMENTS.
+	The Death Star laser cannon slowly rotates as it shoots
+	laserbolts.
+</sd>
+   </scene>
+   <scene n="389">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks around for the Imperial TIE fighters. He thinks for
+	a moment and then moves his targeting device into position.
+</sd>
+      <sp spk="LUKE"> Watch yourself! Increase speed full throttle!
+</sp>
+   </scene>
+   <scene n="390">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge looks excitedly about for any sign of the TIE fighters.
+</sd>
+      <sp spk="WEDGE"> What about the tower?
+</sp>
+   </scene>
+   <scene n="391">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> You worry about those fighters! I'll worry about the tower!
+</sp>
+   </scene>
+   <scene n="392">
+      <sd>EXTERIOR: DEATH STAR SURFACE.
+	Luke's X-wing streaks through the trench, firing lasers.
+</sd>
+   </scene>
+   <scene n="393">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke breaks into a nervous sweat as the laserfire is returned,
+	knicking one of his wings close to the engine.
+</sd>
+      <sp spk="LUKE"> (to Artoo) Artoo...that, that stabilizer's broken loose again!
+See if you can't lock it down!
+</sp>
+   </scene>
+   <scene n="394">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Artoo works to repair the damages. The canyon wall rushes by
+	in the background, making his delicate task seem even more
+	precarious.
+</sd>
+   </scene>
+   <scene n="395">
+      <sd>EXTERIOR: DEATH STAR.
+	Two laser cannons are firing on the Rebel fighters.
+</sd>
+   </scene>
+   <scene n="396">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+	Wedge looks up and sees the TIE ships.
+</sd>
+   </scene>
+   <scene n="397">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke's targeting device marks off the distance to the target.
+</sd>
+   </scene>
+   <scene n="398">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader and his wingmen zoom closer.
+</sd>
+   </scene>
+   <scene n="399">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his controls and fires laserbolts at two X-wings
+	flying down the trench. He scores a direct hit on Wedge.
+</sd>
+   </scene>
+   <scene n="400">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others are grouped around the computer board.
+</sd>
+      <sp spk="WEDGE"> (over speaker) I'm hit! I can't stay with you.
+</sp>
+      <sp spk="LUKE"> (over speaker) Get clear, Wedge.
+</sp>
+   </scene>
+   <scene n="401">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+</sd>
+      <sp spk="LUKE"> You can't do any more good back there!
+</sp>
+   </scene>
+   <scene n="402">
+      <sd>INTERIOR: WEDGE'S COCKPIT.
+</sd>
+      <sp spk="WEDGE"> Sorry!
+</sp>
+   </scene>
+   <scene n="403">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Wedge pulls his crippled X-wing back away from the battle.
+</sd>
+   </scene>
+   <scene n="404">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader watches the escape but issues a command to his wingmen.
+</sd>
+      <sp spk="VADER"> Let him go! Stay on the leader!
+</sp>
+   </scene>
+   <scene n="405">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Luke's X-wing speeds down the trench; the three TIE fighters,
+	still in perfect unbroken formation, tail close behind.
+</sd>
+   </scene>
+   <scene n="406">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs looks around at the TIE fighters. He is worried.
+</sd>
+      <sp spk="BIGGS"> Hurry, Luke, they're coming in much faster this time. I can't
+hold them!
+</sp>
+   </scene>
+   <scene n="407">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The three TIE fighters move ever closer, closing in on Luke
+	and Biggs.
+</sd>
+   </scene>
+   <scene n="408">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks back anxiously at little Artoo.
+</sd>
+      <sp spk="LUKE"> Artoo, try and increase the power!
+</sp>
+   </scene>
+   <scene n="409">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Ignoring the bumpy ride, flak, and lasers, a beeping
+	Artoo-Detoo struggles to increase the power, his dome turning
+	from side to side.
+</sd>
+   </scene>
+   <scene n="410">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Stealthily, the TIE formation creeps closer.
+</sd>
+   </scene>
+   <scene n="411">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control stick.
+</sd>
+   </scene>
+   <scene n="412">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs looks around at the TIE fighters.
+</sd>
+   </scene>
+   <scene n="413">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER.
+	Luke looks into his targeting device. He moves it away for a
+	moment and ponders its use. He looks back into the computer
+	targeter.
+</sd>
+      <sp spk="BIGGS"> (over headset) Hurry up, Luke!
+</sp>
+   </scene>
+   <scene n="414">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader and his wingmen race through the Death Star trench.
+	Biggs moves in to cover for Luke, but Vader gains on him.
+</sd>
+   </scene>
+   <scene n="415">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs sees the TIE fighter aiming at him.
+</sd>
+      <sp spk="BIGGS"> Wait!
+</sp>
+   </scene>
+   <scene n="416">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader squeezes the fire button on his controls.
+</sd>
+   </scene>
+   <scene n="417">
+      <sd>INTERIOR: BIGGS' COCKPIT.
+	Biggs' cockpit explodes around him, lighting him in red.
+</sd>
+   </scene>
+   <scene n="418">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Biggs' ship bursts into a million flaming bits and scatters
+	across the surface.
+</sd>
+   </scene>
+   <scene n="419">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare at the computer board.
+</sd>
+   </scene>
+   <scene n="420">
+      <sd>INTERIOR: LUKE'S X-WING COCKPIT.
+	Luke is stunned by Biggs' death. His eyes are watering, but
+	his anger is also growing.
+</sd>
+   </scene>
+   <scene n="421">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Grand Moff Tarkin watches the projected target screen with
+	satisfaction.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, thirty seconds and closing.
+</sp>
+   </scene>
+   <scene n="422">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader takes aim on Luke and talks to the wingmen.
+</sd>
+      <sp spk="VADER"> I'm on the leader.
+</sp>
+   </scene>
+   <scene n="423">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR -- LUKE'S SHIP.
+	Luke's ship streaks through the trench of the Death Star.
+</sd>
+   </scene>
+   <scene n="424">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Princess Leia returns her general's worried and doubtful
+	glances with solid, grim determination. Threepio seems nervous.
+</sd>
+      <sp spk="THREEPIO"> Hang on, Artoo!
+</sp>
+   </scene>
+   <scene n="425">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke concentrates on his targeting device.
+</sd>
+   </scene>
+   <scene n="426">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Three TIE fighters charge away down the trench toward Luke.
+</sd>
+   </scene>
+   <scene n="427">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's finger's curls around the control stick.
+</sd>
+   </scene>
+   <scene n="428">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke adjusts the lens of his targeting device.
+</sd>
+   </scene>
+   <scene n="429">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship charges down the trench.
+</sd>
+   </scene>
+   <scene n="430">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke lines up the yellow cross-hair lines of the targeting
+	device's screen. He looks into the targeting device, then
+	starts at a voice he hears.
+</sd>
+      <sp spk="BEN'S VOICE"> Use the Force, Luke.
+</sp>
+   </scene>
+   <scene n="431">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The Death Star trench zooms by.
+</sd>
+   </scene>
+   <scene n="432">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks up, then starts to look back into the targeting
+	device. He has second thoughts.
+</sd>
+      <sp spk="BEN'S VOICE"> Let go, Luke.
+		</sp>
+      <sd> A grim determination sweeps across Luke's face as he closes
+	his eyes and starts to mumble Ben's training to himself.
+</sd>
+   </scene>
+   <scene n="433">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's fighter streaks through the trench.
+</sd>
+   </scene>
+   <scene n="434">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+</sd>
+      <sp spk="VADER"> The Force is strong with this one!
+</sp>
+   </scene>
+   <scene n="435">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Vader follows Luke's X-wing down the trench.
+</sd>
+   </scene>
+   <scene n="436">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks to the targeting device, then away as he hears
+	Ben's voice.
+</sd>
+      <sp spk="BEN'S VOICE"> Luke, trust me.
+		</sp>
+      <sd> Luke's hand reaches for the control panel and presses the
+	button. The targeting device moves away.
+</sd>
+   </scene>
+   <scene n="437">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stand watching the projected screen.
+</sd>
+      <sp spk="BASE VOICE"> (over speaker) His computer's off. Luke, you switched off
+your targeting computer. What's wrong?
+</sp>
+      <sp spk="LUKE"> (over speaker) Nothing. I'm all right.
+</sp>
+   </scene>
+   <scene n="438">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship streaks ever close to the exhaust port.
+</sd>
+   </scene>
+   <scene n="439">
+      <sd>INTERIOR: LUKE'S X-WING -- COCKPIT.
+	Luke looks at the Death Star surface streaking by.
+</sd>
+   </scene>
+   <scene n="440">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Artoo-Detoo turns his head from side to side, beeping in
+	anticipation.
+</sd>
+   </scene>
+   <scene n="441">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters, manned by Vader and his two wingmen,
+	follow Luke's X-wing down the trench.
+</sd>
+   </scene>
+   <scene n="442">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader maneuvers his controls as he looks at his doomed target.
+	He presses the fire buttons on his control sticks. Laserfire
+	shoots toward Luke's X-wing fighter.
+</sd>
+   </scene>
+   <scene n="443">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	A large burst of Vader's laserfire engulfs Artoo. The arms go
+	limp on the smoking little droid as he makes a high-pitched
+	sound.
+</sd>
+   </scene>
+   <scene n="444">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks frantically back over his shoulder at Artoo.
+</sd>
+   </scene>
+   <scene n="445">
+      <sd>EXTERIOR: LUKE'S X-WING FIGHTER.
+	Smoke billows out around little Artoo and sparks begin to fly.
+</sd>
+      <sp spk="LUKE"> I've lost Artoo!
+		</sp>
+      <sd> Artoo's beeping sounds die out.
+</sd>
+   </scene>
+   <scene n="446">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others stare intently at the projected screen,
+	while Threepio watches the Princess. Lights representing the
+	Death Star and targets glow brightly.
+</sd>
+      <sp spk="MASSASSI INTERCOM VOICE"> The Death Star has cleared the planet. The
+Death Star has cleared the planet.
+</sp>
+   </scene>
+   <scene n="447">
+      <sd>INTERIOR: DEATH STAR -- CONTROL ROOM.
+	Tarkin glares at the projected target screen.
+</sd>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Rebel base, in range.
+</sp>
+      <sp spk="TARKIN"> You may fire when ready.
+</sp>
+      <sp spk="DEATH STAR INTERCOM VOICE"> Commence primary ignition.
+		</sp>
+      <sd> An officer reaches up and pushes buttons on the control
+	panel, as green lighted buttons turn to red.
+</sd>
+   </scene>
+   <scene n="448">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters zoom down the Death Star trench in
+	pursuit of Luke, never breaking formation.
+</sd>
+   </scene>
+   <scene n="449">
+      <sd>INTERIOR: LUKE'S COCKPIT.
+	Luke looks anxiously at the exhaust port.
+</sd>
+   </scene>
+   <scene n="450">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader adjusts his control sticks, checking his projected
+	targeting screen.
+</sd>
+   </scene>
+   <scene n="451">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's ship barrels down the trench.
+</sd>
+   </scene>
+   <scene n="452">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader's targeting computer swings around into position. Vader
+	takes careful aim on Luke's X-wing fighter.
+</sd>
+      <sp spk="VADER"> I have you now.
+		</sp>
+      <sd> He pushes the fire buttons.
+</sd>
+   </scene>
+   <scene n="453">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	The three TIE fighters move in on Luke. As Vader's center
+	fighter unleashes a volley of laserfire, one of the TIE ships
+	at his side is hit and explodes into flame. The two remaining
+	ships continue to move in.
+</sd>
+   </scene>
+   <scene n="454">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks about, wondering whose laserfire destroyed Vader's
+	wingman.
+</sd>
+   </scene>
+   <scene n="455">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader is taken by surprise, and looks out from his cockpit.
+</sd>
+      <sp spk="VADER"> What?
+</sp>
+   </scene>
+   <scene n="456">
+      <sd>INTERIOR: DARTH VADER'S WINGMAN -- COCKPIT.
+	Vader's wingman searches around him trying to locate the
+	unknown attacker.
+</sd>
+   </scene>
+   <scene n="457">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Han and Chewbacca grin from ear to ear.
+</sd>
+      <sp spk="HAN"> (yelling) Yahoo!
+</sp>
+   </scene>
+   <scene n="458">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The Millennium Falcon heads right at the two TIE fighters.
+	It's a collision course.
+</sd>
+   </scene>
+   <scene n="459">
+      <sd>INTERIOR: WINGMAN'S COCKPIT.
+	The wingman spots the pirateship coming at him and warns the
+	Dark Lord.
+</sd>
+      <sp spk="WINGMAN"> Look out!
+</sp>
+   </scene>
+   <scene n="460">
+      <sd>EXTERIOR: DEATH STAR TRENCH.
+	Vader's wingman panics at the sight of the oncoming pirate
+	starship and veers radically to one side, colliding with
+	Vader's TIE fighter in the process. Vader's wingman crashes
+	into the side wall of the trench and explodes. Vader's damaged
+	ship spins out of the trench with a damaged wing.
+</sd>
+   </scene>
+   <scene n="461">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Vader's ship spins out of control with a bent solar fin,
+	heading for deep space.
+</sd>
+   </scene>
+   <scene n="462">
+      <sd>INTERIOR: DARTH VADER'S COCKPIT.
+	Vader turns round and round in circles as his ship spins
+	into space.
+</sd>
+   </scene>
+   <scene n="463">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Solo's ship moves in toward the Death Star trench.
+</sd>
+   </scene>
+   <scene n="464">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+	Solo, smiling, speaks to Luke over his headset mike.
+</sd>
+      <sp spk="HAN"> (into mike) You're all clear, kid.
+</sp>
+   </scene>
+   <scene n="465">
+      <sd>INTERIOR: MASSASSI OUTPOST -- WAR ROOM.
+	Leia and the others listen to Solo's transmission.
+</sd>
+      <sp spk="HAN"> (over speaker) Now let's blow this thing and go home!
+</sp>
+   </scene>
+   <scene n="466">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke looks up and smiles. He concentrates on the exhaust port,
+	then fires his laser torpedoes.
+</sd>
+   </scene>
+   <scene n="467">
+      <sd>EXTERIOR: SURFACE OF THE DEATH STAR.
+	Luke's torpedoes shoot toward the port and seems to simply
+	disappear into the surface and not explode. But the shots do
+	find their mark and have gone into the exhaust port and are
+	heading for the main reactor.
+</sd>
+   </scene>
+   <scene n="468">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke throws his head back in relief.
+</sd>
+   </scene>
+   <scene n="469">
+      <sd>INTERIOR: DEATH STAR.
+	An Imperial soldier runs to the control panel board and pulls
+	the attack lever as the board behind him lights up.
+</sd>
+      <sp spk="INTERCOM VOICE"> Stand by to fire at Rebel base.
+</sp>
+   </scene>
+   <scene n="470">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	Two X-wings, a Y-wing, and the pirateship race toward Yavin in
+	the distance.
+</sd>
+   </scene>
+   <scene n="471">
+      <sd>INTERIOR: DEATH STAR.
+	Several Imperial soldiers, flanking a pensive Grand Moff
+	Tarkin, busily push control levers and buttons.
+</sd>
+      <sp spk="INTERCOM VOICE"> Standing by.
+		</sp>
+      <sd> The rumble of a distant explosion begins.
+</sd>
+   </scene>
+   <scene n="472">
+      <sd>EXTERIOR: SPACE AROUND THE DEATH STAR.
+	The Rebel ships race out of sight, leaving the moon-like Death
+	Star alone against a blanket of stars. Several small flashes
+	appear on the surface. The Death Star bursts into a supernova,
+	creating a spectacular heavenly display.
+</sd>
+   </scene>
+   <scene n="473">
+      <sd>INTERIOR: MILLENNIUM FALCON -- COCKPIT.
+</sd>
+      <sp spk="HAN"> Great shot, kid. That was one in a million.
+</sp>
+   </scene>
+   <scene n="474">
+      <sd>INTERIOR: LUKE'S X-WING FIGHTER -- COCKPIT.
+	Luke is at ease, and his eyes are closed.
+</sd>
+      <sp spk="BEN'S VOICE"> Remember, the Force will be with you...always.
+		</sp>
+      <sd> The ship rocks back and forth.
+</sd>
+   </scene>
+   <scene n="475">
+      <sd>EXTERIOR: DARTH VADER'S TIE FIGHTER.
+	Vader's ship spins off into space.
+</sd>
+   </scene>
+   <scene n="476">
+      <sd>EXTERIOR: SPACE.
+	The Rebel ships race toward the fourth moon of Yavin.
+</sd>
+   </scene>
+   <scene n="477">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN HANGAR.
+	Luke climbs out of his starship fighter and is cheered by a
+	throng of ground crew and pilots. Luke climbs down the ladder
+	as they all welcome him with laughter, cheers, and shouting.
+		 Princess Leia rushes toward him.
+</sd>
+      <sp spk="LEIA"> Luke! Luke! Luke!
+		</sp>
+      <sd> She throws her arms around Luke and hugs him as they dance
+	around in a circle. Solo runs in toward Luke and they embrace
+	one another, slapping each other on the back.
+</sd>
+      <sp spk="HAN"> (laughing) Hey! Hey!
+</sp>
+      <sp spk="LUKE"> (laughing) I knew you'd come back! I just knew it!
+</sp>
+      <sp spk="HAN"> Well, I wasn't gonna let you get all the credit and take all the
+reward.
+		</sp>
+      <sd> Luke and Han look at one another, as Solo playfully shoves
+	at Luke's face. Leia moves in between them.
+</sd>
+      <sp spk="LEIA"> (laughing) Hey, I knew there was more to you than money.
+		</sp>
+      <sd> Luke looks toward the ship.
+</sd>
+      <sp spk="LUKE"> Oh, no!</sp>
+      <sd>The fried little Artoo-Detoo is lifted off the back of the
+	fighter and carried off under the worried eyes of Threepio.
+</sd>
+      <sp spk="THREEPIO"> Oh, my! Artoo! Can you hear me? Say something! (to mechanic)
+You can repair him, can't you?
+</sp>
+      <sp spk="TECHNICIAN"> We'll get to work on him right away.
+</sp>
+      <sp spk="THREEPIO"> You must repair him! Sir, if any of my circuits or gears
+will help, I'll gladly donate them.
+</sp>
+      <sp spk="LUKE"> He'll be all right.
+</sp>
+   </scene>
+   <scene n="478">
+      <sd>INTERIOR: MASSASSI OUTPOST -- MAIN THRONE ROOM.
+	Luke, Han, and Chewbacca enter the huge ruins of the main
+	temple. Hundreds of troops are lined up in neat rows. Banners
+	are flying and at the far end stands a vision in white, the
+	beautiful young Senator Leia. Luke and the others solemnly
+	march up the long aisle and kneel before Senator Leia. From
+	one side of the temple marches a shined-up and fully repaired
+	Artoo-Detoo. He waddles up to the group and stands next to an
+	equally pristine Threepio, who is rather awestruck by the
+	whole event. Chewbacca is confused. Dodonna and several other
+	dignitaries sit on the left of the Princess Leia. Leia is
+	dressed in a long white dress and is staggeringly beautiful.
+	She rises and places a gold medallion around Han's neck. He
+	winks at her. She then repeats the ceremony with Luke, who is
+	moved by the event. They turn and face the assembled troops,
+	who all bow before them. Chewbacca growls and Artoo beeps with
+	happiness.</sd>
+							 FADE OUT</scene>
+					 END CREDITS OVER STARS
+							 THE END
+
+</xml>

--- a/scripts/ANHDraftsXML/XSLT/transform1/ANHfirstDraft.xml
+++ b/scripts/ANHDraftsXML/XSLT/transform1/ANHfirstDraft.xml
@@ -1,0 +1,5709 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>THE STAR WARS</title>
+      <author>BY GEORGE LUCAS</author>
+      <draft>FIRST DRAFT	LUCASFILM LIMITED</draft>
+      <date>JULY 1974</date>
+   </metadata>
+   <body>
+      <scene n="1">
+         <setting>SPACE</setting>
+         <sd>FADE IN:</sd>
+         <sd>A sea of stars is broken by the vast blue surface of 
+	the planet, OGANA. Five small moons slowly drift into 
+	view from the far side of the planet. The main 
+	titles are followed by a roll-up:</sd>
+         <sd>	Until the recent GREAT REBELLION, 
+		the DAI NOGAS were the most feared 
+		warriors in the universe. For one 
+		hundred thousand years, generations 
+		of DAI perfected their art as the 
+		personal bodyguards of the King. 
+		They were the chief architects of 
+		the invincible ROYAL SPACE FORCE, 
+		which expanded the Kings power 
+		across the galaxy, from the celes-
+		tial equator to the farthest stars.</sd>
+         <sd>	Now these legendary warriors are all 
+		but extinct. One by one, they have 
+		been hunted down and destroyed as 
+		enemies of the NEW GALACTIC KINGDOM 
+		by a ferocious and sinister rival 
+		warrior sect, THE LEGIONS OF LETTOW.</sd>
+         <sd>A small silver spacecraft emerges from behind one of 
+	the Ogana moons.  The deadly little fightercraft 
+	speeds past several of the moons, until it finally 
+	goes into orbit around the FOURTH MOON.</sd>
+      </scene>
+      <scene n="2">
+         <setting>VALLEY OF COLORED LAKES- FOURTH MOON - OGANA</setting>
+         <sd>A harsh gale blows across the bleak grey surface of 
+	the Fourth Moon.  The blood red sky presses down on a 
+	lone figure, JUSTIN VALOR, a tall, heavy-set boy of 
+	sixteen.   He slowly makes his way across a wierd 
+	plain covered with huge sprawling lakes.  The water in 
+	some of the lakes is bright red, while in others it is 
+	a vivid green.  The oddly colored lakes create an 
+	ominous landscape against the eerie red sky.</sd>
+         <sd>The heavy winds whip at the young boy and make the 
+	going extremely difficult.  His face is covered by a 
+	breath mask and goggles.  He stops for a second to 
+	adjust the shoulder strap on his chrome multiplelazer 
+	rifle.  Something in the sky catches his eye, and he
+	instinctively grabs a pair of electrobinoculars from 
+	his belt.  He stands transfixed for a few moments, 
+	studying the heavens, then turns and rushes back in 
+	the direction from which he came.</sd>
+      </scene>
+      <scene n="3">
+         <setting>SUPPLY HUT - FOURTH MOON - OGANA</setting>
+         <sd>A damaged spacecraft, half buried in the dust, rests 
+	next to the remains of an abandoned supply shack.  Justin
+	makes his way across the colorless landscape and 
+	rushes into the crumbling building.  The interior of 
+	the hut is shabby, but manages to abate the howling 
+	winds.  Seated in front of a thermoheater are Justin's
+	father, AKIRA, and his young brother, BINK.  Akira is 
+	a large, burly man, wearing the distinctive robes of a 
+	Dai.  Bink is ten years old, with dusty blond hair and 
+	a large scratch on his cheek.  Justin slams the door 
+	and removes his gear.   His ruggedly handsome face is 
+	caked with many layers of dust.</sd>
+         <sp spk="JUSTIN">
+		Dad!  Dad!  They've found us!</sp>
+         <sd>Bink looks up from a small cube he has been studying. 
+	His father whacks him across the shoulder with a 
+	braided wire connector.</sd>
+         <sp spk="AKIRA">
+		Continue with the problem.  Your 
+		concentration is worse than your 
+		brother's.  (to Justin)  How many?</sp>
+         <sp spk="JUSTIN">
+		Only one this time.  A Cao Four.</sp>
+         <sp spk="AKIRA">
+		Good.  We may not have to repair 
+		this old bucket after all.  Pre-
+		pare yourself.</sp>
+         <sp spk="BINK">
+		Me too!</sp>
+         <sp spk="AKIRA">
+		Do you have the answer?</sp>
+         <sp spk="BINK">
+		I think it's the Corbet dictum: 
+		"What is, is without."</sp>
+         <sd>Akira smiles.  This is the correct answer.  Justin is
+	strapping on a utility belt with chrome lazerpistols 
+	and lazersword.  Akira rises and starts for his equip-
+	ment.</sd>
+         <sp spk="BINK (Cont.)">
+		Ahhh, Pop...</sp>
+         <sp spk="AKIRA">
+		Bink, do you feel you're ready?</sp>
+         <sp spk="BINK">
+		Yes, sir.  I've outmarked Justin in 
+		twelve disciplines.  I'm as good...</sp>
+         <sp spk="AKIRA">
+		All right, son.  Get your gear.</sp>
+         <sd>Bink jumps up with the enthusiasm available only to 
+	a ten-year old and grabs his gear.  His father frowns 
+	and shakes his head.</sd>
+      </scene>
+      <scene n="4">
+         <setting>WASTELAND BLUFF - FOURTH MOON - OGANA</setting>
+         <sd>Akira Valor and his two sons carefully make their way
+	up a rock bluff overlooking the Lettow spacecraft parked
+	among the  colored lakes.Akira inspects the  
+	with his electrobinoculars.</sd>
+         <sp spk="AKIRA">
+		No tracks.  Bi-lock hasn't been opened.
+		Interior systems are still on.</sp>
+         <sp spk="JUSTIN">
+		Are we going to wait for him to come 
+		out?</sp>
+         <sp spk="AKIRA">
+		He's not  in there.  He's baiting us. 
+		I'm surprised they only sent one this 
+		time.  We must be wearing them down, 
+		or they must think this warrior is 
+		something special.  Stay on guard, 
+		and keep hidden.  I'm going to work 
+		my way across the ridge and call his 
+		bluff.  Better we meet in open combat 
+		than wait for him to ambush us.  Keep 
+		your guard!</sp>
+         <sd>Akira leaves his two sons and moves off along the 
+	obscured ridge.  Justin and Bink watch him intently. 
+	Justin throws down his multiplelazer rifle in dis-
+	gust.</sd>
+         <sp spk="JUSTIN">
+		He should have let me go with him.  
+		He's getting too old to make an open 
+		challenge.</sp>
+         <sp spk="BINK">
+		He's not too old to realize you'd 
+		just get in the way.</sp>
+         <sd>Justin ignores his little brother's remark and sneaks 
+	a look over the ridge at the Lettow spacecraft.  Akira 
+	moves out of the rocks some distance away and starts 
+	toward the starship.  Bink moves to the ridge next to 
+	his brother, his chrome lazerrifle sparkling in the 
+	reflected red light of Ogana.</sd>
+         <sp spk="BINK">
+		He's making his move.</sp>
+         <sp spk="JUSTIN">
+		Watch your guard... and cover 
+		that weapon.  It shines like a 
+		beacon.</sp>
+         <sd>Bink reluctantly move away and watches the other 
+	direction.  Akira has almost reached the Lettow 
+	spacecraft and still there is no sign of its 
+	occupant.</sd>
+         <sp spk="BINK">
+		What's happening?</sp>
+         <sp spk="JUSTIN">
+		Nothing.  I don't like it.</sp>
+         <sd>Akira carefully moves to the main hatch of the star-
+	ship.  He kicks a valve and the hatch drops open 
+	with a loud clank and rushing gas.  Justin becomes 
+	more tense as his father carefully moves inside the
+	spacecraft.  Everything is still.  Even the continual 
+	winds seem to have died down.  Moments pass with no 
+	sign of activity inside the enemy starship.  Justin 
+	watches the craft with his electrobinoculars.  The 
+	waiting becomes unbearable.</sd>
+         <sp spk="JUSTIN">
+		Something's happened!  He's been in 
+		there too long.</sp>
+         <sp spk="BINK">
+		Let me look!  Stand my guard.</sp>
+         <sd>Bink takes the electrobinoculars from his brother and 
+	studies the silent spacecraft.  Justin impatiently 
+	scans the distant red horizon.</sd>
+         <sp spk="BINK">
+		I think the power just went off. 
+		We'd better wait here until some-
+		one comes out.</sp>
+         <sp spk="JUSTIN">
+		What if he needs help?</sp>
+         <sp spk="BINK">
+		The power went back on again....</sp>
+         <sd>With the aid of the electrobinoculars, Bink watches 
+	the running lights of the starship flash on and off.
+	Suddenly something huge moves in front of his field 
+	of vision.  Before either of the two young boys can 
+	react, a large, sinister Lettow warrior in black 
+	robes and a face mask  looms over them.  He carries 
+	a long lazersword which cuts young Bink down before 
+	he or his brother is able to raise his weapon.  The 
+	startled Justin backs away in horror, then settles 
+	down and ignites his lazersword which creates an 
+	eerie red glow.  He stumbles over rocks as he attempts 
+	to avoid the charging Lettow warrior.  The evil 
+	warrior swings his mighty lazersword, but Justin 
+	manages to deflect the intended deathblow.</sd>
+         <sd>Finally, Justin is able to assume a defensive stance, 
+	and the two warriors stand, sizing up each other.  The 
+	legionnaire is at least seven feet tall, and dwarfs 
+	the young Dai.  They stand for a few moments, almost 
+	frozen, then in a flurry of blows, lazerswords clash 
+	with the sound of electric snapping and popping. 
+	Justin is barely able to hold his own against the 
+	experienced warrior.  Many blows are exchanged before 
+	the Lettow warrior is able to back Justin up against 
+	a deep crevasse.  Justin stumbles and almost falls 
+	over the cliff to his death.</sd>
+         <sd>The legionnaire suddenly senses something behind him 
+	and whirls around to face Justin's father, Akira Valor, 
+	a Dai Nogas master.  The Lettow warrior raises his 
+	lazersword, but is cut in two before he can bring it 
+	down again.  Akira moves to the fallen legionnaire 
+	and studies him carefully.  Justin, still a little 
+	wobbly from the whole experience, attempts to stand. 
+	Akira sees his dead son Bink and goes to him.  He 
+	lifts him into his arms and begins to weep.  Justin 
+	stands bewildered, watching his father cradle the 
+	dead child.</sd>
+      </scene>
+      <scene n="5">
+         <setting>INTERIOR LETTOW STARSHIP - VALLEY OF COLORED LAKES - 
+	OGANA</setting>
+         <sd>Akira Valor slides into one of the four seats of the
+	small Lettow starship.  Through the front viewing 
+	canopy, he watches Justin drag Bink's body to a small
+	crevasse.  Justin places a small locket around his 
+	brother's neck, makes a complicated sign, and dumps 
+	the body into the shallow depression.  The giant 
+	engines of the spacecraft begin to whine, kicking up 
+	large clouds of dust.</sd>
+         <sd>Justin climbs into the seat beside his father and 
+	removes his breath mask and goggles.   There are 
+	tears in his eyes.  Father and son look out across 
+	the wasteland towards Bink's grave.  The thunderous 
+	clap of an explosion is followed by a small mushroom 
+	cloud rising out of the depression.  Justin throws a
+	container down in a fit of rage.</sd>
+         <sp spk="JUSTIN">
+		How many more of them are there?  I 
+		want to finish it, once and for all. 
+		I'm sick of running.  When will it 
+		stop?</sp>
+         <sd>Justin's father waits silently until the tirade is
+	finished.  Justin sits silently for a few moments.</sd>
+         <sp spk="JUSTIN (Cont.)">
+		I'm sorry.</sp>
+         <sp spk="AKIRA">
+		Son, plot a course for TOWNOWI.</sp>
+         <sd>Justin lights up like a Geenick at feeding time.</sd>
+         <sp spk="JUSTIN">
+		Townowi!  You mean we're going home?</sp>
+         <sp spk="AKIRA">
+		We both need a rest.</sp>
+         <sd>Akira pulls back on the throttle and the powerful 
+	spaceship lifts off the surface of the Fourth Moon 
+	of Ogana.</sd>
+      </scene>
+      <scene n="6">
+         <setting>CLOUD SEA - GRANICUS</setting>
+         <sd>A title card appears over a sea of billowing clouds 
+	on the gaseous planet of GRANICUS:</sd>
+         <sd>	Granicus:   Capital of the New 
+		Galactic Empire.</sd>
+         <sd>The towering yellow oxide clouds pass, revealing the 
+	Royal City of Granicus.  The magnificent domed and 
+	gleaming city is perched, mushroom-like, on a tall 
+	spire which disappears deep into the misty surface 
+	of the planet.  The peacefulness of this nebulous 
+	idyll is broken by the increasing wail of ion 
+	engines.  Four sleek stardestroyers from the Royal 
+	Fleet burst out of the huge cumulus range.  The 
+	craft are flying in a tight formation as they bank 
+	steeply, and head toward the royal   capital of the 
+	New Galactic Kingdom.</sd>
+      </scene>
+      <scene n="7">
+         <setting>INTERIOR STARDESTROYER - GRANICUS</setting>
+         <sd>Stardestroyers are two-man spacecraft crammed with
+	sophisticated electronic weaponry.  The pilot and 
+	gunnery officers sit side-by-side surrounded by 
+	lighted readouts and switches.  They wear the gleaming 
+	black uniforms of the Kings elite corps.</sd>
+         <sp spk="PILOT">
+		Tok-One to Chicks:  Shape it up. 
+		Let's make it good.</sp>
+         <sp spk="CHICK-ONE">
+		Does that glare bother you?</sp>
+         <sp spk="PILOT">
+		Use your face shield, Chick-One.</sp>
+         <sd>The pilot is cold and professional as he maneuvers 
+	his craft closer to the others.  The positions of 
+	the ships are displayed on a read-out, along with a 
+	graphic representation of the city.  The pilot gives 
+	the gunner a quick look before he flips his sunshield 
+	over his eyes.</sd>
+         <sp spk="PILOT">
+		Here we go.  Count:  three, two, 
+		one, now!</sp>
+      </scene>
+      <scene n="8">
+         <setting>REVIEW STAND - PLAZA OF THE DONNS - GRANICUS</setting>
+         <sd>On a huge austere platform stands the dark SON HHAT, 
+	Lord of Granicus, Consul to the Supreme Tribunal, and 
+	ruler of the Galactic Kingdom.  He is a thin gray 
+	looking man with an evil mustache hanging limply 
+	over his insidious lip.  Standing at rigid attention 
+	on his right are several generals  dressed in the 
+	black and grey uniform of the realm.  Five members 
+	of the Supreme Tribunal sit off to the side.  On 
+	Hhat's    left stands MARA HORUS, newly appointed 
+	Governor of the Townowi Systems.  He is a young 
+	treacherous man with stone-cut angular features and 
+	piercing gray eyes.</sd>
+         <sd>They all gaze skyward as the four gleaming star-
+	destroyers scream low overhead in an impressive 
+	barrel-roll formation.  As the sound of the space-
+	craft resonates throughout the glass canyon of the 
+	Plaza, the group of dignitaries return their atten-
+	tion to the parade of  royal   shock troops and 
+	giant air tanks (which ride magically, two or three 
+	feet above the ground).</sd>
+         <sd>The Plaza of the Donns is filled with hundreds of rows 
+	of troops as the last brigade marches into position. 
+	The sound of three thousand men snapping to attention 
+	is followed by a strange silence.  A light wind blows 
+	the great red banner of the kingdom creating a subtle
+	flapping sound.  The king's amplified voice startles 
+	many of the troops as it cuts through the quiet.</sd>
+         <sp spk="SON HHAT">
+		Upon this battle depends the survival 
+		of the Galactic Kingdom. Upon this 
+		battle depends the life and long con-
+		tinuity of our civilization.  Not 
+		since the great Dai Rebellion has our 
+		destiny been placed in such a balance. 
+		This is to be the most magnificent 
+		campaign of all!  You have never been 
+		called without doing something to be 
+		remembered, something notable and 
+		striking.  The conquering of the 
+		Townowi System, the last of the inde-
+		pendent systems and the last refuge 
+		of the outlawed, vile sect of the Dai, 
+		will have such important and lasting 
+		consequences, that I can't but consider 
+		it as an epoch in history.</sp>
+         <sd>To the rear of the Plaza, watching the spectacle over 
+	the shoulder of a curious bureaucrat, stands CLIEG OXUS, 
+	a tall, blond young man about twenty years old.  He seems
+	interested in what the  King   has to say, but keeps 
+	looking around nervously as if someone were after him. 
+	His arm rests across his head, as he carefully but coolly
+	adjusts a glowing blue ring on his index finger.  The 
+	King nears the end of his speech.  Mara Horus has moved 
+	up to stand next to the sinister monarch.  The troops 
+	shout a royal salute in response to a particularly 
+	partisan statement.</sd>
+         <sp spk="SON HHAT (Cont.)">
+		... I have personally asked the Townowians 
+		to accept this Treaty of Alliance.  During 
+		the period of negotiation, they have only 
+		decided to be undecided.  We will barter no 
+		longer.  Governor Horus has been appointed 
+		the First Lord of the Townowi System and 
+		Surrounding Territories.  This is the last 
+		frontier and the final stone in the great 
+		wall of the Galactic Kingdom.</sp>
+         <sd>The troops cheer, and the King escorts Horus inside.
+	Oxus moves quickly away from the Plaza, passing through
+	several check stations, where he is forced to show his
+	identification.</sd>
+      </scene>
+      <scene n="9">
+         <setting>NIGHT CLUB - GRANICUS</setting>
+         <sd>Oxus walks into the glass and chrome splendor of one 
+	of the famous nightclubs of Granicus.  He moves to the 
+	long mirrored bar and sits next to a rough looking man, 
+	BOMOJE ESPAA, dressed in the distinctive gold and furs 
+	of the galactic traders.</sd>
+         <sp spk="OXUS">
+		Your glass is empty.</sp>
+         <sd>Oxus speaks into a small intercom on the bar front.</sd>
+         <sp spk="OXUS (Cont.)">
+		A dantic and...</sp>
+         <sd>He looks in Espaa's glass.</sd>
+         <sp spk="ESPAA">
+		No thanks, Clieg.  I've had enough.</sp>
+         <sp spk="OXUS">
+		Just a dantic, then.  Espaa, it's 
+		not like you to refuse a drink. 
+		You're going to give the galactic 
+		traders a bad name.</sp>
+         <sd>A drink appears magically from a small elevator in the 
+	bar.  Oxus takes it, and then places a pen-like trans-
+	mitter he has taken from his pocket next to the inter-
+	com.  It creates a low electronic buzz.</sd>
+      </scene>
+      <scene n="10">
+         <setting>BAR OBSERVATION CENTER - GRANICUS</setting>
+         <sd>A controller sitting in front of a row of monitors taps 
+	his headphones, then flips a switch back and forth a 
+	couple of times.  He is obviously annoyed.</sd>
+         <sp spk="CONTROLLER">
+		Number eighteen is out again.  Give 
+		me a maintenance check.</sp>
+         <sd>The controller yawns and puts his feet up on the control
+	panel.</sd>
+      </scene>
+      <scene n="11">
+         <setting>NIGHTCLUB - GRANICUS</setting>
+         <sd>Espaa leans in close to Oxus.  He is suddenly very serious.</sd>
+         <sp spk="ESPAA">
+		Clieg, we've got problems.  They've 
+		just grounded all spacecraft, in-
+		cluding trade frigates.  Even the 
+		ships under royal registry can't 
+		move.  Something big is up.</sp>
+         <sp spk="OXUS">
+		I'm afraid they're not waiting for 
+		the Alliance Treaty.  They're 
+		already moving against the System. 
+		I've got to get word back.</sp>
+         <sp spk="ESPAA">
+		The chrome companies are protesting 
+		the embargo, but it's going to take 
+		some time.</sp>
+         <sp spk="OXUS">
+		Isn't anything moving?</sp>
+         <sp spk="ESPAA">
+		Military ships, but...</sp>
+         <sd>They are interrupted by a royal officer and several
+	storm troopers.  The officer shouts over the P.A. 
+	system as the troops rush to block the exits.  Oxus 
+	and the galactic trader are tense, but remain cool.</sd>
+         <sp spk="OFFICER">
+		Attention:  All captains and first 
+		officers of Guild Trade frigates 
+		will accompany me to the Ministry 
+		of Transport immediately.</sp>
+         <sd>Espaa gives Oxus a hopeless look as the troops check 
+	their papers, and then take Espaa away.  A small fight 
+	breaks out in the back of the nightclub as one of the 
+	trader captains expresses his dislike of the kingdom. 
+	Oxus slams his glass to the bar in a gesture of hate 
+	and frustration.</sd>
+      </scene>
+      <scene n="12">
+         <setting>GOVERNOR HORUS QUARTERS - GRANICUS</setting>
+         <sd>The large white-on-white executive quarters resound 
+	with the high-pitched laugh of the evil Governor
+	Horus.  He slaps DARTH VADER, a tall, grim looking 
+	general, on the back and the general's mouth makes 
+	the slightest gesture at a smile.</sd>
+         <sp spk="HORUS">
+		Success!  I told you.  We are no 
+		longer under the control of the 
+		GREAT FAMILIES.  We've gained a 
+		true advantage.</sp>
+         <sd>VANTOS COLL, a member of the Supreme Tribunal, and a 
+	man of the grossest dimensions, appears to be a little
+	worried.</sd>
+         <sp spk="COLL">
+		A rather dangerous advantage. 
+		You still have a system to 
+		conquer.</sp>
+         <sp spk="HORUS">
+		But this system will bring us 
+		more scientific wealth than that 
+		of any other house in the 
+		tribunal.  We will easily gain 
+		control of the directorship.</sp>
+         <sp spk="COLL">
+		Don't underestimate the armies of 
+		Townowi.  They're lead by a Dai 
+		warrior.</sp>
+         <sp spk="HORUS">
+		I've told you about Commissioner 
+		Coll, General.  He worries a lot.</sp>
+         <sp spk="VADER">
+		It's a myth that any Dai still exists.</sp>
+         <sp spk="COLL">
+		General Skywalker is no myth.  When 
+		I first arrived at court, he was 
+		the first bodyguard to the King.
+		He lead the Dai Rebellion.</sp>
+         <sp spk="VADER">
+		NGAI THUC lead the Rebellion.</sp>
+         <sp spk="COLL">
+		So the King would have you beieve, 
+		but I was there.</sp>
+         <sp spk="VADER">
+		Then why wasn't he hunted down like 
+		the others?</sp>
+         <sp spk="COLL">
+		Because he is too dangerous, too 
+		clever.  Besides, his presence on 
+		Townowi is still only a rumor.</sp>
+         <sp spk="HORUS">
+		Then why do you believe it?</sp>
+         <sp spk="COLL">
+		Because I knew him.  He's there 
+		all right.  I can sense it.  Mark 
+		my words, Townowi will not be 
+		easily conquered.</sp>
+      </scene>
+      <scene n="13">
+         <setting>COURTYARD - PALACE OF LITE - TOWNOWI</setting>
+         <sd>A low, sleek landspeeder (an auto-like transport which
+	travels a few feet above the ground on a magnetic field) 
+	glides into the courtyard of the palace of Townowi. 
+	The planet, with its bright green sky, is a desert 
+	wilderness;  but the palace is a sparkling oasis, with 
+	low concrete walls and great turrets spilling over with 
+	foliage from rooftop gardens.  The speeder stops before 
+	an enormous shaded corridor.  Fountains line the 
+	beautiful and highly polished  tile  walkway.  Two 
+	young boys, OETA (7) and PUCK (5) are helped out of the 
+	speeder by AMBER, a one-armed bodyguard dressed in the 
+	flowing white robes of the Townowi military.  The two 
+	boys run through the long corridors, yelling and 
+	screaming, their little footsteps echoing throughout 
+	the palace.</sd>
+      </scene>
+      <scene n="14">
+         <setting>LIBRARY - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The palace library is a dim, cool room, projecting an 
+	aura of time-worn comfort and security.  In the 
+	distance, the children can be heard screaming through 
+	the corridors.  KING KAYOS, silver haired but amazingly 
+	youthful under a tanned and leathery face, motions for 
+	one of his aides to shut the partially closed door. 
+	He is in the middle of an emergency meeting of the 
+	Townowi High Senate.  The twelve men sit in overstuffed 
+	chairs, placed in a large circle.  A large, sallow-eyed 
+	galactic trader named AAY ZAVOS, fiddlesnervously with 
+	a small scrap of leather as he speaks.</sd>
+         <sp spk="ZAVOS">
+		My Lord, the chrome companies are with 
+		you in spirit, but you must understand, 
+		they can't openly support you.  Royal 
+		trade restrictions are very unfavorable 
+		and we, of course, favor your indepen-
+		dence.</sp>
+         <sp spk="KAYOS">
+		If there were to be war, would your 
+		frigates still supply us?</sp>
+         <sp spk="ZAVOS">
+		Your bluntness is to be commended. 
+		It could be arranged.</sp>
+         <sd>COUNT SANDAGE, a corrupt noble of the senate, jumps to 
+	his feet in a rage.</sd>
+         <sp spk="SANDAGE">
+		This is nonsense!  We have no choice 
+		but to approve the treaty.  If there 
+		is war, the New Galactic Kingdom will 
+		destroy our entire system with a snap 
+		of the finger.  General Skywalker is 
+		a dreamer if he thinks he can mount 
+		any meaningful resistance, and you're 
+		dreamers if you believe him.  So much 
+		trust in one aged man.  You must see...</sp>
+         <sd>At that moment, all heads turn as someone enters the 
+	room.  It is General Luke Skywalker, Commander of the 
+	Townowi Star Force.  He is a large man, apparently in 
+	his early forties, but actually much older.  Every-
+	one senses the aura of power that radiates from this 
+	great warrior.  Here is a leader:  a Dai general.  He 
+	looks weary, but is still a magnificent looking warrior. 
+	His face, cracked and weathered by exotic climates, is 
+	set off by a close silver beard, and dark, penetrating 
+	eyes.  Sandage is somewhat embarrassed and quietly sits 
+	down.</sd>
+         <sp spk="SKYWALKER">
+		Is there anyone here so naive he 
+		believes the Galactic Kingdom 
+		would even bother negotiating if 
+		they were contemplating destruction 
+		of this system?  Your Excellencies, 
+		this is more than a simple raid on 
+		your resources.  You must reach a 
+		decision.</sp>
+         <sd>MIR NASH, a thin, birdlike senator, turns to General 
+	Skywalker.</sd>
+         <sp spk="NASH">
+		General Skywalker, war is a serious 
+		business... a deadly business.</sp>
+         <sp spk="SKYWALKER">
+		Procrastination is a deadly business, 
+		Senator.  War is my business.  Have 
+		you approved my defense measures?</sp>
+         <sd>The GRANDE MOUFF TARKIN wears the long black robes of 
+	the Townowian religion.  He speaks with a high, 
+	cracking voice.</sd>
+         <sp spk="TARKIN">
+		An actual war with the Galactic Kingdom
+		is still only a remote possibility.  As 
+		a military treatise, your proposal has 
+		certain merits, but in the harsh light 
+		of reality, an attack against the Galac-
+		tic Kingdom appears to be a somewhat 
+		extreme defense.</sp>
+         <sp spk="NASH">
+		You must understand, General, were
+		interested in avoiding a war, not 
+		starting one.</sp>
+         <sp spk="SKYWALKER">
+		There are times when offense makes 
+		the best defense.  If that Alliance 
+		Treaty isn't signed, we will need 
+		all the advantage we can get.</sp>
+         <sp spk="KAYOS">
+		Count Sandage, I want you to head 
+		the delegation to Granicus.  You 
+		will leave tomorrow with our answer 
+		regarding the treaty.  My decision 
+		will be forthcoming.</sp>
+         <sd>The senators whisper among themselves.</sd>
+         <sp spk="KAYOS (Cont.)">
+		All right, then.  May the force 
+		of others be with you all.</sp>
+         <sd>The senators leave in a flurry of hushed conversation. 
+	The general is lost in thought, and remains in his chair. 
+	Oeta and Puck, King Kayos two young sons, storm through 
+	the existing senators, and rush on to Kayos' lap.  The 
+	King is obviously very proud of the two young princes. 
+	He throws Oeta into the air, and then catches him again.</sd>
+         <sp spk="PUCK">
+		Me too! Me too!</sp>
+         <sp spk="OETA">
+		Zara's leaving!  Zara's leaving and 
+		you gotta say good-bye.</sp>
+         <sd>The King picks up Puck and swings him around, then puts 
+	him down.</sd>
+         <sp spk="KAYOS">
+		Okay, whippersnapper, go tell your 
+		mother and your sister that I'm on 
+		my way.</sp>
+         <sd>The two boys run out of the room and are heard yelling 
+	and screaming down the hallway. The king starts out, but
+	stops in front of the general.</sd>
+         <sp spk="KAYOS">
+		Luke, my daughter is leaving for the 
+		academy at Chathos. Won't you come 
+		and wish her well?  It would mean a 
+		lot to her.  She truly idolizes you, 
+		you know.  Come on, the war will 
+		wait.</sp>
+         <sp spk="SKYWALKER">
+		Of course. I'm sorry, My Lord. 
+		Politics always seem to distress me.</sp>
+         <sd>General Skywalker rises, and as they head for the door, 
+	Kayos pats him on the back.</sd>
+         <sp spk="KAYOS">
+		I know, Luke.  I feel THE FORCE also.</sp>
+      </scene>
+      <scene n="15">
+         <setting>COURTYARD - PALACE OF LITE - TWONOWI</setting>
+         <sd>A large, four-seat speeder sits gleaming in the sun-
+	soaked courtyard.  The PRINCESS ZARA, about fourteen 
+	years old, possessing a soft beauty and iron will, is
+	embracing her mother, QUEEN BREHA, a warm, silver-
+	haired matron.  There are tears in the princess' blue 
+	eyes.  Oeta and Puck jump around inside the speeder, 
+	disrupting the efforts of the one-armed Amber to pack 
+	several plaxiform cases.</sd>
+         <sd>Zara embraces the King as he approaches with the 
+	general.</sd>
+         <sp spk="ZARA">
+		Oh, Daddy, I'll miss you so.</sp>
+         <sp spk="KAYOS">
+		The semester will be over before you 
+		know it.  You'll have a grand time. 
+		There are so many new things to learn. 
+		I wish I were going.
+	He gives her a fatherly smile, and she hugs him again. 
+	The general stands rather formally to one side.  The 
+	princess, her long auburn hair tied in braids, moves 
+	to the general and he bows before her.</sp>
+         <sp spk="SKYWALKER">
+		May your studies do you honor.</sp>
+         <sd>Zara is somewhat embarrassed by the general's formality 
+	and can only manage an awkward smile before returning 
+	to her parents at the speeder.</sd>
+         <sp spk="BREHA">
+		Hurry, Zara.  You must make it to 
+		Yuell before nightfall.</sp>
+         <sd>The princess' maids-in-waiting, ALANA, a short stocky 
+	girl, and MINA, more comely (somewhat that same stature 
+	as Zara) with long dark hair, giggle and straighten 
+	Zara's dress before she enters the speeder.  The prin-
+	cess and Mina hug Alana, whose giggles have turned to 
+	tears.  The two boys scramble out of the speeder as 
+	Amber helps the princess and her maid into the back 
+	seat.  The speeder is piloted by a trooper of the 
+	first order.  Amber jumps into the seat beside him, 
+	and the speeder starts with a low buzzing sound.  The 
+	princess waves to her family, and Mina waves to Alana 
+	as the speeder slowly glides out of the courtyard.</sd>
+      </scene>
+      <scene n="16">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The huge war room is a mass of glass enclosures, 
+	electronic wall displays, monitors, and computer 
+	stations.  General Skywalker enters a control station, 
+	followed by a covey of military aides of various ranks. 
+	As the group hurry through the crowded room, men rise 
+	and salute the new arrivals.  The general stops before 
+	a giant display of the galaxy.  Small symbols flash on 
+	and off over various portions of the big board.  The 
+	general studies it intently.</sd>
+         <sp spk="SKYWALKER">
+		Montross!</sp>
+         <sd>CAPTAIN MONTROSS, one of the general's aides, snaps to
+	attention.</sd>
+         <sp spk="MONTROSS">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		What's the TQ on this?</sp>
+         <sp spk="MONTROSS">
+		The last frigate to leave Granicus 
+		was at twenty-three forty, Sir.</sp>
+         <sp spk="SKYWALKER">
+		Have any ships at all left the 
+		planet?  (to another aide)  Check 
+		with the Guild on NORTON THREE.</sp>
+         <sp spk="MONTROSS">
+		At twenty-four hundred, a full 
+		battalion of stardestroyers left 
+		for what is projected to be 
+		ANCHORHEAD, or a nearby system.</sp>
+         <sp spk="SKYWALKER">
+		And no word from Oxus.  He should 
+		have reported by now.  CAPTAIN PRUE!</sp>
+         <sd>An older, academic looking aide, steps forward.</sd>
+         <sp spk="PRUE">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		What do you make of this?</sp>
+         <sp spk="PRUE">
+		A battalion is invasion force, but the 
+		Royal Galactic Kingdom controls that 
+		entire part of the galaxy.  A revolution, 
+		maybe?  At any rate, they're going in the 
+		wrong direction to be any trouble for us.</sp>
+         <sd>The general ponders this for a few moments, then speaks
+	almost to himself.</sd>
+         <sp spk="SKYWALKER">
+		I don't know.  It doesn't feel good.</sp>
+         <sp spk="MONTROSS">
+		Put 'em on alert.</sp>
+         <sd>A loud uproar is heard on the far side of the war room.
+	Everyone turns to see a foreign dressed warrior pushing 
+	his way past several guards and war-room bureaucrats. 
+	The warrior, with his long hair tied in an odd bun on 
+	the top of his head, is Akira Valor.  He is followed by 
+	his son, Justin, who rudely pushes the pesky bureaucrats 
+	out of the way.</sd>
+         <sp spk="BUREAUCRATS">
+		It's restricted.  You'll have to 
+		wait.  (etc.)</sp>
+         <sp spk="AKIRA">
+		Get out of my way, boy, before I 
+		grind you into the surface. (etc.)</sp>
+         <sd>As the dauntless Akira approaches the general, the guards
+	stop in bewilderment as General Skywalker rushes up to 
+	the warrior and embraces him.  The two Dai warriors 
+	laugh jubilantly and slap one another, as the aides and
+	bureaucrats look on in amazement.</sd>
+         <sp spk="SKYWALKER">
+		Akira Valor - you old muscle-rat! 
+		What a sight!  We heard that you 
+		had been executed.</sp>
+         <sp spk="AKIRA">
+		So the Galactic Kingdom would have 
+		you believe.  I've been in the 
+		KESSIL System.  You remember little 
+		Justin.</sp>
+         <sd>Akira puts his arms around his son, who has been making 
+	eyes at one of the cute young female aides. He bows 
+	before the general.</sd>
+         <sp spk="SKYWALKER">
+		He takes after his mother!  (they laugh)  
+		It's so good to see you.</sp>
+         <sp spk="AKIRA">
+		It's wonderful to be with another 
+		Dai again.  There are so few of us 
+		left.</sp>
+         <sd>The cute aide goes back to her duties, flirting with 
+	Justin as she passes.  The young warrior pinches her 
+	on the ass, which startles her, but she goes on like 
+	nothing has happened.</sd>
+         <sp spk="SKYWALKER">
+		What a sight!</sp>
+         <sd>The two Dai stand looking at one another, hardly believing
+	the other is real.  Finally, the general realizes his 
+	aides are standing around, gawking at the duo.</sd>
+         <sp spk="SKYWALKER (to the aides)">
+		Wake up, gentlemen.  You're on alert. 
+		Keep me posted on that battalion.</sp>
+      </scene>
+      <scene n="17">
+         <setting>CONTROL STATION - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general, Akira and Justin enter a small glass enclosed
+	control office.  They sit, and an awkward silence ensues 
+	as each man waits for the other to speak.</sd>
+         <sp spk="AKIRA">
+		I've come for your help.</sp>
+         <sp spk="SKYWALKER">
+		Anything you ask.  You're a Dai 
+		brother.  We're one.</sp>
+         <sp spk="AKIRA">
+		My friend, we've been through much 
+		together.  I've been through much 
+		since we parted.  I've lost much. 
+		The Legions of Lettow have chased 
+		us half way across the galaxy.  There 
+		is no refuge.  One day they will come 
+		here.  Take my son as your JUWO 
+		learner.  He would be a Dai.  I've
+		trained him from birth.  He's reached 
+		the fifth stage. He fought in the 
+		Kessilian civil wars and commanded a 
+		Hubble expedition to the CONE Systems. 
+		He's a good boy, Luke, and one hell 
+		of a fighter.</sp>
+         <sd>The general looks down, somewhat embarrassed. He scratches
+	his head, then smiles.</sd>
+         <sp spk="SKYWALKER">
+		Old friend, you do me too much honor. 
+		I was never a match for you.  Why don't 
+		you finish his training yourself?</sp>
+         <sp spk="AKIRA">
+		I'm too old, Luke. I can't go on. 
+		You must finish it.</sp>
+         <sp spk="SKYWALKER">
+		What kind of talk is this?  You're 
+		not the old Valor I remember.  Too 
+		old?!?</sp>
+         <sd>Akira Valor suddenly ignites in a rage and swings 
+	his left forearm down with a mighty blow across the 
+	solid chrome desk the general is sitting at.  The 
+	old Dai warrior's forearm cracks in two, spewing forth 
+	wires  and many fine multicolored electronic components. 
+	The artificial limb flops lifelessly to Valor's side. 
+	The warrior rips open his tunic, revealing a plastic 
+	chest stuffed with flashing electronic parts.</sd>
+         <sp spk="AKIRA (angrily)">
+		I'm not the same.  There is nothing 
+		left but my head and right arm.  I've 
+		lost too much, Luke.  I'm dying.</sp>
+         <sd>The general bows his head in sorrow for one of the 
+	greatest warriors in the galaxy and a dear friend.</sd>
+         <sp spk="SKYWALKER">
+		I'm sorry...</sp>
+         <sp spk="AKIRA">
+		I'm sorry.  I keep losing control. 
+		I'm very tired.  Take my son!  The DAI 
+		NOGAS must survive.  We must pass it 
+		on.  Only a Dai can stop Son Hhat. 
+		We're very old, Luke.  A new 
+		generation of Dai must be started. 
+		Take him;  teach him the way of 
+		the Dai Nogas.</sp>
+         <sd>Captain Montross bursts into the office and somewhat
+	excitedly salutes the general.</sd>
+         <sp spk="MONTROSS">
+		Sir, we have picked up something! 
+		An asteroid, or solid comet moving 
+		away from the Anchorhead System.</sp>
+      </scene>
+      <scene n="18">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general rushes out of the control station and back 
+	to the giant galactic display.  He is followed by 
+	Montross, Akira and Justin.</sd>
+         <sp spk="SKYWALKER">
+		Are you sure it's not the battalion?</sp>
+         <sp spk="MONTROSS">
+		A solid object.  It's as big as our 
+		Third Moon.</sp>
+         <sp spk="PRUE">
+		It's too large to be man-made, and it's 
+		too slow to be a comet.</sp>
+         <sp spk="SKYWALKER">
+		Analysis?</sp>
+         <sp spk="MONTROSS">
+		It's too far out.</sp>
+         <sp spk="SKYWALKER">
+		I'll be with the king.  Report as soon 
+		as you can get a reading on it.  (turning 
+		to Akira's son)  Captain Valor, from now 
+		on you stick close to me.</sp>
+         <sd>The older Valor smiles, and puts his good arm around 
+	his old friend.</sd>
+      </scene>
+      <scene n="19">
+         <setting>DINING CHAMBER - PALACE OF LITE - TOWNOWI</setting>
+         <sd>King Kayos moves his arm around Breha's waist as they 
+	stand on a balcony watching two giant twin suns in the 
+	green sky disappear behind a distant dune range.  The 
+	general enters, rather in a rush, followed by the 
+	young Valor, who is now dressed in the white uniform of 
+	the Townowi star force.  (He still wears the distinctive
+	Kessilian hair knot.)  They bow before the King.</sd>
+         <sp spk="KAYOS (pointing to the suns)">
+		Aren't they beautiful, General? 
+		"Always and never the same." 
+		You're just in time for dinner.</sp>
+         <sp spk="SKYWALKER">
+		I have come for other reasons.  
+		Could...?</sp>
+         <sp spk="KAYOS">
+		Relax, General.  We will discuss it, 
+		but over dinner.  There are times, 
+		Luke, when I find you a bit too rigid. 
+		Is this your new disciple?</sp>
+         <sd>Justin is ill at ease and bows again.</sd>
+         <sp spk="JUSTIN">
+		Justin Valor, sir.</sp>
+         <sp spk="KAYOS">
+		Where's your father?</sp>
+         <sp spk="SKYWALKER">
+		He left for the spaceport at GORDON 
+		to visit an old friend, Han Solo, 
+		the UREALLIAN.</sp>
+         <sp spk="KAYOS">
+		We are becoming quite a refuge.</sp>
+         <sd>The group sit at a large table and food is brought in by
+	servants.  They eat.  Justin is nervous and watches the
+	general, to make sure he is being proper.</sd>
+         <sp spk="SKYWALKER">
+		My Lord, several events have occurred 
+		which lead me to believe we are in 
+		imminent danger of attack.  There is 
+		no longer time for discussion and debate.</sp>
+         <sp spk="KAYOS">
+		What events?</sp>
+         <sp spk="SKYWALKER">
+		Oxus, our best agent, has disappeared 
+		in the galactic capital. There is 
+		unusual military traffic in the S-4 
+		sectors.</sp>
+         <sp spk="KAYOS">
+		Unless you have direct, concrete proof 
+		of a pending attack, there is nothing 
+		I can do.</sp>
+         <sp spk="SKYWALKER">
+		By the time we have proof, it may be 
+		too late.</sp>
+         <sp spk="KAYOS">
+		Luke, I'm leaving tonight for AMSEL. 
+		I'm meeting with the full assembly 
+		first thing in the morning.  I am not 
+		going to approve the Alliance Treaty, 
+		and I will get your defense measure 
+		approved.  Just be patient.  You will 
+		have the war code.</sp>
+         <sp spk="SKYWALKER">
+		Tomorrow may be too late.  My Lord, 
+		I need the war code now.  We must 
+		get our forces into space.</sp>
+         <sp spk="KAYOS">
+		But it must be done legally, with 
+		everyone's approval.  Tomorrow you 
+		will have that.  I doubt the New 
+		Galactic Kingdom would attack before 
+		receiving our answer.  The separation 
+		of war powers is the one condition 
+		upon which you assumed command of our 
+		forces.  You're a friend, Luke, and  
+		I trust you;  but you're also an out-
+		lander who controls a great deal of 
+		power.  I can't forsake my oath any 
+		more than you can.  Just be patient. 
+		You will have the code tomorrow.</sp>
+         <sd>Captain Montross enters the large chamber and bows before 
+	the King.</sd>
+         <sp spk="MONTROSS">
+		I bring a report to General Skywalker, 
+		My Lord.</sp>
+         <sp spk="KAYOS">
+		You may deliver it.</sp>
+         <sp spk="MONTROSS">
+		Sir, the asteroid has disappeared from 
+		our scopes.  There is no trace of it.</sp>
+         <sp spk="SKYWALKER">
+		Were they able to analyze it?</sp>
+         <sp spk="MONTROSS">
+		It never came within range, sir.</sp>
+         <sd>The general rises, quickly followed by Captain Valor.</sd>
+         <sp spk="GENERAL">
+		Excuse us, My Lord.  We'd better 
+		get back.  I will wait patiently 
+		for the approval.</sp>
+         <sd>The general and Montross exit the chamber.  Valor takes 
+	one last bite of his dinner, then dashes after his mentor.</sd>
+      </scene>
+      <scene n="20">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general sits rigidly  facing the big galactic display
+	board.  Several aides and bureaucrats rush to and fro,
+	ignoring the general.  He is asleep.  Captain Prue 
+	approaches the general and snaps to attention.  The 
+	general's eyes open.</sd>
+         <sp spk="SKYWALKER">
+		What are the results?</sp>
+         <sp spk="PRUE">
+		Negative, Sir.</sp>
+         <sp spk="SKYWALKER">
+		Are you sure?</sp>
+         <sp spk="PRUE">
+		Absolutely.</sp>
+         <sp spk="SKYWALKER">
+		It's just not possible.  Something 
+		that size can't just disappear with-
+		out a trace.  Check it again.</sp>
+         <sp spk="PRUE">
+		That's the tenth negative, Sir.</sp>
+         <sp spk="SKYWALKER">
+		I said check it again.</sp>
+         <sd>Captain Prue retreats to a computer station. The general
+	looks around for Captain Valor.</sd>
+         <sp spk="SKYWALKER">
+		Valor!</sp>
+         <sd>Everyone near the general turns, but Valor doesn't show.</sd>
+         <sp spk="SKYWALKER">
+		Where is that boy?  Montross!</sp>
+         <sd>Montross rushes up to the general and snaps to attention.</sd>
+         <sp spk="SKYWALKER">
+		Page Captain Valor.</sp>
+         <sd>Montross goes back to his station and a few moments later,
+	Captain Valor is paged over the P.A. system.  The general
+	waits, watching the big board.  Eventually, Justin stumbles
+	out of an enclosed computer closet, fastening his pants and
+	tucking in his tunic.  A moment later, the cute female aide
+	rather sheepishly exits the computer closet.  She also is 
+	in the process of putting her uniform back together.  Justin
+	rushes up to the general and snaps to attention.</sd>
+         <sd>The general lets him stand there for a moment, not acknow-
+	ledging his presence;  then, suddenly without warning and 
+	in one masterful flash motion, the general stands, grabs 
+	a small baton attached to his belt (which immediately 
+	ignites into a four-foot glowing lazersword) and swings 
+	at the young warrior's head.  In an equally quick movement,
+	Justin ignites his lazersword and blocks the general's 
+	blow.  Everyone in the war room is surprised and startled.
+	After a moment, they rush to the general.  Justin and the
+	general stand motionless for a few moments, with lazer-
+	swords locked in mid-air.  Finally, the general grins and Justin
+	hesitantly relaxes.  They lower their swords and turn them off.</sd>
+         <sp spk="SKYWALKER">
+		You are trained well, but remember, 
+		a Dai must be single-minded, a 
+		discipline your father obviously 
+		never learned, hence your existence.
+		Clean yourself up.  Discipline is 
+		essential.  Your mind must follow 
+		the way of the Nogas.</sp>
+         <sp spk="JUSTIN">
+		It won't happen again, sir.  There 
+		are many new....</sp>
+         <sd>			 P.A.
+		General Skywalker, white com.</sd>
+         <sd>The general moves to a control station and picks up a phone.</sd>
+         <sp spk="PHONE VOICE">
+		Sir, Captain Oxus has just been 
+		admitted to Med Vac.</sp>
+         <sp spk="SKYWALKER">
+		What's his condition?</sp>
+         <sp spk="PHONE VOICE">
+		No data, sir.</sp>
+         <sp spk="SKYWALKER">
+		I'm on my way.</sp>
+      </scene>
+      <scene n="21">
+         <setting>MED VAC EMERGENCY ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor waits in an outer chamber as General Sky-
+	walker rushes into the Med Vac emergency room where
+	several doctors are working on the prostrate Oxus.</sd>
+         <sp spk="SKYWALKER">
+		What's his condition?  Is 
+		he conscious?</sp>
+         <sp spk="DOCTOR">
+		Partially.  He'll be all right - 
+		a few bruises, primary exhaustion...</sp>
+         <sd>Oxus thrashes around in a semi-conscious state.  He sees 
+	the general.</sd>
+         <sp spk="SKYWALKER">
+		What happened, boy?  What's going on?</sp>
+         <sp spk="OXUS (with difficulty)">
+		The Royal Starforce is already on its 
+		way, not far behind me.  They're going 
+		to attack.</sp>
+         <sp spk="SKYWALKER">
+		Are you sure?</sp>
+         <sp spk="OXUS">
+		I have tapes.  A giant space fortress...</sp>
+         <sd>He struggles to give General Skywalker his ring.</sd>
+         <sp spk="SKYWALKER">
+		As big as our Third Moon?</sp>
+         <sp spk="OXUS">
+		Bigger.  It's unlike anything 
+		I've ever seen.  Sophisticated 
+		deflection systems - works in 
+		opposition to the suns.</sp>
+         <sp spk="SKYWALKER">
+		Then they will show up on our 
+		screens at sunrise.  They'll 
+		attack before that.</sp>
+         <sd>The general rushes into the outer chamber where Captain
+	Valor is waiting for him.</sd>
+         <sp spk="SKYWALKER">
+		Take the fastest landspeeder to 
+		Chathos.  Pick up Princess Zara -
+		and only Princess Zara.  Return by 
+		way of the Great Reef.  Most speed.</sp>
+         <sd>Valor exits and the general goes to an intercom and
+	pushes several buttons.</sd>
+         <sp spk="SKYWALKER">
+		Montross!</sp>
+         <sp spk="MONTROSS">
+		Sir!</sp>
+         <sp spk="SKYWALKER">
+		Full alert - everything!  Get the 
+		Royal Family back here.</sp>
+         <sp spk="MONTROSS">
+		The princess is at Chathos.  There 
+		are no transports...</sp>
+         <sp spk="SKYWALKER">
+		I've already sent Captain Valor for 
+		her!  Contact the King, first priority. 
+		He's probably still en route to Amsel.  
+		Use the scan com.  I'm on my way.</sp>
+      </scene>
+      <scene n="22">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The war room is on full alert.  Everyone is at attention
+	waiting for the command that will put each of them into 
+	action.  The general enters a communication center, 
+	followed by many aides.  Captain Montross and the com 
+	aide salute.</sd>
+         <sp spk="MONTROSS">
+		We're having a problem getting 
+		through, sir.  There is a great 
+		deal of interference.</sp>
+         <sp spk="PRUE">
+		It could be jamming.</sp>
+         <sp spk="SKYWALKER">
+		Try a surface link through Amsel.</sp>
+         <sd>The aides go back to the com-link system to try to get a 
+	line through to the King.</sd>
+         <sp spk="PRUE">
+		We should be able to spot them at 
+		sunrise.  That's not too far off.</sp>
+         <sp spk="SKYWALKER">
+		They'll attack with sunrise.  Until 
+		the King gives us the code to start 
+		the war computers, we'll just have 
+		to sit tight.</sp>
+         <sp spk="PRUE">
+		All units are on alert, sir.</sp>
+         <sp spk="SKYWALKER (to Montross)">
+		Have you made contact yet?  (to himself)  
+		This is one hell of a way to run a war.</sp>
+         <sp spk="PRUE">
+		Sir?</sp>
+      </scene>
+      <scene n="23">
+         <setting>COURTYARD - ACADEMY OF CHATHOS - TOWNOWI</setting>
+         <sd>A landspeeder roars into a courtyard of the academy at
+	Chathos.  Valor jumps out, and runs up to the large,
+	heavy doors of the academy.  They are locked.  He 
+	bangs madly on the carved metallic door until finally 
+	an old woman manages to swing it open.  Valor rushes 
+	past her into the main courtyard, where Princess Zara 
+	and her handmaiden, Mina, struggle with two large cases. 
+	They are followed by two very old matrons, dragging 
+	several more cases.</sd>
+         <sp spk="JUSTIN">
+		Forget the cases;  we've no time.</sp>
+         <sp spk="ZARA">
+		These are my things.  They must...</sp>
+         <sp spk="JUSTIN">
+		I said forget them, and hurry.</sp>
+         <sp spk="ZARA">
+		Just who do you think you are?</sp>
+         <sd>Valor grabs the princess by the arm, and hauls her to the
+	speeder.  Mina and the old women run after them.</sd>
+         <sp spk="ZARA">
+		I will not be treated like this!  You 
+		bring my things.  My father will have 
+		your head (etc.)</sp>
+         <sd>Zara struggles to break away from the young warrior's grasp, 
+	as he opens the door of the speeder.</sd>
+         <sp spk="JUSTIN">
+		Settle down!</sp>
+         <sd>When the door to the speeder is opened, Mina starts in, 
+	and Valor stops her.</sd>
+         <sp spk="JUSTIN">
+		You must stay.  Here, take the crest.</sp>
+         <sd>Captain Valor rips the royal crest from the princess' 
+	neck, and hands it to the startled handmaiden.  The old 
+	women gasp in horror.  The princess starts hitting 
+	Captain Valor with little result.</sd>
+         <sp spk="PRINCESS">
+		Mina's not staying.  I'm not leaving 
+		her.  You can't...</sp>
+         <sd>Valor punches her square on the jaw and knocks her cold. 
+	Mina is panic stricken, one of the old women faints, and 
+	another starts for Valor with a large staff.</sd>
+         <sp spk="JUSTIN">
+		She'll be all right.  I'm taking her 
+		to safety, as ordered.  You will wear 
+		the crest and continue as before.</sp>
+         <sd>The authority of Captain Valor's voice stops the old lady.  
+	He places the princess into the speeder, and maneuvers it 
+	out of the courtyard.  Mina puts on the crest as the speeder
+	races away from the academy.</sd>
+      </scene>
+      <scene n="24">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Queen Breha, Oeta and Puck are escorted into a rest area 
+	of the war room.  General Skywalker sits rigidly in a chair 
+	in the communications area, apparently asleep.</sd>
+         <sp spk="MONTROSS">
+		We've made contact, sir!</sp>
+         <sd>The general opens his eyes and takes the intercom mike.</sd>
+         <sp spk="KAYOS">
+		What is it, General?</sp>
+         <sp spk="SKYWALKER">
+		The Royal Starforce will attack on the 
+		rising of the sun.  My agent made it 
+		back.  I now have proof.  I need the 
+		war code.</sp>
+         <sp spk="KAYOS">
+		I'll relay it directly to the computer. 
+		Is Breha...?</sp>
+         <sp spk="SKYWALKER">
+		The Royal Family is safe.  Captain 
+		Valor has gone after Princess Zara.</sp>
+         <sp spk="KAYOS">
+		I'm on my way back.</sp>
+      </scene>
+      <scene n="25">
+         <setting>RED PLAINS - TOWNOWI</setting>
+         <sd>The small caravan of four speeders sits motionless on the 
+	vast red plains of Townowi.  The King returns the intercom 
+	to the pilot and takes a small metallic card from around 
+	his neck and gives it to the co-pilot.</sd>
+         <sp spk="KAYOS">
+		Send this sub-land, priority one.  
+		(to the pilot)  Get us back to 
+		CALVAS immediately!</sp>
+         <sd>The four speeders turn around and scream away in the
+	direction from which they came.   They pass a huge, ultra-
+	sleek powerplow which is planting green fungus in endless
+	furrows.  Two clay-covered farmers riding atop the pon-
+	derous machine watch the speeders disappear over the 
+	horizon.  The twin suns peek over the distant hillside. 
+	and make their way into the vivid green sky.  A bright 
+	object twinkling in early morning heavens  catches the 
+	eye of the older of the two farmers  and he brings the 
+	machine to a lumbering halt.  The younger farmer also 
+	notices the object  and stares into the green sky, shading 
+	his eyes to get a better view.</sd>
+         <sd>Suddenly there is a huge, bright atomic flash on the 
+	horizon.  A few moments later, a thunderous shaking, 
+	followed by high winds, tumbles the older farmer from his
+	perch.  A second flash on the opposite horizon brings 
+	another jolting earthquake, and the younger farmer col-
+	lapses, terror frozen on his face.</sd>
+      </scene>
+      <scene n="26">
+         <setting>READYROOM - SPACEPORT OUTPOST - TOWNOWI</setting>
+         <sd>Chaos - red scramble lights are flashing.  Alert horns 
+	and attack buzzers create an unbelievable cacophony. 
+	Air warriors, with the distinctive circle and cross 
+	medallion on their white space suits, scramble out of 
+	the low concrete readyroom, grabbing helmets and space-
+	packs as they race out of the door.</sd>
+      </scene>
+      <scene n="27">
+         <setting>ATTACK RUNWAY - SPACEPORT OUTPOST - TOWNOWI</setting>
+         <sd>Thirty pilots and navigators dash in unison to a line of
+	waiting two-man starships of the destroyer class.  Ground
+	crews scurry back and forth, loading last-minute armament
+	and unlocking power couplings.  PILOT LEADER, a rugged,
+	handsome boy  of twenty, gives his ground crew a signal 
+	that his is okay.  He has a winning smile and a distinctive 
+	scar along the side of his face.  His crew chief pats him 
+	on the back.</sd>
+         <sp spk="CHIEF">
+		Knock them all the way back to 
+		Granicus.</sp>
+         <sd>The canopy is closed and the powerful starship moves 
+	onto the runway.  Other crewmen say good-bye to their 
+	pilots, some grinning and others kidding - all with a 
+	great deal of hidden emotion.  The din of four dozen
+	retrorockets cuts through the uproar, and fifteen 
+	silver spacecraft leave the runway and disappear into 
+	the morning cloud cover.</sd>
+      </scene>
+      <scene n="28">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general stands before a giant display of the 
+	Townowian solar system.  Montross signals the general.</sd>
+         <sp spk="MONTROSS">
+		They're away, sir.  Fifteen from 
+		Gordon, twenty from Amsel.  All 
+		other spaceports were destroyed. 
+		The King hasn't arrived yet.</sp>
+         <sp spk="SKYWALKER">
+		Keep checking.  Put the starships 
+		intercom over the P.A.</sp>
+         <sd>The general sits at one of the intercom panels  and puts 
+	on a headphone.  A row of monitors is before him.  He 
+	turns to Montross.</sd>
+         <sp spk="SKYWALKER">
+		Where are they?</sp>
+      </scene>
+      <scene n="29">
+         <setting>SPACE - TOWNOWI IN ECLIPSE</setting>
+         <sd>The eerie reddish-yellow planet of Townowi slowly drifts
+	into view from total eclipse.  A small, bright speck, 
+	orbiting the planet, sparkles in the light of the twin 
+	suns.  The six deadly starships settle ominously into the
+	foreground, moving swiftly toward the orbiting speck.  As 
+	the sleek starships move closer, the orbiting speck is 
+	revealed to be a gargantuan space fortress.  The moon-
+	sized satellite fortress dwarfs the approaching fighters. 
+	Every few moments, explosions create blinding flashes on 
+	the planet's surface, as the fortress bombards the planet 
+	with a fusillade of lazer bolts.</sd>
+      </scene>
+      <scene n="30">
+         <setting>TOWNOWIAN STARSHIP - INTERIOR</setting>
+         <sd>Pilot Leader, in the first ship, signals to his navigator 
+	who sits in a small, isolated glass bubble to the rear of 
+	the craft.  General Skywalker is seen on one of many 
+	monitors.  A view of the space fortress is on another. 
+	The rest are filled with various computer readouts and
+	displays.  One of the other starships reports to Pilot 
+	Leader.</sd>
+         <sp spk="DEVIL SIX (intercom)">
+		Look at the size of that thing! 
+		Hey, Coelo, I hope you remembered 
+		to bring your pop gun, 'cause I 
+		think we caught us a big one this 
+		time.</sp>
+         <sp spk="PILOT LEADER">
+		Cut off, Devil Six.  Stand by.</sp>
+         <sp spk="SKYWALKER (monitor)">
+		It looks like they're still using 
+		the basic quad-tristation configura-
+		tion.  Use a "ranger defense." 
+		Concentrate on breath ports and lock 
+		areas.</sp>
+         <sp spk="PILOT LEADER">
+		Affirmative base.  Copy and transmit.
+		Devil Two, check your rotation plates.</sp>
+         <sp spk="DEVIL TWO">
+		Roger, Boss.  We're getting a thresh-
+		hold disturbance on gyro-three.</sp>
+         <sp spk="SKYWALKER (monitor)">
+		Switch over, Five.  Cover it! 
+		Devil pack, generate a spread six 
+		formation.  May the force of others 
+		protect you.</sp>
+         <sp spk="PILOT">
+		Settle in. Devil pack, stand by. 
+		Mark five, break off. Here we go! </sp>
+      </scene>
+      <scene n="31">
+         <setting>SPACE - TOWNOWIAN STARSHIP</setting>
+         <sd>Fuel pods are jettisoned.  The half-dozen fighters break 
+	off into a powerline attack on the huge fortress.  Multiple
+	lazer bolts streak from the starships, creating small 
+	explosions on the complex surface of the fort.</sd>
+      </scene>
+      <scene n="32">
+         <setting>INTERIOR MAIN CORRIDOR - ROYAL SPACE FORTRESS</setting>
+         <sd>The chaos of battle echoes through the vast corridors of 
+	the fortress.  Walls buckle and cave in, sucking debris 
+	and personnel into the vacuum of outer space.  Alarm 
+	sirens scream as soldiers scramble to large turbo-powered 
+	lazer gun emplacements.  Sergeants yell orders through the 
+	smoke and confusion.  Men and robots of various shapes and 
+	sizes run to their battle stations.</sd>
+      </scene>
+      <scene n="33">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The monitors with pictures from the starships suddenly go 
+	blank.  Technicians check channels as others in the war 
+	room silently listen to the action over the intercom. The
+	general remains calm but concerned.</sd>
+         <sp spk="PILOT LEADER (intercom)">
+		Tighten it up, Devil Two.  Tighten it up. 
+		Watch those towers.</sp>
+         <sp spk="DEVIL TWO ">
+		Heavy fire, Boss, twenty-three degrees.</sp>
+         <sp spk="PILOT LEADER">
+		I see it. Pull in.  We're picking up some 
+		interference.</sp>
+         <sp spk="DEVIL SIX">
+		Wow!  I've never seen such fire power.</sp>
+         <sp spk="PILOT LEADER">
+		Pull in, Devil Two.  Pull in! </sp>
+         <sp spk="DEVIL TWO ">
+		I'm all right, Boss.  I've got a target.</sp>
+         <sp spk="DEVIL SIX">
+		Theres too much action.  Get out!</sp>
+         <sp spk="PILOT LEADER">
+		Break off...acknowledge.  Devil Six, 
+		can you see Devil Two?</sp>
+         <sp spk="DEVIL SIX">
+		I've lost him.  There's a very heavy 
+		fire zone on this side.  My radar's 
+		jammed.</sp>
+         <sp spk="DEVIL FIVE">
+		He's gone....No, wait.  There he is.
+		Fin damage, but he's all right.</sp>
+         <sd>A sigh of relief sweeps across the war room.  The monitors 
+	flash on, then off again.</sd>
+         <sp spk="DEVIL FOUR (intercom)">
+		Watch your back, Boss!  Watch your 
+		back!!</sp>
+      </scene>
+      <scene n="34">
+         <setting>TOWNOWI STARSHIP</setting>
+         <sd>The speedy little fighters dart back and forth across the 
+	soft underbelly of the fortress, leaving a trail of des-
+	truction behind them.</sd>
+         <sp spk="PILOT LEADER">
+		Converge on south axis point, point three 
+		nine four.  It appears accessible.  I'm 
+		going to map the surface.  Devil Four, 
+		cover me.</sp>
+         <sd>Pilot Leader and Devil Four dive in unison through a forest 
+	of radar domes, antennae, and gun towers.  Devil Four fires 
+	into the protrusions as the two starships criss-cross the
+	surface of the fortress.  Suddenly, a dense barrage of 
+	lazerfire erupts from a tower, catching Devil Four broad-
+	side.  The spacecraft bursts into a million flaming pieces.
+	Pilot Leader reacts to the loss of his wing man, but con-
+	tinues on his mission.</sd>
+      </scene>
+      <scene n="35">
+         <setting>SUB-HALLWAY - ROYAL SPACE FORTRESS</setting>
+         <sd>Constant explosions rock the interior of the fortress.
+	Civilians, including women and children, scurry for safety 
+	in the panic-ridden hallways.  Two construction robots, 
+	A-2 and C-3, are blown, slipping and sliding across the 
+	hallway floor into some freight canisters.  Both robots 
+	are rather old and battered.  A-2 is a short (three feet) 
+	claw-armed triped.  His face is a mass of computer lights,
+	surrounding a radar eye.  C-3 is a tall, gleaming android of
+	human proportions.  He is thin, with a totally metallic 
+	surface.  The robots attempt to get out from under the
+	canisters, but rushing gas from a broken pipe keeps knocking
+	them over.</sd>
+         <sd>			 C-3
+		This is madness.  We're going to be 
+		destroyed.  I'm still not accustomed 
+		to space travel.</sd>
+         <sd>			 A-2
+		The external bombardment does appear 
+		to be concentrated in this area.  The 
+		structure has exceeded the normal 
+		stress quotient by point four, although 
+		there appears to be no immediate danger.</sd>
+         <sd>			 C-3
+		No immediate danger!  You're faulty. 
+		This is madness!</sd>
+         <sd>A-2 gives C-3 a sheepish look and clings to a siderail for 
+	dear life, as debris flies through the hallway.</sd>
+      </scene>
+      <scene n="36">
+         <setting>TOWNOWI STARSHIP</setting>
+         <sd>Devil Two, a young hotshot of about sixteen years, miracu-
+	lously dives his ship through a virtual wall of lazerfire, 
+	and blasts a huge radar disc into dust.  Devil Two signals 
+	his navigator, who lets out a whooping cheer as the craft 
+	veers into a victory roll.</sd>
+         <sp spk="PILOT LEADER">
+		Great moves, Devil Two.  Re-group at point 
+		two, zero one.  Coincide, Devil Six.</sp>
+         <sp spk="SKYWALKER">
+		Devil One, your map projection shows a 
+		weak point at south portal:  niner point 
+		six.  Concentrate the attack on that 
+		point.  Coordinate.
+		
+				 PILOT LEADER
+		I see it.  It looks good.</sp>
+         <sd>Devil Five and Devil Three bob and weave in formation 
+	toward a giant transformer jutting from the fort's 
+	surface.</sd>
+         <sp spk="DEVIL THREE">
+		I've got a... We're hit.  We're hit!</sp>
+         <sp spk="PILOT LEADER">
+		Eject...Eject.  Babs, Babs, do you read?</sp>
+         <sp spk="DEVIL THREE">
+		I'm okay.  I can hold it.  Clear me
+		a little, Devil Five.  Watch it! 
+		Watch it!</sp>
+         <sd>Devil Three wobbles a little, then drops away sharply,
+	plowing into a lazergun emplacement, causing a hideous 
+	series of chain reaction explosions.</sd>
+      </scene>
+      <scene n="37">
+         <setting>SUB-HALLWAY - ROYAL SPACE FORTRESS</setting>
+         <sd>A huge explosion rips a large hole in the ceiling of a sub-
+	hallway.  A-2 and C-3 are in a state of shock as they 
+	scramble through the rubble.  There is a constant sound of
+	creaking and snapping as the sections of the hallway re-
+	settle in the fortress superstructure.</sd>
+         <sd>			 A-2
+		You're a mindless, useless philosopher. 
+		Come on!  Let's go back to work;  the 
+		system is all right.</sd>
+         <sd>			 C-3
+		You overweight glob of grease.  Quit 
+		following me.  Get away!  Get away!</sd>
+         <sd>Suddenly, the hallway lurches, and a dead trooper falls
+	through a gaping hole in the ceiling.  The foot of a carcass 
+	is caught in the rubble and it hangs upside down, staring at 
+	the two robots.  A-2 grabs C-3 and they cling to each other 
+	in terror.</sd>
+         <sd>			 A-2
+		We're lost.  We're destroyed.</sd>
+         <sd>Three sharp blasts from an airhorn send the two androids 
+	running for cover in a burned-out doorway.  Five grim-
+	faced troopers riding small rocket platforms  pass the 
+	two mechanical men.</sd>
+      </scene>
+      <scene n="38">
+         <setting>GOVERNOR'S QUARTERS - ROYAL SPACE FORTRESS</setting>
+         <sd>The five troopers race through several hallways, and 
+	finally stop in front of an important-looking office 
+	complex.  Two officers dismount and enter the complex. 
+	They pass through several heavily guarded doorways 
+	until they reach the main chamber.  Seated behind a large
+	cluttered desk, surrounded by generals and attaches, is
+	Governor Horus.  General Vader paces in front of a row of 
+	blank monitors.  The two officers salute General Vader.</sd>
+         <sp spk="FIRST OFFICER">
+		All com-link power is out.  Twenty-
+		two transformer sections have been 
+		destroyed.  The situation is grave 
+		on all southern levels.  Com-link 
+		communication should be repaired 
+		shortly.</sp>
+         <sd>The officers salute, turn and leave the chamber.  The 
+	general turns to Governor Horus, who looks a little
+	worried.</sd>
+         <sp spk="VADER">
+		Don't look so worried.  Not even a 
+		Dai could penetrate this fortress.
+		We've already wiped out most of 
+		their forces.</sp>
+         <sp spk="HORUS">
+		If it goes on too long, we'll run 
+		over budget.  When do the landings 
+		begin?</sp>
+         <sp spk="VADER">
+		As soon as the attack has been 
+		broken:  not long.</sp>
+         <sd>A short, stocky attache salutes the general.</sd>
+         <sp spk="ATTACHE">
+		Contamination has set in on quadrants 
+		B-5 and R-4.  All sections are sealed. 
+		We've lost two major power stations 
+		in the southern quadrants.  That puts 
+		section 5-1 in serious trouble.</sp>
+         <sd>The general turns away in controlled anger and embarrass-
+	ment.</sd>
+      </scene>
+      <scene n="39">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general sits in a glass-enclosed computer station,
+	watching the battle progress on several monitors.  An 
+	officer enters and salutes the general.</sd>
+         <sp spk="OFFICER">
+		Analysis reports those ZQ configurations 
+		are definitely power transformers.  Every-
+		thing in the southern sectors of the 
+		fortress is out.</sp>
+         <sd>			 SKYWALKER</sd>
+         <sd>	I'm surprised they are still using exter-
+		nal power units.  It's a definite weak 
+		point.  Concentrate on searching for the 
+		main crosslink transformer.</sd>
+         <sd>The officer exits as Montross rushes in.</sd>
+         <sd>			 MONTROSS</sd>
+         <sd>	The senate has voted to end the war.</sd>
+         <sp spk="SKYWALKER">
+		They can't do anything without the 
+		King's approval, which gives us a 
+		little time.  Have you been able to 
+		regain contact with the King?</sp>
+         <sp spk="MONTROSS">
+		No, sir.  All ground communications 
+		are jammed.</sp>
+         <sp spk="SKYWALKER">
+		Send four men  from third squad  to 
+		meet the King  and escort him back. 
+		Let me know before he arrives.  Is 
+		Captain Valor back with the princess?</sp>
+         <sp spk="MONTROSS">
+		No, sir.  They're long overdue.</sp>
+         <sd>Pilot Leader checks in over the intercom.</sd>
+         <sp spk="PILOT LEADER">
+		All right, base one, we're in 
+		position.</sp>
+         <sd>An officer with headphones looks to the general.  He 
+	signals to attack.</sd>
+      </scene>
+      <scene n="40">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>All four starships dive in formation toward a main trans-
+	former area  flanked by several solar towers.</sd>
+         <sp spk="PILOT LEADER">
+		Hold your fire until we're within point 
+		zero five four.  Make it count.</sp>
+         <sd>Several ack-ack lazers begin to open fire on the approaching 
+	spacecraft.  The starships direct their fire at a large 
+	black transformer  which when hit  spurts bright blue and 
+	white electrical arcs.  One of the starships (Devil Five) 
+	explodes and careens out of formation, leaving an erratic 
+	trail of smoke, before eventually crashing into a solar 
+	panel.</sd>
+      </scene>
+      <scene n="41">
+         <setting>SUB-HALLWAYS - ROYAL SPACE FORTRESS</setting>
+         <sd>The impact of the exploding starship can be felt throughout 
+	the giant fortress.  The tall gleaming C-3 races through 
+	several corridors, yelling at A-2, who struggles vainly to 
+	keep pace with his stubby mechanical feet.</sd>
+         <sd>			 C-3
+		I don't care what you do, but I'm 
+		getting out.  All the power's out. 
+		Those explosions are coming from 
+		the reactor section.  This is the 
+		end. Abandon ship!</sd>
+         <sd>			 A-2
+		Our work - we can't leave!  It's 
+		desertion.  It's not possible. 
+		It's not possible.</sd>
+         <sd>			 C-3
+		Your programming is so limited. 
+		My first order is preservation. 
+		You stay.  I'm going to eject 
+		before the whole thing goes up.</sd>
+         <sd>C-3 breaks open the seal on an emergency lifepod.  A 
+	red warning light begins to flash, and a low hum is 
+	heard.  The lanky chrome android works his way into 
+	the cramped four-man craft.</sd>
+         <sd>			 A-2
+		These lifepods aren't for us. 
+		It's not right!</sd>
+         <sd>A new explosion, this time very close, sends dust and 
+	debris through the narrow passageway.  Flames lick at 
+	the two robots.  The runt-sized A-2 jumps  into the 
+	lifepod.</sd>
+         <sd>			 A-2
+		It's the end.  Eject.  Eject.</sd>
+         <sd>The safety door snaps shut, and the pod ejects from the
+	fortress.</sd>
+      </scene>
+      <scene n="42">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>The terrified androids in the lifepod speed away from 
+	the fortress  and pass the attacking starships.</sd>
+         <sp spk="DEVIL TWO">
+		Object approaching.  Attack bearing.</sp>
+         <sp spk="DEVIL FOUR">
+		It's a lifepod.  Forget it.  We've got...</sp>
+         <sd>Devil Four is hit by lazerfire, and disintegrates, leaving 
+	a trail of flaming particles.  The two remaining craft 
+	continue the assault.  Devil Two and Pilot Leader watch 
+	the remains of Devil Four disappear.  The general appears 
+	over one of the monitors.</sd>
+         <sp spk="SKYWALKER">
+		Analysis indicates transformer code 
+		zero three is the main relay.  Hit it, 
+		and the whole thing goes dead.</sp>
+         <sp spk="PILOT LEADER">
+		We're on our way.</sp>
+      </scene>
+      <scene n="43">
+         <setting>GOVERNOR'S QUARTERS - ROYAL SPACE FORTRESS</setting>
+         <sd>A row of monitors and the main overhead lights go on, and 
+	a trooper appears on one of the screens.</sd>
+         <sp spk="TROOPER">
+		Internal relays operative.  All 
+		power restored.  All contaminated 
+		areas sealed.</sp>
+         <sd>An officer appears on another monitor.</sd>
+         <sp spk="OFFICER">
+		Only two enemy craft remain operative. 
+		We calculate victory by zero three 
+		hundred.</sp>
+         <sd>General Vader switches to another monitor.</sd>
+         <sp spk="VADER">
+		Alert the invasion forces.  (turning 
+		to the governor)  The planet is ours. 
+		A three-hour war.  You expected 
+		longer.  Dai or not, we've beaten 
+		him, and the culture is intact.</sp>
+         <sp spk="HORUS">
+		A truly great prize for the kingdom. 
+		They have a treasure of biotic science. 
+		Genetics, cloning - they've added two
+		hundred years to a lifespan.  Remember, 
+		you must capture at least one member of 
+		the Royal Family alive.  The Townowi 
+		family has ruled this system for ten 
+		thousand years.  The people will follow 
+		no other.  If the royal line is broken, 
+		there is a good chance the entire 
+		population will destroy themselves and 
+		their knowledge before submitting to our 
+		rule.</sp>
+         <sd>The general is interrupted by a call on one of the 
+	monitors.</sd>
+         <sp spk="OFFICER (on monitor)">
+		We've received a message from the 
+		planet.</sp>
+      </scene>
+      <scene n="44">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker watches a giant computer display of 
+	the space fortress mapped by the starships.  An aide
+	approaches.</sd>
+         <sp spk="AIDE">
+		Sir!  The King's convoy has destroyed 
+		at Caldin.  All the bodies were con-
+		taminated.</sp>
+         <sp spk="SKYWALKER">
+		I will audience with the Queen. 
+		Who knows of this?</sp>
+         <sp spk="AIDE">
+		Many.  It came through civilian 
+		sources.</sp>
+         <sp spk="SKYWALKER">
+		Confine Senator Sandage to his 
+		quarters.  Use any pretext.  Where 
+		is the senator now?</sp>
+         <sd>Sandage and several other senators enter the computer
+	station.</sd>
+         <sp spk="SANDAGE">
+		Right here, General.  It's over. 
+		We've already relayed peace terms 
+		to the kingdom, and they've been 
+		accepted.  Your war has ended.</sp>
+         <sd>The general is angry and stands pointing at the senators.
+	They jump back, as if the general were pointing a gun at
+	them.</sd>
+         <sp spk="SKYWALKER">
+		Senator, this war isn't over.  It's 
+		just begun.  I take my commands 
+		from the Royal Family.</sp>
+         <sp spk="SANDAGE">
+		The Queen concurs.  I have her 
+		written decree.  It is to be 
+		implemented immediately.  I order 
+		you to cease the attack.</sp>
+         <sp spk="SKYWALKER">
+		Not likely.</sp>
+         <sp spk="SANDAGE">
+		Treason?  Revolution?  The people 
+		won't follow you, General, nor will 
+		your troops.  I suggest you follow 
+		your orders.</sp>
+         <sd>General Skywalker stands angrily pondering the situation.
+	Sandage and the other senators are tense, a little afraid
+	that he might cut them down on the spot.</sd>
+         <sp spk="SANDAGE">
+		Well, General?</sp>
+      </scene>
+      <scene n="45">
+         <setting>LIFEPOD - GREEN SKY OVER TOWNOWI</setting>
+         <sd>The reddish-yellow mass of Townowi seems to engulf the 
+	tiny lifepod containing the two fleeing androids, as it 
+	descends into the greenish atmosphere.</sd>
+         <sd>			 A-2
+		It's desertion.  They'll destroy us. 
+		How could this happen?</sd>
+         <sd>			 C-3
+		That's funny.  The damage doesn't 
+		look as bad from out here.</sd>
+      </scene>
+      <scene n="46">
+         <setting>TOWNOWI STARSHIPS</setting>
+         <sd>Pilot Leader and Devil Two make a second dive on the now
+	smoldering transformer area.  All firing from the fortress 
+	suddenly stops.  Pilot Leader looks back to his navigator, 
+	who is equally puzzled.  The two fighters continue to attack 
+	the now silent fortress.</sd>
+         <sp spk="DEVIL TWO">
+		I don't get it.  What do you 
+		think, Boss?</sp>
+         <sd>General Skywalker appears on the monitors.</sd>
+         <sp spk="SKYWALKER (with difficulty)">
+		Base one to Devil Leader, scramble code 
+		niner.  Break your attack and return to 
+		base.  Repeat, break your attack. 
+		Confirm.</sp>
+         <sp spk="PILOT LEADER">
+		They're hurt, sir, but they still have 
+		power.  We should finish...</sp>
+         <sp spk="SKYWALKER">
+		Break off.  The war is over.  Run on 
+		white lights.  Get back here, Mace. 
+		We're going to need you.</sp>
+         <sp spk="PILOT LEADER">
+		Confirmed base one.  We're on our way. 
+		Did you copy, Devil Two?</sp>
+         <sp spk="DEVIL TWO">
+		Roger, Boss.</sp>
+         <sd>The two starfighters break off the attack and start back
+	toward the planet.  Without warning, the fort directs
+	concentrated fire at the two starfighters.  Devil Two
+	instantly bursts into flames, then disintegrates.  Pilot
+	Leader's tail section is hit, and the ship pinwheels 
+	toward the planet.  Blood covers Pilot Leader's immobile 
+	face.</sd>
+         <sp spk="PILOT LEADER'S NAVIGATOR">
+		We're under fire.  They're still shooting.  
+		I thought it was over.  We're hit!  We're 
+		hit!  Pilot is dead.... Ejecting.</sp>
+         <sd>The dead Pilot Leader is jettisoned free of the craft, but 
+	the navigator's eject panel is dead.  He struggles with it, 
+	then bangs on the canopy to no avail.  The navigator is 
+	still trapped in the craft when it explodes, leaving only 
+	a puff of pink smoke reflected in the rim light of the 
+	planet.</sd>
+      </scene>
+      <scene n="47">
+         <setting>DESERT NEAR OUTPOST - TOWNOWI</setting>
+         <sd>Pilot Leader's dead body drifts toward his arid mother-
+	planet.  Automatic rockets kick in occasionally to direct 
+	and soften the landing.  Two gray-clad troopers stand next 
+	to a military landspeeder, watching the descending air-
+	warrior through electrobinoculars.  Mace's corpse hits the
+	ground rather hard, creating a whirlwind of dust, and the 
+	two troopers rush over to the pilot.  The younger of the 
+	two troopers, a young boy in his teens, cradles the dead 
+	starpilot in his arms and begins to cry.</sd>
+      </scene>
+      <scene n="48">
+         <setting>WAR ROOM - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker sits alone, meditating in the deserted 
+	war room.  Montross approaches the contemplative general.</sd>
+         <sp spk="MONTROSS">
+		No sign of Captain Valor or the 
+		princess.  There was much damage 
+		in that area.  The Queen will see 
+		you at ten hundred.</sp>
+         <sd>The general doesn't reply.</sd>
+      </scene>
+      <scene n="49">
+         <setting>ASSEMBLY - DEPARTURE AREA - ROYAL SPACE FORTRESS</setting>
+         <sd>General Vader stands behind a row of men at computer 
+	control panels overlooking a huge assembly of troop, 
+	tanks, and transports. A commander reports to the general.</sd>
+         <sp spk="COMMANDER">
+		All enemy craft destroyed.  First 
+		and fifth division troops and 
+		equipment standing by.</sp>
+         <sd>The general gives a sly smile of approval and takes a
+	microphone from one of the computer technicians.  He 
+	speaks to the troops and pilots waiting in their huge 
+	war machines for the invasion order.</sd>
+         <sp spk="VADER">
+		The war is won.  With the conquering 
+		of this  system, we have ushered in a 
+		new millennium for the New Galactic 
+		Kingdom which will echo throughout the 
+		universe.  Our reward is the knowledge 
+		this system possesses.  This planet 
+		must be controlled with a minimum 
+		of force, but you must not think 
+		lightly of this enemy.  They have 
+		exacted a heavy toll.  Today you will 
+		make the kingdom complete.  Do so with 
+		pride and care.</sp>
+         <sd>Vader puts down the mike, and turns to his commander.</sd>
+         <sp spk="VADER">
+		Let the invasion begin.</sp>
+      </scene>
+      <scene n="50">
+         <setting>EDGE OF THE DUNE SEA - TOWNOWI</setting>
+         <sd>KUROLAND, or "No-Man's Land," where the rugged desert 
+	mesas meet the foreboding dune sea.  The two helpless astro 
+	robots kick up clouds of dust as they clumsily work their 
+	way across the desert coastline.  The short A-2 struggles 
+	desperately to keep up with the long-legged C-3.</sd>
+         <sd>			 A-2
+		It's not possible.  We're not 
+		built for this.  You're nothing 
+		more than a dim-witted, emotion
+		brained intellectual.  Why you 
+		were created is beyond my logic 
+		systems.  Thanks to you, we're 
+		now deserters, and will probably 
+		be destroyed on sight.  And on 
+		top of that, you're going the 
+		wrong way!  All this filth is 
+		getting...</sd>
+         <sd>The towering C-3 stops short and turns on the blabbering 
+	mechanical runt.</sd>
+         <sd>			 C-3
+		I've had enough of you, you 
+		pragmatic, nearsighted scrap 
+		pile.  You go your own way.</sd>
+         <sd>He picks up the tiny robot and tosses him several feet into 
+	a large sand dune.  C-3 starts off in the direction of the 
+	dune sea.  A-2 struggles to his feet and shakes a metallic 
+	claw arm at his disappearing ex-partner.</sd>
+         <sd>			 A-2
+		You'll be malfunctioning within a 
+		day.  You're going the wrong way, 
+		but your way is always the wrong 
+		way.</sd>
+         <sd>C-3 stops and yells to the smaller android.</sd>
+         <sd>			 C-3
+		And don't let me catch you following 
+		me, begging for help, because you 
+		won't get it from me.</sd>
+         <sd>A-2s reply is a rather rude sound, which only an electronic 
+	person could make.  He turns and trudges off in the opposite 
+	direction into the rocky desert mesas.</sd>
+      </scene>
+      <scene n="51">
+         <setting>DUNE SEA - TOWNOWI</setting>
+         <sd>C-3, hot and tired, struggles up over the ridge of the dune, 
+	only to find more dunes, which seem to go on for endless 
+	miles.  He looks back in the direction he came.</sd>
+         <sd>			 C-3
+		You little malfunctioning twerp. 
+		This is all your fault.  You tricked
+		me into going this way, but you'll do 
+		no better!</sd>
+         <sd>He sits in a huff of anger and frustration, knocking the 
+	sand from his joints.</sd>
+      </scene>
+      <scene n="52">
+         <setting>DESERT MESA - TOWNOWI</setting>
+         <sd>A-2 stumbles through a narrow canyon until he climbs over 
+	a small boulder and sees before him a sight he first thinks 
+	is a mirage.  Nestled in a rock formation is a deserted 
+	landspeeder.  Once the little robot is convinced that he 
+	is alone, he approaches the battered speeder and begins to 
+	analyze it.  He climbs into the pilot's seat  and attempts 
+	to start the unfamiliar transport.  He hears a sound and 
+	stops for a moment.  He sees nothing, so he continues to 
+	fiddle with the control panel until the speeder lurches 
+	forward with a start, banging into a large rock.  The 
+	stubby android is shaken, but neither he  nor the speeder 
+	seems to be damaged.</sd>
+         <sd>Shivers run down A-2's metal spine, and again he has an
+	eerie feeling that he is being watched.  He slowly looks
+	around  and sees a large man, Captain Valor, standing 
+	directly behind him.  He is startled, then terrified.</sd>
+         <sp spk="JUSTIN">
+		Where is your master?</sp>
+         <sd>The little robot clicks and rattles, but doesn't speak.</sd>
+         <sp spk="JUSTIN (Cont.)">
+		Can't you speak?  How do you relate 
+		your data?  You're of Karollian manu-
+		facture.  You should be able to talk. 
+		Are you damaged?</sp>
+         <sd>Valor pokes at the machine  but doesn't see any damage. 
+	A-2 eyes him suspiciously.  The robot turns with a start 
+	and discovers a young girl, Princess Zara, has been 
+	standing next to him for some time.</sd>
+         <sp spk="PRINCESS (sarcastically)">
+		Well, General, who's your friend?</sp>
+         <sp spk="JUSTIN">
+		I don't know.  He doesn't seem to 
+		be able to talk.  Damaged, probably...
+		Jettisoned from a damaged ship...</sp>
+         <sp spk="PRINCESS">
+		What do you intend to do with it?</sp>
+         <sp spk="JUSTIN">
+		We'll take it with us.  Could be a 
+		storehouse of valuable information.</sp>
+         <sd>Justin guides the android into the small luggage area 
+	behind the front seat, then hops into the driver's seat.</sd>
+         <sp spk="PRINCESS">
+		I don't want to ride with that thing. 
+		I order you to destroy it immediately.</sp>
+         <sp spk="JUSTIN">
+		Get in!  We've got to hurry if we're 
+		going to get across the "dunehedge" 
+		by nightfall.  You're coming, one way 
+		or the other.  Will you join us peace-
+		ably?</sp>
+         <sd>The princess reluctantly gets into the speeder, and it starts 
+	with a jolt.</sd>
+      </scene>
+      <scene n="53">
+         <setting>LANDSPEEDER - DESERT MESAS - TOWNOWI</setting>
+         <sd>The speeder flies along, a foot or so above the landscape.</sd>
+         <sp spk="PRINCESS">
+		You are such a barbarian.  I'll have 
+		my father cut you into little pieces 
+		when we get back...and I'll take 
+		pleasure in feeding you to the Gonthas,
+		a little bit each day.  I may save your 
+		eyes though.  I'll have them petrified 
+		and made into a necklace.</sp>
+         <sp spk="JUSTIN">
+		Your sweetness is only surpassed by your 
+		beauty.  Just try to remember, I'm only 
+		following orders.</sp>
+         <sp spk="PRINCESS">
+		To beat and abuse me?
+					 
+				 JUSTIN
+		I'm afraid I've only learned one way 
+		to treat wild animals.</sp>
+         <sd>A-2 thrashes about, trying to relieve the pressure on his	 
+	cramped legs.</sd>
+         <sp spk="PRINCESS">
+		You stay out of this.</sp>
+      </scene>
+      <scene n="54">
+         <setting>DUNE SEA</setting>
+         <sd>C-3 struggles to the top of a large dune.  He is dirty and 
+	hot.  His plight seems hopeless.  He searches the horizon 
+	for any sign of life.  A glint of reflected light in the 
+	distance  reveals an object speeding toward him.  The 
+	chrome android waves frantically  and yells at the 
+	approaching speeder.  The sleek landspeeder races past 
+	him about a hundred yards away.  He runs after it, 
+	screaming in desperation, until he stumbles and falls 
+	head over heels down an enormous sand dune.  Silently,	 
+	the speeder sweeps around in a circle and stops behind 
+	the immobile robot.  Valor jumps out of the speeder and 
+	is quickly followed by A-2.</sd>
+         <sp spk="PRINCESS">
+		We're in a hurry, remember!  If 
+		you're going to stop for every 
+		unfortunate along the way, we'll 
+		never get back.  We're lucky you 
+		got the speeder running as it is.</sp>
+         <sd>A-2 waddles up to his fallen partner and starts pulling on 
+	his leg, then runs up and starts pulling on his arm.</sd>
+         <sd>			 A-2
+		Function!  Function!  It's me. 
+		Come on, function.</sd>
+         <sp spk="VALOR">
+		Well, my little friend, you've 
+		found your tongue.</sp>
+         <sd>			 A-2
+		We must help him.  We've been 
+		lost.</sd>
+         <sp spk="VALOR">
+		Where did you come from?</sp>
+         <sd>The little robot runs around his fallen partner giving him 
+	small electric charges from his claw hand.  C-3 shudders 
+	from head to toe, then regains consciousness.</sd>
+         <sd>			 C-3
+		What happened?</sd>
+         <sd>			 A-2
+		You're overheated.</sd>
+         <sp spk="VALOR">
+		Where did you come from?</sp>
+         <sd>			 A-2
+		We were jettisoned from six twenty-
+		nine P.R. one.</sd>
+         <sp spk="VALOR">
+		I'm unfamiliar with that ship. 
+		What type is it?</sp>
+         <sd>			 C-3
+		It's a class M station, not a 
+		conventional craft.</sd>
+         <sd>C-3 then stands and shakes the young Dai's hand.</sd>
+         <sd>			 C-3
+		I'm C-3, Human-Cyborg Relations.  
+		Your kindness is greatly appreciated.</sd>
+         <sd>Captain valor and the two robots walk back to the speeder.</sd>
+      </scene>
+      <scene n="55">
+         <setting>LANDSPEEDER - DESERT CANYON - TWONOWI</setting>
+         <sd>Both A-2 and C-3 are stuffed into the tiny luggage com-
+	partment.  It is late in the day when the speeder rumbles 
+	to a stop in a small desert canyon surrounded by steep 
+	cliffs and broken boulders.</sd>
+         <sp spk="JUSTIN">
+		We'll rest here.</sp>
+         <sd>			 C-3
+		At last.  The transport is welcome 
+		but my joints are frozen.</sd>
+         <sd>Everyone climbs out of the low-slung speeder.  Valor
+	watches the two androids as they stretch their mechanical 
+	limbs.</sd>
+         <sd>			 A-2
+		I've got a bad case of dust contami-
+		nation.  I can barely move.</sd>
+         <sd>			 C-3
+		What a foresaken place this is.  We 
+		seem to be made to suffer.  It's 
+		our lot in life.  Sir, could you 
+		tell...?</sd>
+         <sd>C-3 turns and notices that Valor and the princess have 
+	disappeared.  He looks all around.</sd>
+         <sd>			 C-3
+		Where did they go?  They've dis-
+		appeared.</sd>
+         <sd>			 A-2
+		Maybe they were attacked. 
+		I sense danger!</sd>
+      </scene>
+      <scene n="56">
+         <setting>HIDDEN FORTRESS ENTRANCE - DESERT CANYON - TOWNOWI</setting>
+         <sd>Captain Valor and Princess Zara hurry through a maze of 
+	large boulders  until they reach a sheer rock face.  Valor 
+	looks around to see if they were followed.  Suddenly  a 
+	large section of the rock slides away  revealing a well-
+	lit corridor carved out of the rock.  They enter  and are 
+	greeted by two jubilant guards.  Valor gives them some 
+	orders and points in the direction of the speeder.  The 
+	secret rock door silently slides closed.</sd>
+      </scene>
+      <scene n="57">
+         <setting>MAIN HALLWAY - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor and the princess are greeted by General 
+	Skywalker and Montross.  They bow before the princess.</sd>
+         <sp spk="PRINCESS (angrily pointing at Valor)">
+		General, I want you to do something 
+		with this...this barbarian.  Where's 
+		my father?</sp>
+         <sp spk="GENERAL">
+		The King is dead, Your Highness.</sp>
+         <sd>All anger suddenly drains from the princess. She almost
+	timidly asks the next question.</sd>
+         <sp spk="PRINCESS">
+		My mother?... and brothers?</sp>
+         <sp spk="GENERAL">
+		She's here.  She's safe, so are your 
+		brothers.  They're in the main chamber.</sp>
+         <sd>Zara, now looking more like a frightened young girl than 
+	a vindictive princess, runs down the hallway toward the 
+	main chamber.  She vainly attempts to hold back the tears.</sd>
+      </scene>
+      <scene n="58">
+         <setting>DESERT CANYON - TOWNOWI</setting>
+         <sd>The two puzzled androids sit on the landspeeder, pondering 
+	the disappearance of their saviour.</sd>
+         <sd>			 C-3
+		Do you suppose we're in danger?</sd>
+         <sd>			 A-2
+		The logic of this environment 
+		escapes me.</sd>
+         <sd>As night begins to fall, and the shadows begin to lengthen, 
+	the two robots begin to get a little edgy.  The sound of 
+	approaching feet startles A-2, and he ducks behind his 
+	taller friend.  Two guards approach the robots.</sd>
+         <sp spk="GUARD">
+		You will remain calm, and you will 
+		remain here.</sp>
+         <sd>			 C-3
+		Certainly. I'm C-3, Human Cyborg 
+		Relations.  Your kindness is greatly 
+		appreciated.</sd>
+         <sd>A-2 sits rather suspiciously behind his extroverted friend.</sd>
+      </scene>
+      <scene n="59">
+         <setting>ROYAL CHAMBER - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>General Skywalker bows low before Princess Zara.  She sits 
+	on a raised platform, dressed in the royal robes of a 
+	planetary ruler.  The Queen sits off to one side on a
+	smaller platform.  The princess waits for a few moments 
+	before she allows the general to rise.</sd>
+         <sp spk="QUEEN">
+		The senate has been corrupted.</sp>
+         <sp spk="SKYWALKER">
+		They cannot rule without your 
+		wish.</sp>
+         <sp spk="QUEEN">
+		I rule by marriage.  With the King 
+		dead, I am not strong enough to stop 
+		them.  Zara is now the true Queen. 
+		She must be protected.  The line must 
+		be preserved.  I am placing the 
+		future of our people in your hands. 
+		You must deliver Zara and her 
+		brothers to the OPHUCHI System. 
+		They will be safe there.  General, 
+		you must understand.  I had no 
+		alternative but to condone an end 
+		to the hostilities.  I deeply 
+		believe your campaign could have 
+		been successful, but there are 
+		things that...</sp>
+         <sp spk="SKYWALKER">
+		I understand, Your Highness.</sp>
+         <sp spk="QUEEN">
+		The chrome companies on Ophuchi have 
+		offered to supply you with the men 
+		and ships necessary to return Zara 
+		to the throne.</sp>
+         <sp spk="SKYWALKER">
+		Can the chrome companies be trusted?</sp>
+         <sp spk="QUEEN">
+		The price for their cooperation is 
+		high.  It is waiting for you in 
+		Med Center blue.  Guard it as you 
+		would the princess herself.  No-one 
+		must know of this mission.  There 
+		are those among the trusted who 
+		would wish us ill.  Take only two 
+		of your best officers with you, the 
+		most loyal.  May the force of others 
+		be with you.</sp>
+         <sp spk="ZARA">
+		Mother, you must not stay.</sp>
+         <sp spk="QUEEN">
+		I am too old for such a journey.  The 
+		kingdom already controls the space-
+		port cities.  You have a long way to 
+		travel.  It won't be easy.</sp>
+         <sp spk="SKYWALKER">
+		We will have to travel in disguise. 
+		I must have full command.  No-one 
+		can suspect wealth or royal training. 
+		I fear the new Queen will not stand 
+		for this.</sp>
+         <sp spk="ZARA">
+		Do not put words into my mouth. 
+		I will stand for what is necessary.</sp>
+         <sd>The general simply smiles.</sd>
+      </scene>
+      <scene n="60">
+         <setting>SUB-HALLWAY - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general walks briskly through an isolated hallway,
+	closely followed by Montross.</sd>
+         <sp spk="SKYWALKER">
+		How is Captain Oxus recovery?</sp>
+         <sp spk="MONTROSS">
+		Very good;  he's up and around.</sp>
+         <sp spk="SKYWALKER">
+		Fine!  Have Oxus and...ah, Captain 
+		Valor report at zero three hundred. 
+		I want two converted transports,  
+		agricultural type, and two days' 
+		provisions, travel papers, weapons. 
+		Contact Han Solo at the Gordon 
+		spaceport.  I'll talk to him...with 
+		speed!</sp>
+         <sd>Montross turns and rushes down another hallway.</sd>
+      </scene>
+      <scene n="61">
+         <setting>MEDICAL CENTER BLUE - UNDERGROUND FORTRESS - TOWNOWI</setting>
+         <sd>The general enters a stark white waiting area filled 
+	with scholarly looking gentlemen.  An attendant greets 
+	General Skywalker and takes him into a small observation 
+	chamber overlooking a large operating theatre. An 
+	elderly doctor greets him.</sd>
+         <sp spk="DOCTOR">
+		Good to see you, General.  I'm afraid 
+		we're not quite ready yet.  Thank God 
+		you'll be the one taking them, though.</sp>
+         <sd>An attendant brings in one of the scholars from the waiting 
+	area and places him on a large operating table surrounded 
+	by strange looking equipment.  An ominous looking clamp is 
+	placed on the man's head.</sd>
+         <sp spk="SKYWALKER">
+		How many are going?</sp>
+         <sp spk="DOCTOR">
+		Thirty-three of the greatest scientific 
+		minds in our system...A high price for 
+		freedom.</sp>
+         <sp spk="SKYWALKER">
+		Thirty-three scientists!  Transporting 
+		a group that size, undetected... I don't...</sp>
+         <sp spk="DOCTOR">
+		Don't worry, General.  All you'll be 
+		taking are their minds.</sp>
+         <sd>The doctor moves over to a safe-like cabinet guarded by 
+	two attendants.  The doctor gingerly picks up a small 
+	clear vial filled with gray fluid.  It has a label which
+	reads:  Faubun, Astro-dynamics.  In the background , the 
+	scholar on the operating table is undergoing a form of
+	mechanized brain surgery.</sd>
+         <sp spk="SKYWALKER">
+		"Bloodory's distillation?"</sp>
+         <sp spk="DOCTOR">
+		Yes.  It has been greatly perfected. 
+		The brain is condensed into five 
+		ounces of fluid.  Cloning cell samples 
+		are included so that a structural 
+		duplicate of the scientist can be 
+		reproduced.  When the  duplicate child 
+		reaches the age of six, he or she 
+		begins a series of injections of the 
+		brain fluid.  By the age of ten years, 
+		they have received all the knowledge 
+		and memory of an experienced scientist:  
+		an old mind in a young body.  We have 
+		prepared a special shock belt to carry 
+		the vials.</sp>
+         <sd>In the background, the limp body of the scholar on the
+	operating table is removed, and another scientist is 
+	escorted into the operating threatre.  Dr. Bloodory, a 
+	portly doctor in his forties, enters the room and shakes 
+	hands with the general.</sd>
+         <sp spk="DOCTOR">
+		General, this is Dr. Bloodory. 
+		He'll be making the trip with 
+		you.</sp>
+         <sp spk="BLOODORY">
+		It's an honor to meet you, General. 
+		I'm sure I couldn't be in safer 
+		hands.
+					
+				 SKYWALKER
+		The chrome companies are exacting 
+		a high price indeed!  Politics will 
+		be the ruin of us all.</sp>
+         <sp spk="BLOODORY">
+		Careful.  If we could rid ourselves 
+		of the politicians, generals would 
+		no longer be necessary.</sp>
+         <sp spk="DOCTOR">
+		We should be ready by zero three 
+		hundred.</sp>
+         <sd>The doctors exit, leaving the general alone to watch the 
+	huge machine extract another brain.</sd>
+      </scene>
+      <scene n="62">
+         <setting>SPACEPORT - OBSERVATION DECK - TOWNOWI</setting>
+         <sd>Governor Horus, General Vader walk down a boarding ramp to 
+	an observation deck overlooking the conquered city of 
+	Gordon.  They are followed by a number of aides and officers 
+	from the royal fleet.  Below them, air tanks and other 
+	military equipment and supplies are being unloaded.</sd>
+         <sp spk="VADER">
+		Not much of a planet.</sp>
+         <sp spk="HORUS">
+		Darth, you've done well.  Do you 
+		think you will have the Royal 
+		Family by nightfall?</sp>
+         <sp spk="VADER">
+		An advance expedition is already 
+		on its way to their underground 
+		hideaway.  They should reach it 
+		by nightfall, but only if this 
+		Count Sandage can be trusted.</sp>
+         <sp spk="HORUS">
+		A man hungry for power can always 
+		be trusted... to betray those in 
+		power.  I'm sure his information 
+		is correct.</sp>
+      </scene>
+      <scene n="63">
+         <setting>HIDDEN FORTRESS CANYON -TOWNOWI</setting>
+         <sd>The huge rock face of the canyon opens, and two shabby
+	agricultural landspeeders are pushed into the late after-
+	noon sun.  A-2 and C-3 stand on the far side of the canyon 
+	with their guards  watching in amazement.  The general and 
+	Captain Valor walk behind the men pushing the landspeeder.</sd>
+         <sp spk="SKYWALKER">
+		We'll take them with us.  They 
+		know more about that fortress 
+		than any ten men.  They will be 
+		very useful.</sp>
+         <sp spk="JUSTIN">
+		Can they be trusted?</sp>
+         <sp spk="SKYWALKER">
+		Loyalty can't be programmed. 
+		They can be trusted never to 
+		harm a living creature, and to 
+		always give accurate information
+		as they know it, to anyone who 
+		asks.  You just have to remember 
+		not to tell them anything that 
+		you don't want to fall into the 
+		wrong hands.</sp>
+         <sd>The general approaches the two robots. A-2 shyly moves
+	around his taller companion.</sd>
+         <sp spk="SKYWALKER">
+		Greetings.  I'm Luke:  Agricultural 
+		Engineering.  We're going to be 
+		travelling together.  You're going 
+		with us to help set up a hortastation 
+		on KANDALAR.</sp>
+         <sd>C-3 shakes hands with the general.</sd>
+         <sd>			 C-3
+		I'm C-3:  Human Cyborg Relations.  
+		Your kindness is greatly appreciated.</sd>
+         <sd>C-3 and the general both look down at A-2.  C-3 gives the 
+	smaller android a little kick.</sd>
+         <sd>			 A-2
+		A-2:  Fusion Repair.</sd>
+         <sp spk="SKYWALKER">
+		Load them into one of the speeders.</sp>
+         <sd>Captain Oxus, walking with a slight limp, emerges from the 
+	underground fortress with the Royal Family.  A small group 
+	of guards and aides are lined up, standing at attention. 
+	The two young princes, Oeta and Puck, hug and kiss their 
+	mother good-bye, then jump into the back of the larger 
+	four-man speeder.  The princess bows before her mother, 
+	then embraces her.  Tears roll down her cheeks.  Her 
+	mother wipes them away.</sd>
+         <sp spk="QUEEN">
+		You must learn strength.</sp>
+         <sd>The princess turns and moves to the larger speeder where 
+	she is helped aboard by Captain Valor.</sd>
+         <sp spk="PRINCESS (fuming)">
+		I don't need your help, thank you.</sp>
+         <sd>She gives the general an angry look.</sd>
+         <sp spk="SKYWALKER">
+		I'm afraid he's necessary.</sp>
+         <sd>A commotion erupts at the mouth of the underground fortress. 
+	Count Sandage, several senators and ten to twelve troopers 
+	rush into the canyon and block the speeders.</sd>
+         <sp spk="SANDAGE">
+		Where are you going?  What is 
+		this?</sp>
+         <sd>In one quick movement the general moves between Sandage and 
+	the Queen.  Oxus and Valor assume defensive positions in 
+	front of the princess and her brothers.</sd>
+         <sp spk="QUEEN">
+		Zara and the boys are being taken to 
+		safety.  It is my wish.</sp>
+         <sp spk="SANDAGE">
+		The King has assured their safety.  
+		They must stay.</sp>
+         <sp spk="QUEEN">
+		It is not my wish....</sp>
+         <sp spk="SANDAGE">
+		General, you've gone too far this 
+		time.  (to the troops)  Arrest him.</sp>
+         <sd>Five troops start to move on the general, as Sandage draws 
+	his lazerpistol.  Before anyone can complete his action, the 
+	general ignites his lazersword and cuts the senator in two. 
+	He drops to the ground in a heap, and the approaching troops 
+	stop in their tracks.</sd>
+         <sp spk="QUEEN">
+		Stop this!</sp>
+         <sd>The general, Valor, and Oxus replace their swords, and bow 
+	low to the Queen.  All of the troops, senators, and aides 
+	do the same.  The formalness of the occasion is broken when 
+	the Queen embraces the general.  She then turns and embraces 
+	each of the captains.  They are both flustered, and somewhat 
+	embarrassed.</sd>
+         <sp spk="QUEEN">
+		May the force of others be with you.</sp>
+         <sd>The general and his captains head for the speeders, while 
+	the Queen and all the others return to the underground 
+	fortress.</sd>
+      </scene>
+      <scene n="64">
+         <setting>DESERT BLUFF - TOWNOWI</setting>
+         <sd>The two speeders edge their way onto a bluff overlooking the 
+	hidden fortress canyon.  They stop for one last reflective 
+	moment.  Forced to leave their closest friends and relatives, 
+	the group is deeply moved.  The two robots, for the most 
+	part, are puzzled.  Suddenly, there is a huge atomic flash, 
+	followed by a loud rumble, and the entire canyon collapses 
+	into a large crater.  The group quietly watches the dust 
+	settle.  The hidden fortress and all its inhabitants have 
+	been destroyed.  The general watches the princess, who 
+	appears to take it well.</sd>
+         <sp spk="SKYWALKER">
+		It was the only way we could be 
+		safe from treachery.</sp>
+      </scene>
+      <scene n="65">
+         <setting>DUNE SEA - TOWNOWI</setting>
+         <sd>The two sleek landspeeders glide effortlessly through the 
+	vast hills and valleys of the dune sea.  At the base of the 
+	towering ridge, the four-man speeder stops.   The smaller 
+	speeders, with Valor and the two robots, makes its way to the 
+	top of the ridge.  Captain Valor stops the speeder just short 
+	of the top of the ridge.  He gets out and continues the rest 
+	of the way on foot.  The young captain peeks over the ridge 
+	into the canyon below.  Muted sounds and large dust clouds 
+	rise from the canyon floor.  Valor immediately ducks back 
+	behind the ridge with an amazed look on his face.  He 
+	quickly returns to the speeder  and picks up the intercom.</sd>
+         <sp spk="JUSTIN">
+		Sir, you'd better take a look at 
+		this.  But come easy.</sp>
+         <sd>The four-man speeder starts with a crack  and slowly moves 
+	up the side of the imposing dune.  It stops next to the 
+	smaller speeder.  The general and Oxus get out and make 
+	their way to the top of the ridge where they join Valor. 
+	Far in the distance, crossing the endless dune sea, is the 
+	royal invasion army.  It is immense.  A convoy of giant 
+	tanks, troop carriers, and supply ships stretch from 
+	horizon to horizon.  Cavalry, mounted on giant dunebirds 
+	ride the line from one end of the convoy to the other. 
+	Hundreds of troops ride one-man jetsticks in precision 
+	formation.  Their lances form a giant pin-cushion. It is 
+	an awesome sight.</sd>
+         <sp spk="SKYWALKER">
+		They're coming from the spaceport at 
+		Anchorhead, which means they control 
+		everything between here and the space-
+		port at Gordon.</sp>
+         <sp spk="JUSTIN">
+		Can we go around them?</sp>
+         <sp spk="SKYWALKER">
+		No.  We'll have to wait for them to 
+		pass.  Captain Valor, see if you can 
+		monitor any of their communications 
+		on the com-link in the big speeder.</sp>
+         <sd>Valor returns to the speeder.  He collapses in the large 
+	speeder next to the princess  and flips on the com-link 
+	radio, moving back and forth across the dial.</sd>
+         <sp spk="PRINCESS">
+		Must you do that?</sp>
+         <sd>Valor smiles rather sarcastically.</sd>
+         <sp spk="JUSTIN">
+		Orders... The invasion force has cut 
+		us off.  We'll probably be here for 
+		some time.  You ought to stretch a 
+		bit.</sp>
+         <sp spk="PRINCESS">
+		Is that a command, General?  Maybe I 
+		feel like watching after my brothers.</sp>
+         <sd>Valor looks back at the two sleeping boys.</sd>
+         <sp spk="JUSTIN">
+		They're not going anywhere.  They're 
+		asleep.</sp>
+         <sp spk="PRINCESS">
+		I want to stay with them.</sp>
+      </scene>
+      <scene n="66">
+         <setting>LIBRARY - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The King's old library has been converted into an office 
+	for General Vader.  He is sitting behind his desk as 
+	Captain Dodona of the Lettow legions enters and salutes. 
+	The legionnaire is dressed in the fascist black and chrome 
+	uniform of the legendary Lettow One Hundred.  The general 
+	returns his salute.</sd>
+         <sp spk="VADER">
+		Welcome, Captain Dodona.  Your 
+		exploits are legendary.  I have 
+		long waited to meet you.  If there 
+		is any way I can assist you, my 
+		entire command is at your bidding.</sp>
+         <sp spk="DODONA">
+		I want a tie-in to your computer 
+		network, a control center, and 
+		communication access.</sp>
+         <sp spk="VADER">
+		Right away!  I'll also transfer 
+		all information we have on the general. 
+		His command post was destroyed, but we 
+		believe he is still alive.  Do you 
+		really believe he's a Dai?</sp>
+         <sp spk="DODONA">
+		If he was not a Dai  I wouldn't be 
+		here.</sp>
+      </scene>
+      <scene n="67">
+         <setting>WASTELAND - TOWNOWI</setting>
+         <sd>The speeders make their way across the gray desert.  It is 
+	dawn.  The twin suns have yet to rise in the green sky.  The 
+	speeders are coated with dust and grime, indicating that 
+	they have travelled far.  The two captains drive through the 
+	night as everyone else sleeps.  Valor calls Oxus on the 
+	intercom.</sd>
+         <sp spk="JUSTIN">
+		How are your fuel packs?  I'm reading 
+		minus four.</sp>
+         <sp spk="OXUS">
+		I'm too low to transfer any.</sp>
+         <sd>The general, who appeared to be asleep, opens his eyes, and 
+	takes the microphone from Oxus.</sd>
+         <sp spk="SKYWALKER">
+		There is a fuel station fourteen 
+		degrees by two meters.  The occu-
+		pation force should have control 
+		of it by now, so hide your weapons,
+		but keep them within reach.</sp>
+      </scene>
+      <scene n="68">
+         <setting>FUEL STATION - TOWNOWI</setting>
+         <sd>A series of low concrete structures rise out of the desert. 
+	The speeders stop in front of an old weather-beaten block 
+	house.  The rusted hulk of a landspeeder lies half-buried 
+	to one side of the building.  Valor and Oxus jump out of the 
+	speeder and go into the block house.</sd>
+      </scene>
+      <scene n="69">
+         <setting>INTERIOR - FUEL STATION - TOWNOWI</setting>
+         <sd>The two young captains, dressed as farmers, enter the dingy 
+	little fuel station.  It is quiet.  A few power packs line 
+	the walls and a dismantled speeder rests in the repair bay. 
+	There is a sharp dripping sound coming from the speeder.  It 
+	appears that no-one is there.</sd>
+         <sp spk="JUSTIN">
+		Greetings!  Who's in charge here?</sp>
+         <sd>They look around the deserted station, but find no attendant. 
+	An eerie quiet pervades the building.</sd>
+         <sp spk="OXUS">
+		I don't get it.</sp>
+         <sp spk="JUSTIN">
+		You don't have to.  It's abandoned.</sp>
+         <sd>Oxus opens a door leading to a storage area, and stops 
+	short.</sd>
+         <sp spk="OXUS">
+		Not quite abandoned.</sp>
+         <sd>Valor moves to the doorway and sees the attendant, his wife, 
+	and small daughter hanging upside down, tortured to death. 
+	Oxus cuts them down.</sd>
+         <sp spk="OXUS">
+		They shouldn't have resisted.</sp>
+         <sd>Valor grabs two power packs from the shelf.</sd>
+         <sp spk="JUSTIN">
+		Help me with these power packs. 
+		We'd better move out of here.</sp>
+         <sd>Oxus covers the family with an old work tarp.  He bows to 
+	the dead, then reluctantly grabs a couple of power packs 
+	and they start for the door.  Oxus stops for a moment.</sd>
+         <sp spk="OXUS">
+		Hear that?  Someone's here.  (yelling)  
+		We're friends.  Show yourself.
+		
+	Silence.  Oxus shrugs his shoulders and they start out the 
+	door, only to run straight into a burly stormtrooper.</sp>
+         <sp spk="STORMTROOPER">
+		Get out of here!</sp>
+      </scene>
+      <scene n="70">
+         <setting>FUEL STATION - TOWNOWI</setting>
+         <sd>Oxus and Valor are pulled out of the doorway and shoved into 
+	the center of a group of fifteen or twenty royal storm-
+	troopers who have surrounded the two speeders.  Several 
+	troops have pulled General Skywalker out of the speeder. He 
+	acts senile, like a man twice his age.</sd>
+         <sp spk="SKYWALKER">
+		I'm all right.  I can still move 
+		about by myself.</sp>
+         <sd>A rough looking sergeant grabs Captain Oxus.</sd>
+         <sp spk="SERGEANT">
+		What are you doing here?
+			
+				 OXUS
+		We're out of power, sir.</sp>
+         <sp spk="SERGEANT">
+		Let me see your passes!</sp>
+         <sp spk="OXUS">
+		I have it here, somewhere.  We've 
+		been relocated to a hortastation, 
+		by royal order...</sp>
+         <sd>Oxus fumbles to retrieve something from his pocket, and 
+	eventually pulls out a small  round disc.  The sergeant 
+	puts the disc in a small portable reader.  Various computer 
+	readouts are displayed on the monitor.  Valor starts to put 
+	a power pack into one of the speeders.</sd>
+         <sp spk="SERGEANT">
+		What are you doing there?  All 
+		power has been restricted.</sp>
+         <sp spk="SKYWALKER">
+		We've run out.  We must have power, 
+		or be forced to stay here  and 
+		become your responsibilities.</sp>
+         <sd>The sergeant thinks about this for a moment  as the old 
+	wise general watches him.  Tension fills the air.  Valor 
+	shuffles around to a position where he can reach his weapon. 
+	A trooper hands the sergeant a message.</sd>
+         <sp spk="SERGEANT (to Oxus)">
+		Take only two of those power packs 
+		and then move out quickly.</sp>
+         <sd>The sergeant hurries to a military craft, where he takes a 
+	call on an intercom.  General Skywalker and his two young 
+	captains load the remaining power packs into the speeder 
+	and roar away from the station.</sd>
+      </scene>
+      <scene n="71">
+         <setting>WASTELAND - TOWNOWI</setting>
+         <sd>The speeders race along through the rocky desert wasteland. 
+	The general speaks into the intercom to Valor</sd>
+         <sp spk="SKYWALKER">
+		Keep a close watch.  If that sergeant 
+		runs an analysis on those passes  we 
+		might be seeing him again.  We should 
+		be safely inside Gordon within the day.</sp>
+         <sd>Everyone is in good spirits.  The princess and her young
+	brothers sing a Townowi melody, which is transmitted to Valor 
+	in the smaller speeder.  The general takes little Puck,  and 
+	lets him sit on his lap in the forward compartment of the 
+	speeder.  A-2 flexes C-3's arm back and forth  attempting 
+	to discover the cause of a loud squeak.</sd>
+         <sd>			 A-2
+		Oilar doesn't seem to help at all.</sd>
+         <sd>			 C-3
+		It's all this filth and dust.  This 
+		environment is murderous.</sd>
+         <sd>Valor notices a small speck on the horizon.</sd>
+         <sp spk="JUSTIN (into intercom)">
+		Object approaching, bearing three 
+		point two.</sp>
+         <sd>The general looks through an electrotelescope mounted in the 
+	speeder.  He spots a distant row of troopers riding strange 
+	dune birds.</sd>
+         <sp spk="SKYWALKER (to Justin)">
+		It's a patrol.  It could mean trouble. 
+		We'd better split up.  You stay on a 
+		direct course.  We'll meet you at the 
+		western edge of ravine 23-64.  Stay in 
+		contact.</sp>
+         <sd>The larger speeder makes a sharp left turn, speeding off
+	across a deep ravine.  Valor can begin to distinguish the 
+	approaching troopers.</sd>
+         <sp spk="JUSTIN">
+		It looks like there are ten of them. 
+		They're heading right for me.  Wait 
+		a second.  They've disappeared.  I've 
+		lost them.</sp>
+         <sp spk="SKYWALKER">
+		Continue on ahead.</sp>
+      </scene>
+      <scene n="72">
+         <setting>WASTELAND LAKEBED - TOWNOWI</setting>
+         <sd>Oxus deftly maneuvers the bulky speeder through a narrow 
+	boulder-strewn ravine.  They eventually come out on a dry 
+	lake bed, where they stop.  Standing not more than a hundred 
+	feet away, apparantly waiting for the speeder, are five 
+	royal troops on their dune birds.</sd>
+         <sp spk="SKYWALKER">
+		We've found them, five of them, 
+		anyway.  Watch yourself.</sp>
+         <sd>The troops slowly ride their huge birds over to the speeder 
+	and dismount.  The officer in charge is a vicious looking 
+	warrior  with a large scar across his face.</sd>
+         <sp spk="OFFICER">
+		Let me see your passes.</sp>
+         <sd>Oxus hands him the small pass disc, and he places it in his 
+	reader.  He studies the computer readout for a few moments 
+	and then returns the disc to Oxus.</sd>
+         <sp spk="OFFICER">
+		Have you seen any other transports 
+		in this area?</sp>
+         <sp spk="SKYWALKER">
+		We saw two heading south.  Going 
+		towards Ansel, looked like to me.</sp>
+         <sp spk="OFFICER">
+		All right.  Be on your way.</sp>
+         <sd>The officer mounts his dune bird, and the patrol moves away. 
+	Oxus winks at the princess  and smiles at the general, as 
+	the speeder starts off across the dry lake.  The general 
+	fiddles with the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, are you clear?</sp>
+         <sp spk="JUSTIN">
+		I have five troopers approaching. 
+		Any problem your end?</sp>
+         <sp spk="SKYWALKER">
+		We came through all right.  You 
+		shouldn't have any trouble, but stay 
+		alert.</sp>
+         <sp spk="JUSTIN">
+		Best wishes!  Here they come.</sp>
+         <sd>Everyone rides along in silence, a little worried about
+	Captain Valor, especially the princess.</sd>
+         <sp spk="PRINCESS">
+		Do you think he'll be all right?</sp>
+         <sp spk="SKYWALKER">
+		He can take care of himself.</sp>
+         <sd>Oeta is looking out the back window of the speeder.</sd>
+         <sp spk="OETA">
+		Hey look!  They're coming back.</sp>
+         <sd>Everyone looks to see the patrol quickly gaining on them.</sd>
+         <sp spk="SKYWALKER">
+		Stop!  They're faster.  Get 
+		your weapon.</sp>
+         <sd>The speeder screeches to a halt in a cloud of dust.  The
+	general and his captain jump from the transport with lazer-
+	pistols drawn.  The patrol bears down on them, swords drawn, 
+	at full charge.  Both the general and Oxus fire.  Two of the 
+	troopers and their dunebirds explode in a cloud of smoke. 
+	The remaining three troopers are upon the duo in a matter 
+	of seconds.  The general ignites his lazersword and cuts down 
+	two of the troops as they pass.  The last turns his bird 
+	around before reaching the speeder, and hightails it back 
+	towards the ravine.  The general jumps onto one of the 
+	riderless dunebirds and takes off in pursuit.  Oxus checks 
+	the dead troopers.</sd>
+      </scene>
+      <scene n="73">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The general rides at breakneck speed after the fleeing
+	trooper.  His lazersword is raised high over his head, ready 
+	to deal a deathblow.  The lumbering birds race through the 
+	winding ravine.</sd>
+      </scene>
+      <scene n="74">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The intercom warning buzzer begins to scream.  Oxus rushes 
+	for it  but the princess gets there first.
+					 
+				 PRINCESS
+		Are you all right?</sd>
+         <sp spk="JUSTIN">
+		Two riders heading your way.  I 
+		got three, but two got away. 
+		Watch yourselves!</sp>
+      </scene>
+      <scene n="75">
+         <setting>WASTELAND RAVINE - TOWNOWI</setting>
+         <sd>The general is riding neck and neck with the trooper.  He
+	swiftly brings his sword down and the trooper drops from 
+	his saddle.  The momentum of his charge carries the general 
+	around a bend in the ravine  and right inTO the path of two 
+	more troops charging down on him.  The two troopers are 
+	taken by surprise.  They stop their birds  and so does the 
+	general.  They stand there, about fifty yards apart, sizing 
+	up each other.  Suddenly, the two troopers start for the Dai 
+	warrior at full speed.  The general raises his sword  and 
+	starts for them.  The troopers are no match for the general 
+	who kills them both before they are even able to swing their 
+	swords.</sd>
+      </scene>
+      <scene n="76">
+         <setting>WASTELAND LAKEBED - TOWNOWI</setting>
+         <sd>Valor stops near the larger landspeeder and gets out.  He 
+	is wounded.  Blood streams from his left arm.  Oxus rushes 
+	to help him.  The princess shows a great deal ofconcern.</sd>
+         <sp spk="OXUS">
+		It looks worse than it is.  You'll 
+		be all right.</sp>
+         <sd>Oxus motions to the princess, who looks a little relieved.</sd>
+         <sp spk="OXUS">
+		Bring me the med aid pack.</sp>
+         <sp spk="PRINCESS">
+		It he was clumsy enough to get hurt, 
+		maybe we ought to let him bleed to 
+		death.</sp>
+         <sd>She hands Oxus the kit, as the general rides up and dis-
+	mounts.  He moves to Valor.</sd>
+         <sp spk="SKYWALKER">
+		You missed two.</sp>
+         <sp spk="JUSTIN">
+		I know. I couldn't...</sp>
+         <sp spk="SKYWALKER">
+		Don't let it happen again. 
+		We'd better move out.  They might 
+		have reported in.</sp>
+      </scene>
+      <scene n="77">
+         <setting>CONTROL ROOM - PALACE OF LITE - TOWNOWI</setting>
+         <sd>The dark and sinister Dodona moves several markers on a
+	large map readout to form a line from the destroyed under-
+	ground fortress to the spaceport at Gordon.  An aide enters 
+	with General Vader.</sd>
+         <sp spk="AIDE">
+		The patrol was lost, sir.  All 
+		ten of them.</sp>
+         <sp spk="DODONA">
+		It's to be expected.</sp>
+         <sp spk="VADER">
+		Have you found them?</sp>
+         <sp spk="DODONA">
+		They're heading for the spaceport 
+		at Gordon.  I'm going there.  Have 
+		all security doubled.  Make it an 
+		alert.</sp>
+      </scene>
+      <scene n="78">
+         <setting>THE OUTSKIRTS OF GORDON - TOWNOWI</setting>
+         <sd>The speeders stop on a bluff overlooking a small cantina on 
+	the outskirts of Gordon.  The spaceport can be seen in the 
+	distance.  The general and Captain Oxus walk over to the 
+	smaller speeder.  Valor helps the two androids out of their 
+	cramped quarters.</sd>
+         <sd>			 C-3
+		Your kindness is greatly appreciated.</sd>
+         <sp spk="JUSTIN (to Skywalker)">
+		I'm fit enough to...</sp>
+         <sd>The general gives him a hard look and he shuts up.  Oxus 
+	and the general climb into the speeder.</sd>
+         <sp spk="SKYWALKER">
+		We'll make contact at zero four 
+		hundred.  If we're not back by 
+		fifty-five forty, get worried.</sp>
+         <sd>The speeder starts off toward the cantina.</sd>
+      </scene>
+      <scene n="79">
+         <setting>SPACEPORT CANTINA - TOWNOWI</setting>
+         <sd>The speeder pulls up in front of the low  blockhouse style 
+	cantina.  Various strange forms of transport are parked out-
+	side the bar.</sd>
+         <sp spk="SKYWALKER">
+		Take care here.  If there is any 
+		trouble, get back to the others.</sp>
+         <sd>The general and Oxus enter the shabby cantina.  The murky 
+	little den is filled with a startling array of weird and 
+	exotic alien creatures, laughing at the bar.  At first, the 
+	sight is horrifying.  One-eyed, thousand-eyed, slimy, furry, 
+	scaly armed creatures with tentacles and claws huddle over 
+	drinks.  The general looks over the patrons, but does not 
+	see the contact, Han Solo. A large multiple-eyed creature 
+	shoves the general.</sd>
+         <sp spk="CREATURE">
+		Assha dughi wouldugga?</sp>
+         <sd>The general tries to ignore the creature  and turns back to 
+	his drink.  A short  grubby looking human  and an even 
+	smaller  rodent-like creature join the first creature.</sd>
+         <sp spk="HUMAN">
+		He doesn't like you.</sp>
+         <sp spk="SKYWALKER">
+		I understood him.</sp>
+         <sp spk="HUMAN">
+		I don't like you either.</sp>
+         <sp spk="SKYWALKER">
+		I'm sorry.</sp>
+         <sd>The big creature is getting agitated  and yells at the
+	general.</sd>
+         <sp spk="HUMAN">
+		Don't insult us.  You just watch 
+		yourself.  We're wanted men.  I 
+		have the death sentence on twelve 
+		systems.</sp>
+         <sp spk="SKYWALKER">
+		I'll be careful then.</sp>
+         <sp spk="HUMAN">
+		You'll be dead.</sp>
+         <sd>The short rodent yells something  and everything at the bar 
+	moves away.  The general assumes a defensive position.  His 
+	three adversaries ready their weapons.</sd>
+         <sp spk="SKYWALKER">
+		You insist on a fight then?</sp>
+         <sp spk="HUMAN">
+		Just try and kill us.</sp>
+         <sp spk="SKYWALKER">
+		It will hurt a little.</sp>
+         <sp spk="HUMAN">
+		We aren't cowards.</sp>
+         <sp spk="SKYWALKER">
+		Then it can't be helped.</sp>
+         <sd>The general's lazersword sparks to life.  An arm lies on the 
+	floor.  The rodent is cut in two  and the large  multiple-
+	eyed creature lies doubled, cut from chin to groin.  The 
+	general  with quiet dignity  replaces his sword in its sheath. 
+	The entire fight has lasted only a matter of seconds.  A 
+	figure stands in the doorway watching the general.  As soon 
+	as the general notices him, he leaves.  The cantina goes back 
+	to normal, as if nothing had happened, although the general 
+	is given a respectable amount of room at the bar.  The Dai 
+	finishes his drink  and then leaves.  Captain Oxus follows.</sd>
+      </scene>
+      <scene n="80">
+         <setting>SPACEPORT ALLEYWAY - GORDON - TOWNOWI</setting>
+         <sd>General Skywalker embraces Han Solo, the underground contact. 
+	Han is a huge  green skinned monster with no nose and large 
+	gills.</sd>
+         <sp spk="HAN">
+		You old stardog.  Took a war to get 
+		you out here...</sp>
+         <sd>Oxus arrives with Captain Valor, the princess, and her
+	brothers, and the two puzzled androids.</sd>
+         <sp spk="SKYWALKER">
+		It's been too long.  We've been through 
+		much together.  It will be good to have 
+		you out of retirement and back at my 
+		side.  How is General Valor?  (putting 
+		his arm around the young Captain Valor)  
+		This is his son.</sp>
+         <sp spk="HAN">
+		You're all the old boy will talk about. 
+		He's still holding up.  Come, let's get 
+		off the street.</sp>
+         <sd>The group enters a small doorway at the far end of the alley-
+	way.  On the main street, within view of the doorway, giant 
+	royal airtanks and other military hardware rumble through 
+	the city.  Starving refugees sit in the gutter watching the 
+	immense display of force with a mixture of awe and terror. 
+	The princess stops for a moment  and stares at her people, 
+	watching the might of the kingdom.  The general escorts her 
+	through the doorway with the others.</sd>
+      </scene>
+      <scene n="81">
+         <setting>SLUM DWELLING - LIVING AREA - TOWNOWI</setting>
+         <sd>The seedy dwelling is dark and dingy.  The group is greeted 
+	by three underground leaders, and the old Dai, Akira Valor. 
+	Justin embraces his father as the underground leaders bow 
+	before the princess.</sd>
+      </scene>
+      <scene n="82">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>The princess walks through the dining area, followed by Oxus 
+	and Valor, who carry the two sleeping princes.  The general 
+	sits at a large table  finishing dinner with Han, Akira, 
+	and the three underground leaders.  Oxus returns from the 
+	bedroom.</sd>
+         <sp spk="SKYWALKER (to Oxus)">
+		Captain, why don't you take the 
+		androids into the other room for 
+		a game of chess?  I'm sure they'd 
+		enjoy it.</sp>
+         <sd>			 C-3
+		A wonderful idea.  Your kindness 
+		is greatly appreciated.</sd>
+         <sd>Oxus escorts the two robots into the next room.  DATOS, a 
+	thin  wizened old man, seems greatly relieved.</sd>
+         <sp spk="DATOS">
+		You're taking a great risk travelling 
+		with them.  This whole operation 
+		sounds bad to me.  I don't trust the 
+		chrome companies.  Time is growing 
+		short.  The King's attempts at control 
+		have already caused a great deal of 
+		suffering to our people.</sp>
+         <sd>OCCO, a brash young rebel  about the same age as Captain
+	Valor  slams his fist on the table.</sd>
+         <sp spk="OCCO">
+		It must happen now!  We are ready. 
+		Each day the royal S.B.T. finds and 
+		destroys a few more in the organiza-
+		tion.  We cannot wait any longer.</sp>
+         <sp spk="SKYWALKER">
+		Any uprising without a coordinated 
+		attack on the death star is out of 
+		the question.</sp>
+         <sp spk="HAN">
+		He's right.  As long as it's 
+		operational, any action down here 
+		would be meaningless.  We must 
+		proceed as planned.  Are the 
+		arrangements secure?</sp>
+         <sd>QUIST, the third member of the underground, sparks to life 
+	and places several discs and badges on the table.</sd>
+         <sp spk="QUIST">
+		All passenger transport has been 
+		suspended, so we've arranged for 
+		you to travel as the crew of a 
+		Baltarian freighter.  The boys 
+		will have to be placed in suspended 
+		animation and hidden in shielded 
+		micropacks.  It's the only way we 
+		will be able to get them past the 
+		scanners.</sp>
+         <sp spk="DATOS">
+		Were you able to aquire the necessary 
+		power packs?</sp>
+         <sp spk="QUIST">
+		It's become a serious problem.  All 
+		power supplies have been restricted. 
+		S-4 units are impossible to come by.</sp>
+         <sp spk="HAN">
+		I know an agent who might be able to 
+		acquire them for us.  I'll check with 
+		him.  It will be risky, but we've no 
+		other choice.</sp>
+      </scene>
+      <scene n="83">
+         <setting>SPACEPORT OBSERVATION DECK - TOWNOWI</setting>
+         <sd>The dark figure of Dodona stands overlooking a group of
+	Townowi partisans who are being tortured in the plaza below. 
+	Two royal officers are finishing a report to the evil legion-
+	naire.  They salute smartly, then leave the observation 
+	balcony  passing KURO, one of General Vader's aides, who 
+	approaches Dodona  and bows low before him.  Kuro and the 
+	legionnaire carry on an animated conversation;  it is 
+	inaudible over the screams of the tortured partisans.</sd>
+      </scene>
+      <scene n="84">
+         <setting>SLUM DWELLING - ALLEYWAY - TOWNOWI</setting>
+         <sd>Residents glance fearfully from their windows as six royal 
+	stormtroopers make their way through the crowded slum alley-
+	way.  Han Solo and Captain Valor move cautiously past the 
+	royal patrol  and disappear into the shabby hideout of the 
+	partisan underground.</sd>
+      </scene>
+      <scene n="85">
+         <setting>SLUM DWELLING - MAIN AREA - TOWNOWI</setting>
+         <sd>The two men enter the dingy main room of the slum dwelling 
+	and are immediately attacked by Oeta, wielding a toy sword. 
+	Valor good-naturedly fends off the young prince  as Han, in 
+	a more serious mood, goes into the other room.  A-2 and C-3 
+	are helping Puck put together a block-like puzzle.  Princess 
+	Zara comes in to see what all the commotion is about, just 
+	as the young captain grabs Oeta by the foot and holds him 
+	upside-down.   Valor and Oeta are laughing uproariously. 
+	Zara gives the captain a stern  disapproving look, then 
+	returns to the other room.</sd>
+      </scene>
+      <scene n="86">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>General Skywalker, Captain Oxus, and Datos are in the process 
+	of assembling two micropacks on the kitchen table.  Han pulls 
+	a small silver powerpack from his pocket, and places it on 
+	the table.  The old Dai, Akira Valor, reaches over with his 
+	one good arm  and takes it.  He inspects it carefully. 
+	Princess Zara sits quietly behind the general.</sd>
+         <sp spk="HAN">
+		We could only get one unit.  Their 
+		methods are proving to be very 
+		effective.</sp>
+         <sd>Akira places the powerpack back on the table.  The pain from 
+	those simple movements shows on his face.</sd>
+         <sp spk="AKIRA">
+		This will work fine.</sp>
+         <sp spk="HAN">
+		One of the boys will have to stay.
+		
+				 DATOS
+		We can't hide him for very long.
+		The risk is too great.  Which-
+		ever boy doesn't go must be des-
+		troyed.</sp>
+         <sd>The princess is alarmed, and looks to the general for support. 
+	He gives her an understanding look.</sd>
+         <sp spk="SKYWALKER">
+		Not while they're in my charge. 
+		Find another way to get him through.</sp>
+         <sp spk="DATOS">
+		There's no other way.  We've 
+		analyzed every possible alter-
+		native.  You can't jeopardize 
+		the enitre...</sp>
+         <sd>Captain Valor enters the room.</sd>
+         <sp spk="HAN">
+		We have no time for discussion. 
+		The freighters leave at zero 
+		three hundred.  We must get 
+		started.</sp>
+         <sd>Through a break in the door, Oxus watches A-2 and C-3 
+	play with the two young princes.</sd>
+         <sp spk="OXUS">
+		What about A-2?  Could we loboto-
+		mize him and use his energy pack?</sp>
+         <sp spk="SKYWALKER">
+		They're not compatible.  We'd 
+		have to completely change the 
+		system.</sp>
+         <sp spk="HAN">
+		It could work.</sp>
+         <sp spk="DATOS">
+		There isn't enough time.  You can't 
+		do it.</sp>
+         <sp spk="AKIRA">
+		You won't have to.  My power unit 
+		has more than half life.  Use it.</sp>
+         <sd>The withered Dai opens his tunic  revealing a metallic chest 
+	covered with electrodes.  With his one good arm  he grabs 
+	his chest and rips loose a miniature power unit similar to 
+	the one on the table.  Everyone is taken by surprise.  The 
+	general and the young Valor both rush to the side of the 
+	dying Dai.  The old man turns to his son.</sd>
+         <sp spk="AKIRA">
+		Trust my judgment, Son.  Serve your 
+		new teacher well.</sp>
+         <sd>The Dai's breathing becomes more difficult as he turns to 
+	the general.</sd>
+         <sp spk="AKIRA (Cont.)">
+		An honorable death, my friend. 
+		May the force of others be with 
+		you.</sp>
+         <sd>Akira Valor passes on to the other world.  Everyone is 
+	stunned.  The general breaks the moment of silence.</sd>
+         <sp spk="SKYWALKER">
+		May he be welcomed as a man above 
+		men.  Take him downstairs.</sp>
+         <sd>Justin takes his father in his arms and is followed out of 
+	the room by Han and Datos.</sd>
+         <sp spk="SKYWALKER">
+		Prepare the boys!  We have little 
+		time.</sp>
+         <sd>Princess Zara and Captain Oxus rush out of the room, as the 
+	general places the power units in the micropacks.</sd>
+      </scene>
+      <scene n="87">
+         <setting>SLUM DWELLING - MAIN AREA - TOWNOWI</setting>
+         <sd>Oeta and Puck are not happy about being dragged away from 
+	their puzzle.  Oxus takes the robots into the sleep area.</sd>
+         <sp spk="ZARA">
+		Now straighten up, Oeta.  Remember, 
+		father expects you to follow his ways. 
+		We are going on a trip.  There will be 
+		great danger.  You must go to sleep. 
+		When you wake, you will be in a strange 
+		land, so don't be alarmed.</sp>
+         <sp spk="OETA">
+		Are you going to sleep too?</sp>
+         <sp spk="ZARA">
+		I will be looking after you.  Now 
+		be good boys and stand still.  Lift 
+		your sleeve.</sp>
+         <sd>Puck lifts his sleeze and Zara injects him with a sleep
+	serum.  Oxus enters just as the little prince collapses 
+	into a deep sleep.  Quick as lightening, he catches the 
+	boy before he can hit the floor.  The princess injects 
+	her other brother  and he collapses into her arms.</sd>
+      </scene>
+      <scene n="88">
+         <setting>SLUM DWELLING - DINING AREA - TOWNOWI</setting>
+         <sd>The limp bodies of the two young princes are carried in 
+	by Zara and Captain Oxus.  They are carefully squeezed 
+	into the hollowed out microcases.  Zara pensively watches 
+	as the general expertly attaches electrodes to her 
+	brother's skull.  Han and Datos return from the burial 
+	of Akira.  The general looks up from his operation.</sd>
+         <sp spk="HAN">
+		He is at rest.  Are the systems 
+		working all right?</sp>
+         <sp spk="SKYWALKER">
+		Full power.  Is everything ready?</sp>
+         <sd>Datos nods yes, as the general closes the case holding Puck. 
+	The strain of watching her brothers placed in suspended 
+	animation is too great for Zara  and she retreats into the 
+	main room.</sd>
+      </scene>
+      <scene n="89">
+         <setting>SLUM DWELLING - MAIN ROOM - TOWNOWI</setting>
+         <sd>Captain Valor stands brooding near a window overlooking 
+	the crowded alleyway.  He does not acknowledge Zara's 
+	entrance.  She walks over to the window and stands next to 
+	the young captain.  They are very close but do not touch.</sd>
+         <sp spk="ZARA">
+		I'm sorry.</sp>
+         <sd>He does not respond.  She is moved by his sorrow  and 
+	starts to touch the side of his face  but can't bring her-
+	self to do it.  Her royal training is too strong to let her 
+	show her true affection for Justin.  She breaks down and 
+	runs from the room.  The young Dai continues his meditation.</sd>
+      </scene>
+      <scene n="90">
+         <setting>SPACEPORT AT GORDON - SECURITY RAMP - TOWNOWI</setting>
+         <sd>The spaceport is very crowded.  People rush about in a
+	panicked rush as loudspeakers blurt out indiscernible
+	announcements.  The Royal Galactic Kingdom is in the process 
+	of changing the boarding procedures and the result is chaos. </sd>
+         <sd>Many flights are delayed, and people are running to and 
+	fro, switching boarding ramps.  Han guides the rebel group, 
+	dressed as a Baltarian crew, through the crowded terminal. 
+	Oxus and Valor carry the large micropacks strapped to their 
+	backs.  The robots follow a few paces behind.</sd>
+         <sp spk="HAN">
+		They're changing the boarding 
+		procedures.  I don't like it.</sp>
+         <sd>They are swept into a boarding gate and finally reach a
+	security ramp scan station.  There are a great number of
+	troops and guards standing around the security area.  An
+	officer demands to see their passes and orders.  The ten-
+	sion builds as the officer confers with an aide about the 
+	passes.  The aide speaks quietly into a phone.</sd>
+         <sp spk="OFFICER">
+		Where are your component receipts?</sp>
+         <sd>Valor and Oxus hand the officer two additional discs, 
+	which are placed in the computer.  A few moments later, 
+	the readout appears  and the group is motioned through the 
+	electron scanners.  On the other side of the scanner, new 
+	computer discs are issued to the group.  The group seems 
+	slightly relieved as they walk through several hallways 
+	leading to where the freighter is docked.  Valor moves 
+	next to  the general.</sd>
+         <sp spk="JUSTIN">
+		I don't like the feel of this.</sp>
+         <sp spk="SKYWALKER">
+		Your senses are strong.  It's a 
+		very small disruption.</sp>
+         <sp spk="JUSTIN">
+		It's a Lettow legionnaire.</sp>
+         <sp spk="SKYWALKER">
+		Possibly.  Stay alert.  Warn 
+		the others.</sp>
+         <sd>The group walks through the docking links and into the
+	Baltarian spacecraft.  Several royal guards pass them, 
+	and everyone is ready for the suspected trap, but 
+	nothing happens.</sd>
+      </scene>
+      <scene n="91">
+         <setting>INTERIOR - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The group stops in a narrow electronic  passageway near 
+	the bridge of the ship.  Valor and Oxus unstrap the 
+	micropacks containing the two young princes, and check 
+	the voltage packs.</sd>
+         <sp spk="OXUS">
+		Little Oeta is losing power faster 
+		than normal.  I'd better check it 
+		out.
+		
+				 SKYWALKER
+		Wait until the situation is secure. 
+		Stay here, and keep on your guard.
+		Han!</sp>
+         <sd>The two young captains grow suspicious of several workmen 
+	gathering around the main exit hatch.  Han and the general 
+	enter the bridge area.  Several crewmen sit at elaborate 
+	controls and computer stations.</sd>
+         <sp spk="SKYWALKER">
+		Where is your captain?</sp>
+         <sd>One of the crewmen directs him to a small chamber above the 
+	bridge.  Valor and Oxus strap on their micropacks as more 
+	workmen converge at the main hatch and begin to close it. 
+	The two robots, A-2 and C-3 are confused about what is 
+	going on  and wear their gear in anticipation of moving.</sd>
+      </scene>
+      <scene n="92">
+         <setting>PILOT CHAMBER - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Han and the general enter the small pilot's chamber and 
+	greet the captain, whose face is hidden in the shadows of 
+	a computer bank.</sd>
+         <sp spk="CAPTAIN">
+		Welcome, gentlemen.  You must 
+		have had a difficult journey. 
+		We'll be departing shortly.</sp>
+         <sd>Four 	armed troopers silently enter the room behind the two 
+	old Dai;  their lazerswords are drawn.</sd>
+         <sp spk="CAPTAIN ">
+		I have been authorized to accept 
+		payment for the chrome company 
+		cooperation.  I assume you've 
+		brought it with you.</sp>
+         <sd>The captain moves out of the shadows  and is revealed to 
+	be Dodona.  Instantly, both Han and the general understand 
+	the situation.  They turn, drawing their lazerswords in 
+	the move  and cut down the four royal troopers.  The door 
+	to the chamber instantly seals shut.  Dodona hasn't made 
+	any moves  and remains unusually calm.  The two Dai turn
+	to face him.</sd>
+         <sp spk="DODONA">
+		Its over, gentlemen.  The chamber 
+		is sealed.  Dont force me to 
+		release the Jai gas.</sp>
+         <sd>A tone sounds, and Dodona turns to an intercom.</sd>
+         <sp spk="INTERCOM">
+		Situation secure.  Prisoners taken to 
+		hold "B";  Twelve casualties... gas 
+		was necessary.</sp>
+         <sd>Han and the general relax and drop their weapons.  The 
+	door silently opens behind them and six guards enter wearing 
+	facemasks.  They bind the two Dai with chrome microcuffs.  A 
+	satisfied smile creeps across Dodona's face.  General Sky-
+	walker seems unimpressed with the trap.</sd>
+         <sp spk="DODONA">
+		At last, it's ended.  (to guard)  Take 
+		them to hold "G."  I don't want them 
+		with the others.  Prepare for departure.</sp>
+         <sd>The troopers escort Han and the general out of the chamber 
+	and down several hallways.</sd>
+      </scene>
+      <scene n="93">
+         <setting>INTERIOR - BALTARIAN FREIGHTERS - TOWNOWI</setting>
+         <sd>Eight troops march Han and the general into the hold of the 
+	ship.  They pass near the main exit  where A-2 and C-3 
+	stand deserted, looking lost.  C-3 sees the general pass in
+	a nearby hallway</sd>
+         <sd>			 C-3
+		Well, there he is.  Come on.</sd>
+         <sd>The robots waddle off after the Dai prisoners.  As the 
+	small procession passes detention cell B where the princess 
+	and the others are being held, Han and the general let out 
+	a horrifying Dai scream and leap to the corridor ceiling, 
+	thrusting their bound wrists into the lighting fixtures. 
+	They land on top of the troops, instantly breaking the 
+	necks of four guards, with expertly placed blows.  The 
+	eight surviving guards are momentarily dumbfounded.  Han 
+	and the general grab lazerswords from their victims  and 
+	swiftly cut down the remaining troops.  Han grabs a small 
+	card from one of the dead guards  and starts for detention 
+	cell  B.</sd>
+         <sp spk="SKYWALKER">
+		Watch it!   Those are cutters.</sp>
+         <sd>The general grabs one of the dead troopers and tosses him
+	against the cell door.  Red rays engulf the body  and holds 
+	it there.  Han then places the card in a slot  and the door 
+	silently slides open.  Valor and Oxus leap for the dead 
+	guard, then notice the death ray surrounding him.  General 
+	Skywalker grabs another body and throws it into the doorway.</sd>
+         <sp spk="SKYWALKER">
+		Pass between them!</sp>
+         <sd>Captain Valor squeezes between the slain guards  and is 
+	untouched by the rays.  Oxus and the princess quickly follow, 
+	picking up weapons as they leave.</sd>
+         <sp spk="JUSTIN">
+		They've taken the cases.</sp>
+         <sp spk="SKYWALKER">
+		Are they aware of the boys?</sp>
+         <sp spk="OXUS">
+		I don't think so.</sp>
+         <sp spk="SKYWALKER">
+		Find them.  Use your seeker. 
+		We'll meet you at the main 
+		hatch.  Watch yourselves.  If 
+		an alarm is given, they'll gas 
+		the entire ship.</sp>
+         <sp spk="OXUS">
+		Yes, Sir.</sp>
+         <sd>Oxus and Valor each take a small humming device from their 
+	utility belts and head down a narrow hallway.  The general, 
+	Han, and the princess continue toward the main hatch.  A-2 
+	and C-3 have been completely confused by the turn of events. 
+	They eventually follow the general toward the exit hatch.</sd>
+      </scene>
+      <scene n="94">
+         <setting>ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The two young captains reach a storage area of the huge
+	spacecraft.  They watch their seekers as they move along a 
+	row of electroclosets.  They quietly sneak past a group of 
+	workmen assembling a large gyrohousing.  A second row of 
+	micropacks is searched to no avail.</sd>
+         <sp spk="OXUS">
+		If they were discovered, they would 
+		have been sent to a medical station.</sp>
+         <sp spk="JUSTIN">
+		There are more storage areas on the 
+		far side.</sp>
+      </scene>
+      <scene n="95">
+         <setting>MAIN HATCH AREA - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Han and the general reach the main hatch, closely followed 
+	by Zara and the two robots.  Several lights over the hatch 
+	flash on and off.  The general cuts a camera off the wall 
+	with his lazersword.</sd>
+         <sp spk="HAN">
+		They're going to take off.  It's 
+		too late.
+		
+				 SKYWALKER
+		C-3,  come over here!</sp>
+         <sd>The lanky chrome man approaches the general, who is studying 
+	a complex computer control panel next to the hatch.</sd>
+         <sd>			 C-3
+		Yes sir.  May I be of service?</sd>
+         <sp spk="SKYWALKER">
+		Get this hatch open.  Counterlock 
+		the departure pattern.</sp>
+         <sd>The robot immediately starts pushing buttons on the panel.</sd>
+      </scene>
+      <scene n="96">
+         <setting>ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Captain Valor and Oxus reach a second series of electro-
+	closets.  A signal appears on the seekers  and Valor cuts 
+	down the door of one of the small cabinets.  Oxus stands 
+	guard.  Approaching troops are heard in the distance. 
+	Valor quickly rummages through the electropacks until he 
+	spots the familiar cases containing the two boys.</sd>
+         <sp spk="OXUS">
+		Troops!</sp>
+         <sd>Valor straps on one of the backpacks  and hands the other 
+	to Oxus, as they duck into a narrow passageway.  Four 
+	troops march through a nearby hallway.  After they have 
+	passed, the young captain checks to make sure the way is 
+	clear, then runs down a hallway toward the main hatch.</sd>
+      </scene>
+      <scene n="97">
+         <setting>BRIDGE - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>As the crew makes the final preparations for the blast off, 
+	the main hatch light blinks on.  One of the pilots notices 
+	the light and begins to check it out.</sd>
+         <sp spk="PILOT (into intercom)">
+		Is the main hatch secure?</sp>
+      </scene>
+      <scene n="98">
+         <setting>MAIN HATCH - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The intercom sparks to life, and the general answers it.</sd>
+         <sp spk="SKYWALKER">
+		Everything looks secure, but give 
+		me a minute to check it out.</sp>
+         <sp spk="PILOT">
+		All right.  Stand by.</sp>
+         <sd>The general winks to Han, as C-3 continues his attempt to 
+	override the hatch computer.</sd>
+      </scene>
+      <scene n="99">
+         <setting>HALLWAYS - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>Captain Valor and Oxus cautiously move down a long hallway, 
+	ever watchful of royal troops.  They reach an intersection, 
+	carefully check in all directions, then rush down a main 
+	hallway.  They are about half-way down the hallway, when a 
+	squad of royal guards appears at the end of the hallway 
+	facing them.  The troops start toward the two captains, with 
+	lowered lazerrifles.</sd>
+         <sp spk="VALOR">
+		Here's where it gets tricky.</sp>
+         <sd>Valor, then Oxus, quickly and smoothly draw their lazer-
+	pistols and fire at the troops.  A giant explosion destroys 
+	the far end of the hallway.  A few lazerbolts are returned, 
+	but streak harmlessly overhead  and explode out of range. 
+	The exchange of gunfire lasts only a few moments.  When the 
+	smoke clears, the troops have been destroyed.</sd>
+      </scene>
+      <scene n="100">
+         <setting>MAIN HATCH - BALTARIAN FREIGHTER - TOWNOWI</setting>
+         <sd>The main hatch slowly begins to slide open, when the 
+	rumbling explosion of lazerfire echoes through the hallways. 
+	Han looks to the general  and they both instantly realize 
+	what has happened.  Han draws his weapons.  The hatch is 
+	now fully open.  Everyone stands silently  watching for the 
+	two captains.  Alarms start screaming throughout the ship, 
+	and the giant hatch slowly begins to close.</sd>
+         <sp spk="SKYWALKER">
+		Come on.  We can't wait.</sp>
+         <sd>The group reluctantly exit the spacecraft, giving one last 
+	look back to their lost friends.  The hatch continues to 
+	slowly close, as the alarm sirens wail.  Suddenly, Valor 
+	and Oxus round a corner and head for the ever-closing 
+	hatch, battling several royal troopers as they go.  Han and 
+	the general move up to the hatch and give cover fire.  Oxus 
+	slips through the shrinking opening, and yells to Valor to 
+	hurry.  Many more troops bear down on the young Dai as he 
+	squeezes through the very slim opening.  One of the troops 
+	dives after him  but is caught  and crushed by the emergency 
+	hatch.</sd>
+      </scene>
+      <scene n="101">
+         <setting>BOARDING RAMPS - GORDON SPACEPORT - TOWNOWI</setting>
+         <sd>The general leads the group through various corridors.</sd>
+         <sp spk="HAN">
+		Once the alarm sounds, the entire 
+		spaceport will shut down.</sp>
+         <sd>They stop at a junction.  At the far end of one hallway,
+	several troops guard a restricted passageway.</sd>
+         <sp spk="SKYWALKER">
+		That's the military section.</sp>
+         <sp spk="JUSTIN">
+		Fighter craft!</sp>
+         <sp spk="HAN">
+		But it's very heavily guarded. 
+		We can't take it with subtlety.</sp>
+         <sd>Before the general can answer, the acute scream of the
+	spaceport alarm reverberates through the corridors.  The
+	general, followed by his two young captains, charge toward 
+	the heavily guarded military passageway.  Han, with the 
+	princess and two robots, follow at a safe distance behind. 
+	A guard sees them coming  and orders them to stop.  Captain 
+	Valor and the general fire their lazerpistols and the 
+	passageway entrance and the troops disappear in a huge 
+	explosion.</sd>
+         <sd>The group jump over the dead guards and smoking rubble, then 
+	run through a series of hallways leading to a starship. 
+	They  stop just short of an intersection leading to a boarding 
+	ramp.  Valor peeks around a corner at two guards standing in 
+	front of the boarding ramp.</sd>
+         <sp spk="JUSTIN">
+		Cutters!  We'll have to draw them 
+		out. A blast might alert the crew.</sp>
+         <sp spk="SKYWALKER">
+		A-2,    Come here.</sp>
+         <sd>The little robot waddles over to the old Dai.</sd>
+         <sp spk="SKYWALKER">
+		Move to that intersection and sound the 
+		alarm.</sp>
+         <sd>The mechanical dwarf dutifully marches into the intersection 
+	and lets out a high, electronic scream.  The guards shut off 
+	the deadly lazer cutters, and cautiously approach the wailing 
+	robot.</sd>
+         <sp spk="GUARD">
+		What is it?  What's wrong?</sp>
+         <sd>With incredible speed, both guards are dropped by a few
+	precision blows from the two young captains.  They immediately 
+	drag the unconscious guards into the starship.</sd>
+         <sp spk="SKYWALKER">
+		Valor!  Oxus!  Stand guard.  I'll 
+		signal at take-off minus thirty.
+		And reverse that cutter!</sp>
+      </scene>
+      <scene n="102">
+         <setting>INTERIOR - ROYAL STARSHIP - TOWNOWI</setting>
+         <sd>Han and the general, followed by Zara and the robots, enter 
+	the royal starship.  They rush through several narrow hall-
+	ways leading to the bridge.  Two crew members leaving a con-
+	trol station  stumble into the group and are quickly dis-
+	patched by Han.  The princess waits with the robots as the 
+	general and Han enter the bridge.  The two pilots and 
+	navigator are taken by surprise and are promptly subdued. 
+	Han switches on the intercom and listens.</sd>
+         <sp spk="HAN">
+		How are we going to get them to 
+		open the silo cover?</sp>
+         <sp spk="SKYWALKER">
+		Send C-3 in here.  Dispose of any 
+		crewmen left on board.</sp>
+      </scene>
+      <scene n="103">
+         <setting>BOARDING RAMP - SPACEPORT - TOWNOWI</setting>
+         <sd>Valor and Oxus now wear the uniform of the royal guard. 
+	Oxus has removed a plate from the cutter machinism and is 
+	crossing a few wires.  He replaces the cutter plate just as a 
+	squad of stormtroopers rushes toward the door.  An officer 
+	salutes them.</sd>
+         <sp spk="OFFICER">
+		Have you seen them?</sp>
+         <sp spk="JUSTIN">
+		No, Sir.</sp>
+         <sp spk="OFFICER">
+		They're in this section somewhere. 
+		I'm doubling all the guards.  Stay 
+		alert.</sp>
+         <sd>Two guards take up positions just outside the cutter areas, 
+	and the squad moves on to another starship.  Valor gives 
+	his partner a philosophical look.</sd>
+      </scene>
+      <scene n="104">
+         <setting>INTERIOR - ROYAL STARSHIP - TOWNOWI</setting>
+         <sd>The gleaming chrome C-3 sits in the pilot's seat  talking 
+	on the intercom to a controller.  He breaks off his continual 
+	drone of take-off instructions to the controller  and turns 
+	to the general, shaking his head.</sd>
+         <sd>			 C-3
+		They won't buy it.  I think they're 
+		getting suspicious.</sd>
+         <sd>Han enters.</sd>
+         <sp spk="HAN">
+		The crew is taken care of.</sp>
+         <sp spk="SKYWALKER">
+		Well, they're not going to open 
+		the silo cover, so I'm afraid we'll 
+		have to take it with us.</sp>
+         <sp spk="HAN">
+		We're going to sustain considerable 
+		damage if we blast off through that 
+		cover.</sp>
+         <sp spk="SKYWALKER">
+		It's a thin  shell.  There is no 
+		choice.  (to C-3)  Signal the boys.</sp>
+      </scene>
+      <scene n="105">
+         <setting>BOARDING RAMPS - SPACEPORT - TOWNOWI</setting>
+         <sd>Warning lights flash and the main hatch to the starfighter 
+	slowly begins to close.  The two royal stormtroopers yell 
+	at Valor and Oxus.</sd>
+         <sp spk="STORMTROOPERS">
+		Watch it!  Don't fire into those 
+		cutters!  (to Valor)  Shut down 
+		the cutters!</sp>
+         <sd>The two captains pretend to be confused  and not understand. 
+	At the last minute  they leap aboard the starship.  The hatch 
+	slides closed  and the boarding ramp drops away.  Several 
+	more guards arrive  and give the troopers a special card, 
+	which turns the small cutter warning lights from red to green. 
+	The guards rush on to the boarding ramp and are wiped out by 
+	the reversed cutters.</sd>
+      </scene>
+      <scene n="106">
+         <setting>INTERIOR - STARSHIPS - TOWNOWI</setting>
+         <sd>They strap themselves into lifepods.  C-3 and the general 
+	move forward, and the giant ship shudders as it starts to 
+	lift off the launch pad.  With tense expressions, they all 
+	brace for the impact of the silo cover.</sd>
+      </scene>
+      <scene n="107">
+         <setting>STARSHIP - SPACEPORT SILO - TOWNOWI</setting>
+         <sd>The mighty starship thunders out of the silo, crashing
+	through the cover plate, sending shrapnel in all directions. 
+	The ship leaps toward the heavens.</sd>
+      </scene>
+      <scene n="108">
+         <setting>BOARDING CAMPS - SPACEPORT - TOWNOWI</setting>
+         <sd>Royal flight crews rush to their starships.  Pilots receive 
+	their clearances  and several giant silo covers swing away 
+	revealing deadly hunter-destroyer spaceships.</sd>
+      </scene>
+      <scene n="109">
+         <setting>INTERIOR - BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han and the general watch as five hunter-destroyers leave the 
+	spaceport at Gordon.</sd>
+         <sp spk="SKYWALKER">
+		We suffered light damage to a deflector 
+		fin.  It will take them quite a while 
+		to catch up with us now.  Tell the boys 
+		to get some rest.</sp>
+      </scene>
+      <scene n="110">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Han retreats to the aft section of the ship, where the two 
+	captains are checking out the two main lazercannons mounted 
+	in large rotating bubble turrets.</sd>
+         <sp spk="HAN">
+		The old boy says you two should get 
+		some rest.  You've got some time 
+		before they catch up to us.</sp>
+         <sd>Han notices the packs containing the young princes.</sd>
+         <sp spk="HAN (Cont.)">
+		Better store the boys in a lifepod. 
+		Secure them well.</sp>
+         <sd>He heads back toward the bridge, followed by Oxus.  Valor 
+	carries the two mircropacks to a lifepod and straps them in. 
+	He checks Oeta's energy supply.  It is low.  Zara approaches 
+	him.</sd>
+         <sp spk="ZARA">
+		Couldn't we let them out now?</sp>
+         <sp spk="JUSTIN">
+		It's better this way.  Things are 
+		going to get rough.</sp>
+         <sp spk="ZARA">
+		Will we make it?  Is there any 
+		hope?  Stay with me.  I love you.</sp>
+         <sd>Captain Valor is slightly shocked at this outburst.  The 
+	princess starts to cry and clings to him for support.</sd>
+         <sp spk="JUSTIN">
+		No-one is going to die, so stop acting 
+		like a child and start behaving like a 
+		queen.  What is this silly talk of love?  
+		You belong to the people of Townowi  and 
+		my job is to return you to them, nothing 
+		more.  Now straighten up and get into a 
+		lifepod.</sp>
+         <sd>She's deeply hurt by his callousness.  She breaks away from 
+	him and runs down a hallway into a lifepod.  He is tired 
+	and angry at the whole incident.</sd>
+      </scene>
+      <scene n="111">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>C-3 guides the starship toward the Ophuchi system.  The 
+	general watches the computer readout estimate the position 
+	of the royal hunter destroyers.</sd>
+         <sd>			 C-3
+		Hostile craft will intercept at 
+		thirty plus.</sd>
+      </scene>
+      <scene n="112">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Captain Valor rests in one of the lazercannon pod bays.  He 
+	is thinking about Zara.  Slowly, a smile creeps across his
+	face.  He makes a decision, jumps up  and hurries down a
+	hallway.  He taps on the lifepod bulkhead  and Oxus opens 
+	the door.  Valor is surprised.</sd>
+         <sp spk="OXUS">
+		What is it?</sp>
+         <sp spk="JUSTIN">
+		Where is Zara?</sp>
+         <sp spk="OXUS">
+		She went forward.  What's going 
+		on with you two?
+		
+				 JUSTIN
+		I love her.</sp>
+         <sp spk="OXUS">
+		You're asking for trouble.  She's a queen. 
+		Do you know what you're saying?</sp>
+         <sp spk="JUSTIN">
+		I don't care.  I've got to talk ...</sp>
+         <sd>Oxus just shakes his head, but before Valor can finish his 
+	sentence, the ship is rocked by a bombardment of proton 
+	torpedoes.  The intercom squawks to life.</sd>
+         <sp spk="SKYWALKER (over intercom)">
+		Get to those guns!</sp>
+         <sd>Captain Valor and Oxus rush to the lzercannons and jump into 
+	the protective suits and helmets.</sd>
+      </scene>
+      <scene n="113">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han enters the bridge and sits before a fire control center. 
+	The general sits in a chair  slightly behind and above C-3, 
+	directing the robot pilot.</sd>
+         <sp spk="SKYWALKER">
+		Turn around!  Let's face them.</sp>
+         <sd>A-2, sitting quietly in a corner, watches as C-3 punches 
+	new information into the computer and the giant starship 
+	swings around in a sharp circle.  Several torpedoes explode 
+	near the ship.  The general switches on the intercom.</sd>
+         <sp spk="SKYWALKER">
+		You boys ready?</sp>
+      </scene>
+      <scene n="114">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The captains adjust the lazercannon controls in front of 
+	them and check in with the general.</sd>
+         <sp spk="SKYWALKER">
+		They should be within range in 
+		twelve seconds...</sp>
+         <sd>Captain Valor adjusts his giant lazer ack-ack cannon, 
+	searching his electronic tracking screen for the hunter
+	destroyer.  Oxus is having a problem with one of the
+	rotating mechanisms on the huge gun.  He curses, climbs 
+	out of the chair, and attempts to fix it.</sd>
+         <sp spk="OXUS">
+		My vertical rotating circuits are 
+		out.</sp>
+         <sd>The princess straps herself into a small lifepod.  Only the 
+	slightest hint of concern or worry shows in her face.  She 
+	listens to her protectors relay instructions as the enemy 
+	approach.</sd>
+      </scene>
+      <scene n="115">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The starship shudders as the hunter destroyers open fire.
+	Han relays the ship's status to the general  as C-3 struggles 
+	to keep up with the barrage of orders.</sd>
+         <sp spk="HAN">
+		We're losing deflectors three 
+		thirty-one and ten forty-two.</sp>
+         <sp spk="SKYWALKER (to C-3)">
+		Cut hard to maridian nine zero 
+		six.  Level to three degrees.
+		(into the intercom)  We're 
+		coming under one.  Wait for my 
+		signal.</sp>
+      </scene>
+      <scene n="116">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The constant flashing of deflected lazer bolts reflect in 
+	the interior of the lazercannon bubble.  Captain Valor 
+	rechecks his firing swithces.  Oxus adjusts his headphones 
+	and lowers a glare reflector.  He raps on the power rotation 
+	circuits  and gives them a little test burst.  The pod 
+	instantly rotates a few degrees.  The large starship heads 
+	directly toward the three enemy ships and at the last moment 
+	dives under the attacking craft.  Valor watches the smaller 
+	crafts pass overhead, aching to open fire.  He calls Oxus on 
+	the intercom.</sd>
+         <sp spk="JUSTIN">
+		I've got no signal.  I'm on 
+		target.  What's wrong?  What 
+		is he waiting for?  I've got 
+		an open shield.</sp>
+         <sd>The three royal craft are firing incessantly at point blank 
+	range.</sd>
+         <sp spk="OXUS">
+		Wait for the signal.</sp>
+         <sd>But Captain Valor has a perfect shot and he can't wait.  He 
+	squeezes the trigger and the giant lazercannon, with a burst 
+	of smoke and electrical charge, opens up on the enemy craft. 
+	Moments later, the signal lights flash on and Oxus commences 
+	firing on the receding  hunter-destroyers.  Two of the royal 
+	craft break off, and prepare for another attack run.  The 
+	third is hit by a concentrated barrage from the two captains 
+	and begins spinning out of control until it finally explodes. 
+	Oxus gives the victory wave, which Justin gleefully returns. 
+	These moments of triumph are broken by the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, next run you wait for 
+		my signal.  We haven't much power to 
+		spare on your inaccurate grandstanding!</sp>
+         <sd>Justin's pride is wounded.  He resets his accelerators as 
+	the two remaining hunter-destroyers begin a second run.</sd>
+      </scene>
+      <scene n="117">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+		We have a weakened shield on the 
+		port turret...</sp>
+         <sp spk="SKYWALKER">
+		Warn Captain Valor.  Get him out of 
+		there.  (to C-3)  Change your 
+		heading by point five.</sp>
+      </scene>
+      <scene n="118">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Princess Zara listens to Han warn Valor.</sd>
+         <sp spk="HAN">
+		Your shield power is down.  Abandon 
+		that position and seal that section. 
+		Report!  Captain, do you hear me?  
+		Captain?!!!</sp>
+         <sd>Zara becomes worried that something has happened to Justin. 
+	The young captain switches off the intercom system and 
+	signals to Oxus that the system has gone dead.  Before Oxus 
+	can answer, the two hunter-destroyer spacecraft are upon 
+	them once again.  Lazer bolts flash all around them.  The 
+	general's signal flashes on, and the captain starts to 
+	return the fire.  One of the royal fighters concentrates 
+	its fire on Valor's weakened gunport.  A direct hit blows 
+	open a hole in the turret and everything that isn't bolted 
+	down is sucked into outer space, including Captain Valor. 
+	He bangs against the side of the starship, held only by a 
+	weakened lifeline.</sd>
+         <sd>The princess hears Oxus explain Valors predicament  and 
+	rushes back to help him.  She is stopped by a pressure 
+	locked door leading to the gun emplacement.</sd>
+      </scene>
+      <scene n="119">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The general orders C-3 to swing the spacecraft around and 
+	start a new attack.  He turns to A-2.</sd>
+         <sp spk="SKYWALKER">
+		Use the aft port.  See what you can 
+		do for Valor.</sp>
+         <sd>A-2 hurriedly waddles out of the bridge.  C-3 and Han 
+	simultaneously turn to the general.</sd>
+         <sd>			 C-3
+		More craft approaching!</sd>
+         <sp spk="HAN">
+		It looks like at least six or seven.</sp>
+         <sd>The general studies the radar scopes and then checks a
+	galactic map displayed on one of the monitors.</sd>
+         <sp spk="SKYWALKER">
+		Change course to three point one.</sp>
+         <sd>			 C-3
+		That will head us directly into 
+		the path of the Norton Asteroid 
+		Belt.</sd>
+         <sp spk="HAN">
+		That asteroid belt is too dense 
+		to pass through.  The ship won't 
+		make it!</sp>
+         <sp spk="SKYWALKER">
+		We'll never defeat them in combat. 
+		It's our only chance to lose them.</sp>
+         <sd>C-3 punches in new coordinates  and the starship veers away 
+	toward the treacherous asteroid belt.</sd>
+      </scene>
+      <scene n="120">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Oxus fires on one of the two hunter-destroyers which is
+	pacing the rebel starship.  Captain Valor unsuccessfully 
+	tries to pull himself back inside the spacecraft.  The enemy 
+	craft maneuvers wildly in an attempt to get into a better 
+	position to fire on Valor.  Oxus blasts away until the royal 
+	spacecraft spews forth equipment and personnel, careens off, 
+	and eventually explodes.</sd>
+         <sd>A-2 wobbles along the exterior of the ship until he reaches 
+	the stranded captain.  He attaches a new lifeline to the 
+	young Dai's spacesuit and makes his way back inside the 
+	wounded craft.  Valor is pulled to safety just as the star-
+	ship enters the asteroid belt.  A barrage of small and large 
+	asteroids begins to pelt the ship, causing a great deal of 
+	damage.</sd>
+         <sp spk="SKYWALKER (over intercom)">
+		Secure yourselves.  We may have to 
+		eject.  Abandon the turrets.</sp>
+         <sd>The princess rushes back to her lifepod and straps herself
+	in.  Oxus and A-2 help Valor make his way out of the lazer-
+	cannon turrets and through a series of locks, to the life-
+	pod area.</sd>
+      </scene>
+      <scene n="121">
+         <setting>BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The asteroids hit hard.  The ship is buffeted to and fro as 
+	the general, Han, and C-3 struggle into their spacesuit-
+	like lifepods.  The royal hunter-destroyer closest to the 
+	rebel ship explodes in the on-rush of deadly asteroids. 
+	The new reinforcement hunter-destroyers turn back and give 
+	up the pursuit.  They disappear from the tracking monitors. 
+	The asteroid bombardment becomes almost unbearable.  Warning 
+	lights begin to flash.  Extending foils, antennae, and arma-
+	ment pods are scraped away from the starship hull.  A base-
+	ball sized hole is punched through the midsection, and 
+	hundreds of objects are sucked into space.  A large locker 
+	eventually plugs the opening.  The starship and her passengers 
+	shudder and sway under the punishment of the asteroid storm.</sd>
+         <sd>			 C-3
+		The ship is breaking up.</sd>
+         <sp spk="HAN">
+		We're almost clear of the storm.</sp>
+         <sd>			 C-3
+		We'll never make it.  Eject.  We 
+		must eject.</sd>
+         <sd>The general watches the computer monitor as the starship
+	emerges from the far side of the asteroid belt.</sd>
+         <sp spk="HAN">
+		We're approaching one of the 
+		Forbidden Systems.</sp>
+         <sp spk="SKYWALKER">
+		We've got to achieve orbit.</sp>
+         <sd>			 C-3
+		We'll never make it.</sd>
+         <sd>The starship heads for a small blue-green planet in the
+	distance.</sd>
+      </scene>
+      <scene n="122">
+         <setting>AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Captain Valor was considerably shaken in the destruction of 
+	his lazerturret.  He is slightly dazed as Oxus straps him 
+	into a lifepod with A-2.</sd>
+         <sp spk="OXUS (to A-2)">
+		You watch him.  Make sure this 
+		pod gets off all right.</sp>
+         <sd>A-2 nods  and Oxus moves to the second lifepod and straps 
+	himself in next to the princess.</sd>
+         <sp spk="ZARA">
+		Will he be all right?</sp>
+         <sp spk="OXUS">
+		I think so.  His feelings for 
+		you are dangerous.  You should 
+		discourage him.</sp>
+         <sd>She is surprised that Valor has any feeling for her  but 
+	keeps her emotions to herself.</sd>
+      </scene>
+      <scene n="123">
+         <setting>BRIDGE - STARSHIP - YAVIN ORBIT</setting>
+         <sd>The general is strapped into the lifepod with the two 
+	micropacks containing the young princes.  Han and C-3 are 
+	in the second lifepod.</sd>
+         <sp spk="HAN">
+		We're in orbit.</sp>
+         <sd>			 C-3
+		We've got to eject now!  Those reactors 
+		won't hold much longer.  This ship's 
+		going to end up in a million little 
+		pieces  and I don't want to be one of 
+		them.</sd>
+         <sp spk="HAN">
+		All lifepod systems are operative.</sp>
+         <sp spk="SKYWALKER (into intercom)">
+		If you boys are ready back there, 
+		we'll get off this bucket.</sp>
+         <sp spk="OXUS">
+		All systems operative.  I 
+		have the signal.</sp>
+         <sd>			 A-2
+		All systems operative.  We 
+		have the signal.</sd>
+         <sd>Han salutes the general  and his lifepod jettisons away 
+	from the crippled starship.  He is quickly followed by 
+	the general.</sd>
+      </scene>
+      <scene n="124">
+         <setting>AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>A-2 pushes the jettison switch  but nothing happens.  Cap-
+	tain Valor slowly and with some difficulty  pushes the 
+	switch two or three times.  Nothing happens.  He begins to
+	look a little worried.</sd>
+         <sd>			 A-2 (into intercom)
+		We've got a problem.  Wait a 
+		second.</sd>
+         <sd>A-2 pushes the switch again  and the lifepod blasts off in 
+	a cloud of smoke and debris.  Oxus also seems to be having 
+	a problem.  Half the lights on his control panel have gone 
+	dead.  He struggles to reactivate them.</sd>
+         <sp spk="OXUS">
+		My power's out!</sp>
+         <sp spk="SKYWALKER (over intercom)">
+		Is it a faulty switch?</sp>
+         <sp spk="OXUS">
+		No.  The whole bank is out.</sp>
+         <sd>Oxus gives the princess a reassuring look, then punches some 
+	information into the computer.  The monitor flashes: "Income 
+	line main power."  He looks outside the lifepod and sees a 
+	damaged cable.</sd>
+         <sp spk="OXUS">
+		I've found it.</sp>
+         <sp spk="SKYWALKER">
+		You haven't much time.  The 
+		auxiliary units have already 
+		blown.</sp>
+         <sd>Oxus scrambles out of the lifepod and rushes over to the 
+	severed connector.  He works on it for a few moments, then 
+	stops with a rather defeated look.  The princess watches 
+	him as he tries to think of a solution.  A great explosion 
+	is heard in the forward part of the ship.</sd>
+      </scene>
+      <scene n="125">
+         <setting>LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods containing the general, Han and C-3 drift 
+	away from the disabled starship.</sd>
+         <sp spk="SKYWALKER">
+		Where's Captain Valor?</sp>
+         <sp spk="HAN">
+		I can't see him either.</sp>
+         <sd>Captain Valor uses the small rockets on his lifepod to 
+	maneuver back toward the burning starship.  He can hear the 
+	general over the intercom.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, where are you? 
+		Report in.</sp>
+         <sd>Valor reaches down and switches off the intercom.</sd>
+      </scene>
+      <scene n="126">
+         <setting>AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Oxus appears to have found a solution to his situation and 
+	rushes back to the princess.  He reaches in and locks on the 
+	power switch.</sd>
+         <sp spk="OXUS">
+		There is only one possible solution 
+		and we must use it.  Lock the hitch 
+		and make sure it is sealed.</sp>
+         <sp spk="PRINCESS">
+		But what of...?</sp>
+         <sd>Another explosion creates a large bulge in the wall of the 
+	aft section.</sd>
+         <sp spk="OXUS">
+		We've no time!</sp>
+         <sd>He slams the hatch shut and runs to the power connector.
+	Smoke begins to fill the chamber, as Oxus slams a large 
+	metallic dampening tool across the damaged connector ter-
+	minals, and the lifepod jettisons away.</sd>
+      </scene>
+      <scene n="127">
+         <setting>LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The princess jettisons free, as Captain Valor moves toward 
+	the crippled ship.  Zara calls the general on the intercom.</sd>
+         <sp spk="ZARA">
+		I'm all right, but Clieg is 
+		still on board.</sp>
+         <sp spk="SKYWALKER">
+		Captain Valor, stay out of 
+		there.</sp>
+         <sd>With a rumble, the starship disappears in a spectacular
+	explosion, sending debris in all directions.  Valor stops 
+	his lifepod and it starts to drift.  He is weeping.  Han 
+	and the general watch the remains of the explosion drift 
+	away.</sd>
+         <sp spk="SKYWALKER">
+		Captain Valor, stay near Zara. 
+		Use your beacon.  Coordinate 
+		with us.</sp>
+         <sd>Valor's intercom is weak and there is a great deal of static. 
+	The lifepods drift toward the awesome blue-green Yavin 
+	surface.  The general loses sight of the other lifepods as 
+	they descend through the cloud cover.</sd>
+         <sp spk="SKYWALKER">
+		Captain, I'm losing your beacon. 
+		Send me a new signal.</sp>
+         <sd>All he gets is static.  The planet surface rushes toward the 
+	falling lifepods.  Retrorockets automatically kick in and 
+	slow the pods.  Two of the small craft break through the 
+	brown clouds and land in the dense, steaming jungles.  The
+	sky is a strange light brown color.</sd>
+      </scene>
+      <scene n="128">
+         <setting>VINE JUNGLE - YAVIN</setting>
+         <sd>The general's lifepod crashes through the foliage until it 
+	comes to rest in the middle of a large vine-covered tree. 
+	He grabs the two micropacks and climbs out of the lifepod 
+	and onto a large  moss-covered limb.  Han and C-3 run to the 
+	base of the huge tree.</sd>
+         <sp spk="HAN">
+		Are you all right?</sp>
+         <sp spk="SKYWALKER">
+		Fine.  Any signal from Captain
+		Valor?</sp>
+         <sp spk="HAN">
+		Nothing yet.  I think they landed 
+		further south.</sp>
+         <sd>The general attaches a thin cable from his utility belt to 
+	the tree trunk  and slides to the ground.  Han takes the 
+	micropacks from him. The general looks around at the jungle.</sd>
+         <sp spk="SKYWALKER">
+		This is dangerous country.  We'd better 
+		stay together.</sp>
+         <sd>			 C-3
+		The wildlife in the Forbidden System 
+		is extremely hostile.  Perhaps we 
+		should seek shelter?</sd>
+         <sd>Han inspects the power units of the micropacks.</sd>
+         <sp spk="HAN">
+		Puck's unit is very low.  I can't 
+		tell if the unit is still functioning.</sp>
+         <sp spk="SKYWALKER">
+		We have to find a place to revive 
+		them.  We'll start moving south.  We 
+		should find protection along that 
+		ridge.</sp>
+         <sd>The general grabs one of the micropacks and starts off into 
+	the murky jungle.  Han and C-3 quickly follow.  The jungle 
+	is a strange and eerie fog-laiden purgatory.  Gruesome and 
+	unnatural sounds permeate this ghostly wasteland.  Everyone 
+	is cautious and on the alert for an unseen danger.</sd>
+      </scene>
+      <scene n="129">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Captain Valor's lifepod is also caught in the limbs of a
+	gargantuan tree.  The lifepod has been ripped in half by the 
+	crash landing.  The unconscious Dai hangs half out of the 
+	damaged craft.  A two-foot high insect-like creature scoots 
+	down a branch and onto the back of the dormant warrior.  The 
+	insect lets out a chilling hissing sound and a slimy tube 
+	emerges from its hairy mouth, waking Valor.  He is immediately 
+	aware of the insect.  His eyes are open but he doesn't move.  
+	Suddenly with one quick blow he knocks the creature against 
+	the side of the spacecraft and it is squashed lifeless.</sd>
+         <sd>Captain Valor is a little groggy but he manages to climb 
+	out of the wreckage.  He looks around for A-2.</sd>
+         <sp spk="JUSTIN">
+		A-2!  A-2!</sp>
+         <sd>			 A-2
+		Help!</sd>
+         <sd>Valor turns and sees the little robot hanging upside down, one 
+	of his three feet caught in a vine.  He lifts A-2 out of his 
+	predicament and places him securely on a wide limb.</sd>
+         <sp spk="JUSTIN">
+		Did you see Zara?</sp>
+         <sd>			 A-2
+		She landed on the other side of those 
+		trees, approximately eight hundred 
+		meters.</sd>
+         <sp spk="JUSTIN">
+		Well, come on, old buddy.  Let's get 
+		ourselves out of this tree.</sp>
+      </scene>
+      <scene n="130">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general, Han, and C-3 reach a shallow cave near the top 
+	of a steep ridge.  They quickly pull off the micropacks and 
+	place them on a clear piece of ground at the mouth of the 
+	cave.</sd>
+         <sp spk="SKYWALKER (to Han)">
+		Check out the inside.  C-3, stand 
+		guard.  Keep you eye on the country-
+		side.</sp>
+         <sd>He looks at the power units on the micropacks and shakes his 
+	head with a worried look.  Han returns from a survey of the 
+	inside of the cave.</sd>
+         <sp spk="HAN">
+		It doesn't go very far.  There's 
+		nothing back there.</sp>
+         <sp spk="SKYWALKER">
+		Help me with this.</sp>
+         <sd>Han helps the general lift the top from the case containing 
+	Puck, the younger of the two princes.  The small boy appears 
+	lifeless as the general pulls him from his encasement and 
+	rests him on the cave floor.  Han pulls a small respirator 
+	out of the micropacks and places it over the boy's nose.  The 
+	general attaches two electrodes over his heart.</sd>
+         <sp spk="HAN">
+		He doesn't look good.</sp>
+         <sd>The little prince begins to turn blue.  The general grows
+	tense.  Puck starts to regain consciousness  but begins
+	coughing and choking, then goes limp again.  The general
+	quickly props Puck's mouth open with a small plastic rod and 
+	checks the reading on his powerpack.</sd>
+         <sp spk="SKYWALKER">
+		We need more power.  Tap off Oetas 
+		unit.  Quickly!</sp>
+         <sd>He then places Puck's arms behind his back and starts pressing 
+	on his chest with sharp, rhythmic movements.  Han attaches 
+	new electrodes to the boy's heart.  Puck again comes to, 
+	choking and coughing.  Finally, he begins to cry.  The general 
+	takes the plastic tube from Pucks mouth and tenderly pats 
+	him on the back.</sd>
+         <sp spk="SKYWALKER">
+		Let's get Oeta out of there.  He 
+		shouldn't be a problem.</sp>
+      </scene>
+      <scene n="131">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Valor slams closed the hatch of Princess Zara's lifepod. 
+	In the distance the subhuman cries of lonesome tree beasts 
+	cut through the forest murmur.</sd>
+         <sd>			 A-2
+		Perhaps she went in search of 
+		us.</sd>
+         <sd>Valor studies the ground around the capsule.  There are a 
+	great many footprints and much broken foliage.</sd>
+         <sp spk="JUSTIN">
+		Someone's got her.  She put up 
+		quite a fight.  It's an easy 
+		trail to follow.</sp>
+      </scene>
+      <scene n="132">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Both Oeta and Puck are sleeping restlessly on the floor of 
+	the cave.  Han watches over them as the general scans the 
+	valley below with a pair of electrobinoculars.</sd>
+         <sd>			 C-3
+		It's about fourteen degrees below 
+		the horizon...a little to the left.</sd>
+         <sd>The electrobinoculars sweep the rich green landscape until 
+	they come to rest on a bright reflection revealing some 
+	type of structure.</sd>
+         <sp spk="SKYWALKER">
+		It's too small to be a military 
+		base.  Could belong to a trapper.</sp>
+         <sd>			 C-3
+		Highly unusual.</sd>
+         <sp spk="SKYWALKER">
+		It's on the way.  Perhaps we 
+		should investigate.
+		
+	Little Oeta wakes up with a giant yawn.</sp>
+         <sp spk="OETA">
+		Hey!  Where are we?</sp>
+      </scene>
+      <scene n="133">
+         <setting>FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>The gargantuan trees are shrouded in mist, and the ominous 
+	sounds of unearthly creatures fill the air.  Captain Valor 
+	moves quietly and cautiously, followed by A-2, who 
+	inadvertently makes a loud clicking sound.  The young 
+	warrior stops and motions to the stubby little robot.</sd>
+         <sp spk="JUSTIN">
+		Wait here.  If I don't return by 
+		zero two hundred, come looking 
+		for me.</sp>
+         <sd>The mechanical dwarf acknowledges with his computer light.
+	Valor moves swiftly and silently forward, until he hears 
+	laughing and voices.  He climbs up the bankside of a huge 
+	tree and inches his way out onto one of the huge overhanging 
+	branches.  Below him he can see a group of scruffy alien 
+	trappers sitting around a nutron stove, joking and telling 
+	stories.  Parked on either side of the group are two large, 
+	tank-like jungle-crawlers.  Behind the crawlers, five Jawas 
+	(huge gray and furry beasts) hang upside down in a tree. 
+	Occasionally they thrash about in great anger and frustration.</sd>
+         <sd>The trappers speak in a strange language, and although they 
+	appear slightly human, they are slimy, deformed, hideous 
+	looking creatures.  Two of the trappers yell at each other 
+	in a friendly argument.  One shirtless creature goes into a 
+	crawler and the remaining eight laugh hysterically.  Captain 
+	Valor moves further out on the limb to get a better view.  A 
+	couple  of pieces of bark break loose, and float a hundred 
+	feet to the ground.  The trappers fail to notice.  Moments 
+	later, the shirtless trapper emerges from the crawler with 
+	the princess held unconscious and half naked over his head. 
+	Valor's rage knows no bounds.  With a terrifying Dai war cry, 
+	the young captain jumps from the tree, sails over a hundred 
+	feet, and with great agility, lands in the middle of the 
+	startled trappers.  In one continuous rapid motion, he ignites 
+	his lazersword and cuts down three of the vile creatures.  The 
+	shirtless trapper swings the princess over his shoulder  and	 
+	runs back into the huge jungle crawler.  Two other trappers 
+	reach for their pistols, but the Dai has killed them before 
+	their weapons can clear leather.  The three remaining 
+	creatures have their pistols out and start firing.  Explosions 
+	erupt all around Valor.  One blast hits the branch holding 
+	the Jawas  and they collapse with a loud screech in a heap. 
+	One of the trappers is caught in the crossfire and is blown 
+	apart.</sd>
+         <sd>When the smoke clears  Valor lies unconscious amid the 
+	burning rubble.  The jungle crawler begins to move out of the 
+	camp.  The last two trappers run after it.  One is able to 
+	jump on board, but the second trapper runs too close to the 
+	now freed Jawas.  Boma, one of the furry giants, grabs him 
+	and snaps him in two, like a stick of wood.  The jungle 
+	crawler disappears in the forest mist.  The eight foot Boma, 
+	who resembles a huge, gray bushbaby with fierce baboon-like 
+	fangs, struggles to free his companions.</sd>
+         <sd>Valor regains semi-consciousness, and attempts to get up, only 
+	to groan and collapse back into unconsciousness.  The Jawas 
+	gather around him and poke him a couple of times to see if 
+	he is still alive.  They squawk and jabber, apparently in 
+	some kind of argument.  Finally, Wann, the largest of the Jawas 
+	picks up Valor and puts him over his shoulder.  The group 
+	disappears into the jungle foliage.</sd>
+      </scene>
+      <scene n="134">
+         <setting>TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Han and C-3 carry the two little boys on their shoulders. 
+	The general stops on the edge of a clearing and motions for 
+	the others to be still.  Oeta turns around and signals his 
+	little brother to be quiet.  On the opposite side of the 
+	clearing, a small metal structure is attaached to one of the 
+	huge trees.  It is a small, weatherbeaten hut of futuristic 
+	design.  It appears deserted.  The general cautiously 
+	approaches the structure.</sd>
+         <sp spk="VOICE">
+		Howdy stranger.  What can I offer you?</sp>
+         <sd>The general spins around and sees Huu Tho, an aged and scruffy 
+	looking anthropologist.</sd>
+         <sp spk="THO (Cont.)">
+		I'm Huu Tho of Bastine.</sp>
+         <sd>The general takes the old man's extended hand.</sd>
+         <sp spk="SKYWALKER">
+		I'm Luke Skywalker of Townowi.</sp>
+         <sd>He signals for the others to join him in the clearing.</sd>
+      </scene>
+      <scene n="135">
+         <setting>WOOKEE CAMP - YAVIN</setting>
+         <sd>The small caravan of Jawas, led by Boma, enters a small 
+	clearing surrounded by many bark and mud hovels.  Young 
+	Jawas race ahead of the group, yelling and running in and 
+	out of the grubby little dwellings.  Giant, bushbaby-like 
+	Jawas of all ages and sizes make their way into the clearing. 
+	Many stand dumbfounded, but others let out a joyful scream 
+	and rush up to members of the group, hugging and kissing them.</sd>
+         <sd>Wann dumps the unconscious captain on a raised area in the 
+	middle of the clearing.  Armed Jawas immediately surround the 
+	helpless human.  Boma enters the largest of the lodges.  He 
+	is greeted by his father, Auzituck, chief of the Kaapauku 
+	tribe.  He is an old and feeble Jawa dressed in royal skins 
+	and headdress.</sd>
+      </scene>
+      <scene n="136">
+         <setting>INTERIOR - ANTHROPOLOGIST HUT - YAVIN</setting>
+         <sd>Anthropologist Tho, the general, Han and the children sit 
+	around a large table eating.  Tho yells into the kitchen.</sd>
+         <sp spk="THO">
+		Beru!  Where's the thanta sauce?</sp>
+         <sd>BERU THO, Kuu's warm plump wife, enters carrying a small 
+	pitcher.  She smiles at Kuu.</sd>
+         <sp spk="BERU">
+		I swan!  I put it right here in 
+		front so you'd see it.  (to Han)  
+		Here's some bum bum extract. 
+		It's very mild.</sp>
+         <sp spk="THO (to general)">
+		There are no settlers to the south 
+		since the Dau family was wiped out. 
+		I'm afraid I couldn't even get in 
+		there to bury them.  Those Jawas 
+		are the fiercest critters I've ever 
+		run across.  A new tribe moved in 
+		down there about a year ago  and 
+		it's been hell ever since.  Only 
+		Yourellian trappers venture in 
+		there now  and many of them don't 
+		even come back.</sp>
+         <sp spk="SKYWALKER">
+		Where's the nearest city?</sp>
+         <sp spk="THO">
+		No cities at all, only a few 
+		scattered settlers and -- one 
+		royal outpost.  But the troops 
+		are of no help.  They kill and 
+		plunder rather than protect.
+		Enough.  If your friends landed 
+		farther south, I'd fear for them.</sp>
+         <sp spk="HAN">
+		How far is the outpost from here?</sp>
+         <sp spk="THO">
+		Five leagues...an oppressive 
+		blight.</sp>
+         <sp spk="SKYWALKER">
+		What class is it?  How many 
+		support craft?</sp>
+         <sp spk="THO">
+		It's very small, a class two.  
+		Only ten or twelve starraiders, 
+		I think.</sp>
+         <sd>Beru fusses over the boys, who refuse to eat their vegetables. 
+	She makes up a game  which tricks them into eating.  The 
+	general ponders the situation.  Han eats like he hasn't eaten 
+	in years.</sd>
+      </scene>
+      <scene n="137">
+         <setting>JAWA CAMP - YAVIN</setting>
+         <sd>Captain Valor is surrounded by Jawas.  Young ones push through 
+	to get a better look, as the adults jabber and argue about the 
+	human.  Valor regains consciousness with a groan, and a sudden 
+	hush sweeps over the gathering.  Valor staggers to his feet, 
+	and the group of Jawas back away en masse.  The young dai 
+	surveys the situation for a few moments.  The Jawas appear 
+	to be frightened of this brave warrior.  He reaches for his 
+	weapons  but they are gone.  Three guards with long spears 
+	attempt to contain Valor.  With a loud shout, he lunges at 
+	them and they give him a little room.  Jommillia, a large	 
+	ferocious Jawa, steps forward.  He says something to the 
+	guards and they quickly move away.  He struts before Captain
+	Valor, boasting and taunting him with his spear and battle 
+	ax.  The captain studies the Jawa warrior as he paces back 
+	and forth, his helmet plumes dancing and chest armor jangling. 
+	Without warning, Valor lets out another loud yell, startling 
+	Jommillia into backing off.  Captain Valor continues his 
+	verbal assault, calling the uncomprehending Jawa all manner 
+	of vile and degrading things.  Jommillia continues to back 
+	into the surrounding crowd, momentarily confused by this odd 
+	behaviour.  Slowly, Jommillia begins to grin.  He takes a 
+	defensive stance, then begins to laugh hysterically.  This 
+	stops Valor.  The giant Jawa swings his deadly double-bladed 
+	battle ax over his head and expertly throws it directly at 
+	the young captain's head.  To the amazement of Jommillia and 
+	the other Jawas, Captain Valor, with Dai Nogas skill and 
+	concentration, catches the ax in mid-air, then charges his 
+	furry opponent.</sd>
+         <sd>Jommillia is caught off-guard, but manages to block Valor's 
+	attack with his spear.  The two warriors engage in a savage 
+	and fantastic duel.  Valor cuts the Jawas spear in half, but 
+	is hit along the side of the head by the shaft and is momentaril 
+	dazed.  The battle ax is knocked from his hands.  He grabs the 
+	spear shaft and rams the giant creature in the belly.  A loud 
+	command from outside the crowd stops the fight.  The Jawas 
+	part, revealing Boma and his father, who approach the two 
+	warriors.  Jommillia bows before his chief, and is commanded 
+	to move away.  Boma speaks to Valor.  The captain doesn't 
+	understand, but welcomes the chance to catch his breath. 
+	Boma then presents his father, who steps forward and bows 
+	before the mighty Dai.  Boma bows also as the crowd of Jawas 
+	chatter in disbelief.  When the chief and his son rise, Valor 
+	bows before them.  This pleases the Jawas and they screech 
+	and cheer.</sd>
+      </scene>
+      <scene n="138">
+         <setting>TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Mr. and Mrs. Tho stand on the balcony of their tree house 
+	with C-3 and the two little princes, Oeta and Puck.  Han and 
+	the general emerge with large survival backpacks and multi-
+	plelazer weapons.</sd>
+         <sp spk="SKYWALKER (to C-3)">
+		We'll call for you when we've found them.</sp>
+         <sd>			 C-3
+		Your orders are quite clear.  The 
+		boys will be quite safe.</sd>
+         <sp spk="THO">
+		Don't worry.  The patrols never 
+		come out this far.  We'll take good 
+		care of the boys.</sp>
+         <sp spk="SKYWALKER">
+		Your kindness will surely be 
+		rewarded.</sp>
+         <sp spk="THO">
+		Just be careful out there.</sp>
+         <sd>He pats Skywalker on the back as the old Dai and the ever 
+	faithful Han descend from the tree house.  At the base of 
+	the huge tree, the warriors climb aboard two small rocket 
+	powered platforms.</sd>
+         <sp spk="THO (yelling down to them)">
+		They're pretty old.  I hope they'll 
+		be all right!</sp>
+         <sp spk="SKYWALKER">
+		Out here they're a wonderment.</sp>
+         <sd>C-3 and the kids wave as the jelsticks start with a whine. 
+	They idle about five feet above the ground.</sd>
+         <sp spk="THO">
+		Good hunting!  May the force of 
+		others be with you.</sp>
+         <sd>Han and the general wave as they ride off into the foreboding 
+	Yavin sunset.</sd>
+      </scene>
+      <scene n="139">
+         <setting>JAWA CAMP - YAVIN - NIGHT</setting>
+         <sd>A beautiful but frenzied fire festival is underway.  Jawas 
+	perform the Waita Tar dance, and yodel in a barking fashion 
+	around a large fire.  The female Jawas arrive, carrying 
+	torches  and move in a circle around the males.  The giant 
+	creatures are too involved to notice little A-2 make his way 
+	around the dancers.  The stubby robot stops near one of the 
+	mud huts and looks around.   He then wobbles off toward the 
+	large chief's quarters and enters.</sd>
+         <sd>								  - Dissolve -</sd>
+      </scene>
+      <scene n="140">
+         <setting>JAWA CAMP - YAVIN - MORNING</setting>
+         <sd>A-2 exits the chief's hut and looks around.  It is a quiet 
+	gray morning.  A low mist hangs over the now deserted 
+	clearing.  He turns and signals back into the hut.  Captain 
+	Valor cautiously emerges from the mud house.  He wears a 
+	crude backpack and carries a large battle ax.  They start 
+	across the clearing.  Suddenly, out of nowhere, Boma is 
+	standing before them.  He says nothing, but scratches his 
+	head and then circles around Captain Valor.</sd>
+         <sp spk="JUSTIN">
+		We are leaving.  We must go. 
+		Stand away!</sp>
+         <sd>The huge Jawa kneels and bows down in front of the young Dai. 
+	Valor looks down and smiles.</sd>
+         <sp spk="JUSTIN">
+		Rise my friend.  We will meet 
+		again.</sp>
+         <sd>Valor walks toward the jungle and Boma scurries ahead of him 
+	and bows down once more.</sd>
+         <sd>			 A-2
+		What does he want?</sd>
+         <sd>Valor shakes his head and rubs his several days growth of 
+	beard.  He leans down toward Boma.</sd>
+         <sp spk="JUSTIN">
+		Stand up so we can talk properly.</sp>
+         <sd>Boma jabbers in a questioning fashion.</sd>
+         <sp spk="JUSTIN">
+		I am grateful to you and your 
+		people, but I must go.  I wish 
+		you understood me.  I would 
+		make things so much easier.  
+		Go!  Go!</sp>
+         <sd>Valor turns away, and begins to walk toward the jungle again. 
+	Boma gets to his feet and runs after the Dai, following a few 
+	paces behind.  Valor notices the Jawa following them  and 
+	shakes his head.</sd>
+      </scene>
+      <scene n="141">
+         <setting>FOREST OF THE GARGANTUANS - TRAPPER SIGHT - YAVIN</setting>
+         <sd>The bodies of the killed trappers are covered with rat-sized 
+	insects.  A lazer explosion erupts in the middle of the slimy 
+	creatures and they scatter into the underbush.  Han and the 
+	general turn over one of the dead trappers.</sd>
+         <sp spk="HAN">
+		They ran into something.</sp>
+         <sp spk="SKYWALKER">
+		It's strange they left their 
+		dead.  Something...</sp>
+         <sd>The constant cacophony of jungle creatures suddenly stops. 
+	The two warriors scan the jungle for possible danger.  Han 
+	draws his lazerpistol.  The cacophony starts again as the 
+	general ignites his lazersword.</sd>
+         <sp spk="HAN">
+		Two or three moving this way 
+		from the east.</sp>
+         <sd>He listens more closely for a few moments.</sd>
+         <sp spk="HAN (Cont.)">
+		It's A-2.</sp>
+         <sd>Captain Valor and A-2 break out of the dark foliage into the 
+	clearing.  He waves to Han and the general.  A-2 waddles a 
+	few paces behind.  Boma sees the humans and stops at the 
+	edge of the jungle.  He watches as Captain Valor and the 
+	general carry on an animated conversation.  Han sees the 
+	Jawa lurking in the shadows.</sd>
+         <sp spk="HAN">
+		You were followed.</sp>
+         <sp spk="JUSTIN">
+		He wouldn't stay.  He's the one I 
+		saved.</sp>
+         <sd>Han calls out to Boma in the Jawa's own language  and the 
+	huge lumbering creature approaches the group.  Han and the 
+	Jawa talk for a few moments, then embrace as if they were 
+	old friends.  Captain Valor is surprised.</sd>
+         <sp spk="HAN (to Valor)">
+		This is Boma, son of Auzituck, 
+		Prince of the Sawas - a very 
+		powerful tribe.  It seems they've 
+		made you a god.</sp>
+         <sd>The general smiles.  Captain Valor is embarrassed.</sd>
+      </scene>
+      <scene n="142">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Captain Valor joins the general on a ridge overlooking the
+	royal outpost of Mavassi.  All that can be seen of the
+	fortress is a lone guard standing on a small pedastal jutting 
+	out above the dense jungle.</sd>
+         <sp spk="SKYWALKER">
+		Their trail leads directly to the 
+		outpost.  Patrols are probably 
+		out looking for us by now.</sp>
+         <sp spk="JUSTIN">
+		Finding her in there isn't going 
+		to be easy.</sp>
+         <sp spk="SKYWALKER">
+		Getting in there is going to be 
+		impossible, but we could sure 
+		use those starships.</sp>
+         <sd>Captain Valor spots something moving in the jungle.  He scans 
+	the area with his electrobinoculars.</sd>
+         <sp spk="JUSTIN">
+		Something's going on down there.
+		Han!</sp>
+         <sd>Han moves up next to Valor, followed closely by Boma.</sd>
+         <sp spk="JUSTIN">
+		Your eyes are better than mine.
+		What do you make of that?</sp>
+         <sp spk="HAN">
+		They look like Jawas, hundreds 
+		of them.</sp>
+         <sd>Han turns and speaks to Boma, gesturing toward the movement 
+	far below in the jungle.</sd>
+         <sp spk="HAN">
+		Apparently it's a siege.  They've 
+		been harassing the outpost for 
+		almost two years.</sp>
+         <sp spk="SKYWALKER">
+		Have they ever tried to take the 
+		fortress?</sp>
+         <sd>Han relays this to Boma.</sd>
+         <sp spk="HAN">
+		He says they've made several 
+		assaults, but they are no match 
+		for the weapons.</sp>
+         <sp spk="SKYWALKER">
+		It's only a class three fortress.  
+		Maybe they just need a little 
+		help.</sp>
+         <sd>Captain Valor grins, and Han says something to Boma, who 
+	becomes excited and screeches loudly.</sd>
+      </scene>
+      <scene n="143">
+         <setting>INTERIOR - TREE HOUSE - YAVIN</setting>
+         <sd>The incoming signal alarm on the anthropologist's radio
+	system wails through the calm of the tree house.  Oeta,
+	dragging an eight-legged, furry rodent, rushes up to the 
+	old radio and flips the receiver.</sd>
+         <sp spk="OETA">
+		I'm reading yah.  Go ahead.</sp>
+         <sp spk="SKYWALKER">
+		Oeta, how are you getting along?</sp>
+         <sp spk="OETA">
+		Great!  I caught a thumper, a 
+		really big one.  Its name is 
+		Amber.</sp>
+         <sd>He yanks on the leash, and the furry beast lets out a
+	strained yelp.</sd>
+         <sp spk="SKYWALKER">
+		Good, Oeta.  How's your brother?  
+		Are you taking good care of him?</sp>
+         <sp spk="OETA">
+		Oh, sure.  He's out collecting 
+		"abas" with Huu and Beru.  I'm 
+		in charge here.  Did you find 
+		Zara?</sp>
+         <sp spk="SKYWALKER">
+		Not yet.  We'll be away for a 
+		while.  You mind Tho until we 
+		return.  May the force of others 
+		be with you.</sp>
+         <sp spk="OETA">
+		All right.  Take care.</sp>
+         <sd>C-3 enters the room carrying a plate of steaming food. Oeta 
+	turns the radio off and puts the receiver away.  A crashing 
+	sound and voices are heard in the clearing below.</sd>
+         <sd>			 C-3
+		Come and eat your dinner.</sd>
+         <sp spk="OETA">
+		They're back!  They're back!  Come Amber.</sp>
+         <sd>The furry rodent jumps up onto its eight stubby legs and
+	rushes over to the door, but stops short and begins to growl. 
+	Oeta stops behind the creature.</sd>
+         <sp spk="OETA">
+		What is it, Amber?</sp>
+         <sd>Oeta peeks out the window, and sees a patrol of six royal 
+	stormtroopers climbing out of an airtank.  He ducks back 
+	and tugs Amber away from the door.</sd>
+         <sp spk="OETA">
+		Quiet, Amber.  Come here.  Come on.</sp>
+         <sd>			 C-3
+		What's wrong?</sd>
+         <sp spk="OETA">
+		Troopers.  We must hide.  Stay quiet.</sp>
+         <sd>Oeta and the robot scramble for a trap door near a large 
+	shelf.  The troops begin to climb the ladder to the tree 
+	house.  The trap door is heavy, and the robot and the little 
+	boy struggle to get it open.  The troops break in the door 
+	just as C-3 closes the trap door.  The troopers are led by 
+	a rough looking sergeant.  They poke around, tearing every-
+	thing apart.  Oeta struggles to keep Amber quiet.  Suddenly, 
+	he realizes something.</sd>
+         <sp spk="OETA">
+		The food!</sp>
+         <sd>The sergeant takes the bowl of food from the table and
+	studies it.  He then takes a small chrome ball from his
+	pocket and tosses it into the air.  Antennae shoot from 
+	its surface as it floats around the room.  Eventually it 
+	hovers over the trap door.  A sinister grin sweeps across 
+	the sergeant's face as he moves over to the trap door and 
+	puts the chrome ball back into his pocket.</sd>
+         <sd>C-2 puts his arm around Oeta, who is desperately clutching 
+	the struggling thumper.  All the movement above them stops 
+	and Oeta looks to the robot.</sd>
+         <sd>			 C-3 (quietly)
+		They're still up there.  Stay 
+		still.</sd>
+         <sd>The silence continues, then suddenly the trap door swings 
+	open with a loud bang.  Amber breaks away from Oeta and 
+	attacks the sergeant.  One of the other troopers cuts the 
+	thumper in half with his lazersword.  The sergeant pulls 
+	Oeta out of his hiding place.  Oeta stares at the dead 
+	thumper.</sd>
+         <sp spk="SERGEANT">
+		Well, well!  Here's one of them, 
+		anyway.  Send seekers in all 
+		directions.  Find the others!</sp>
+      </scene>
+      <scene n="144">
+         <setting>VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general sits at the head of the large stone table
+	pushing small markers around.  Han explains what the general 
+	is doing to ten or fifteen Jawa chiefs gathered around the 
+	table.  Occasionally, Boma puts in a word of further explana-
+	tion or answers a question.  Captain Valor sits back silently 
+	watching the Jawa warriors and listens to the general's plan.</sd>
+         <sp spk="SKYWALKER">
+		... then they pull back to here.  
+		That's where the trap will be set.  
+		No-one must advance.  An assault 
+		on the perimeter is useless.  Our 
+		only hope is to use their weapons 
+		against them.</sp>
+         <sd>The general pauses while Han and Boma translate.</sd>
+         <sp spk="SKYWALKER ">
+		Once we acquire those tanks, our
+		prime object must be to secure the 
+		starship.  No-one must escape.</sp>
+      </scene>
+      <scene n="145">
+         <setting>IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three officers run along a row of giant airtanks to a perimeter 
+	bunker.  There, two stormtroopers are watching the jungle. 
+	When the officers arrive, the troopers let them look through 
+	the powerful mounted electrobinoculars.  One of the troopers 
+	points out several areas in the dense jungle.</sd>
+      </scene>
+      <scene n="146">
+         <setting>INTERIOR - CONTROL ROOM - ROYAL OUTPOST - YAVIN</setting>
+         <sd>A trooper sitting at an elaborate control panel turns to an 
+	officer watching a monitor system.</sd>
+         <sp spk="TROOPER">
+		A large concentration of trestuals 
+		at point E-2.</sp>
+         <sp spk="OFFICER">
+		Alert squads one through six.</sp>
+      </scene>
+      <scene n="147">
+         <setting>VINE JUNGLES - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands in a clearing surrounded by many armed 
+	Jawas carrying large shiny shields.  Han moves back and forth, 
+	barking orders to the assembled creatures.</sd>
+         <sp spk="SKYWALKER (to Han)">
+		We're ready.  Give them the signal.</sp>
+         <sd>Han motions to a young Jawa, who takes off, running through 
+	the jungle.</sd>
+      </scene>
+      <scene n="148">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three large airtanks slowly move toward the outpost perimeter. 
+	The tank pilots sit on the hatch rims of the ponderous weapons, 
+	studying the movements of the Jawas.  The tank personnel talk 
+	to one another on an intercom system.</sd>
+         <sp spk="TANK PILOT">
+		There is a large concentration,
+		red two by X-S.  Let's break 
+		them up.</sp>
+         <sd>The pilots slip into the tanks and close the hatches.  The 
+	tanks open up with a barrage of lazerbolts which create a 
+	wall of explosions.  The Jawas retreat, and the tanks follow. 
+	The tank crews track the fleeing creatures with various 
+	electronic scopes, and laugh at the fleeing creatures.</sd>
+      </scene>
+      <scene n="149">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands on a limb of a jungle tree, watching the 
+	advancing tanks.  Captain Valor is on another branch a few 
+	feet away.</sd>
+         <sp spk="SKYWALKER">
+		They've grown sloppy fighting 
+		Jawas.  The intrafazer systems 
+		aren't on.  They're in for a 
+		little surprise.</sp>
+         <sd>Captain Valor flashes a signal mirror, which is received by 
+	a Jawa near the tanks.  The Jawas are in pairs and they hold 
+	heavy stone wedges attached to woven vines, which, in turn, 
+	are fastened high in the trees.  When the tanks pass directly 
+	under the Jawas, they let loose with the heavy stone 
+	pendulums.  The wedges fly through the air, neatly clipping 
+	off the antenna groupings protruding from the tops of the 
+	airtanks.</sd>
+      </scene>
+      <scene n="150">
+         <setting>INTERIOR - AIRTANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Several of the lights and monitors go dark on the main control 
+	panel.  The pilot flips several switches in a panic.</sd>
+         <sp spk="PILOT">
+		All high phasing units are out.  
+		We've lost all contact.</sp>
+         <sp spk="SERGEANT">
+		Send out a ground signal!</sp>
+         <sd>Suddenly, all of the monitors go white, and static fills the 
+	crowded tank interior.  An alarm signal sounds.</sd>
+         <sp spk="SERGEANT">
+		What is it?!!!</sp>
+         <sp spk="PILOT">
+		All signals, sensers, everything, 
+		are coming right back to us.  Some 
+		kind of deflection screen.  It's a 
+		total blackout.</sp>
+         <sp spk="SERGEANT">
+		Get out there and see if you can 
+		see anything.</sp>
+         <sd>The pilot pushes a button and the main hatch slowly slides 
+	away.</sd>
+      </scene>
+      <scene n="151">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The pilot pops out of the hatch and sees two rows of Jawa 
+	warriors holding reflective shields.  They form a circle 
+	that totally encompasses the massive air tank.  Han shouts 
+	a signal to a group of Jawas in another tree, and they cut 
+	loose a bent limb which is attached to a noose around the 
+	tank's hatch.  The noose instantly tightens around the pilot 
+	and he is plucked from the tank and suspended fifty feet in 
+	the air.  In an equally swift move, Captain Valor drops a 
+	small gas grenade into the open hatch.  It explodes and 
+	engulfs the tank in a gray mist.</sd>
+         <sd>The Jawas let out a joyful yell, and charge the tank.  Han 
+	yells at them to stop, but several make it to the conquered 
+	craft before the gas cloud dissipates and they are felled by 
+	the fumes.  Valor waits until after the smoke clears  and
+	then jumps on the back of the immobile tank.</sd>
+         <sd>Several signal mirrors flash their messages to Han and the 
+	general.</sd>
+         <sp spk="HAN">
+		That makes four captured.</sp>
+         <sp spk="SKYWALKER">
+		Have them camouflaged.  I'm 
+		going with Captain Valor.</sp>
+      </scene>
+      <scene n="152">
+         <setting>INTERIOR - AIRTANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Jawas are removing the tank crew as Valor checks out the power 
+	controls.  The general slides through the main hatch.</sd>
+         <sp spk="SKYWALKER">
+		Any damage?</sp>
+         <sp spk="JUSTIN">
+		She's fine.  We're ready to 
+		move.</sp>
+         <sp spk="SKYWALKER">
+		Then let's go.
+		
+	The general yells for the Jawas to clear the tanks, and they 
+	scramble out of the hatch.</sp>
+      </scene>
+      <scene n="153">
+         <setting>VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The tank starts up with a loud roar, startling many Jawas 
+	resting on the mighty vehicle.  Boma yells at the warriors 
+	and they fall a few feet behind the tank, their shields 
+	forming a shiny protective wall.</sd>
+      </scene>
+      <scene n="154">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Several officers stand on a parked airtank trying to get a 
+	better view of the operation.  A light landspeeder pulls up 
+	next to the group and a general gets out.  The officers snap 
+	to attention.</sd>
+         <sp spk="GENERAL">
+		Can you see anything?</sp>
+         <sp spk="OFFICER">
+		No, sir, but they've stopped 
+		firing.</sp>
+         <sp spk="AIDE">
+		Communications still can't reach 
+		them, sir.</sp>
+         <sp spk="GENERAL">
+		Does anyone know what's going on?</sp>
+         <sp spk="OFFICER">
+		I'm sure they've got them on the 
+		run, sir.</sp>
+         <sd>A lazerbolt flashes out of the jungle and destroys a guard 
+	tower about a quarter of a mile from where the men are 
+	standing.  Seconds later, the airtank on which they are 
+	standing explodes into a million pieces.  Out of the jungle 
+	rumbles the captured airtank, driven by Captain Valor and 
+	followed by a column of Jawa warriors.</sd>
+         <sd>Alarms sound, troops rush from the low block-houses, and a 
+	battle rages inside the outpost.  Jawas with spears, axes, 
+	and arrows mange to hold their own against the lazer weapons 
+	of the stormtroopers.  Explosions erupt everywhere as the 
+	Jawas begin to use captured lazerrifles.  They are much 
+	fiercer fighters than the soft royal troops.</sd>
+      </scene>
+      <scene n="155">
+         <setting>INTERIOR - AIRTANK - OUTPOST - YAVIN</setting>
+         <sd>Captain Valor works the controls of the airtank as the general 
+	watches the monitors and works the lazerguns.</sd>
+         <sp spk="SKYWALKER">
+		Swing left.  They're trying to cut us 
+		off.</sp>
+      </scene>
+      <scene n="156">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Captain Valor maneuvers the airtank in front of a line of 
+	ten starships  cutting off a platoon of stormtroopers.  The 
+	troops open fire on the tank  but are cut down by a group of 
+	Jawas who have moved in behind them.  Han and A-2 run up to 
+	the tank as Valor and the general climb out of the hatch.</sd>
+         <sp spk="HAN">
+		We've taken the main control center.  
+		All power units have been shut 
+		down.  They're helpless.</sp>
+         <sp spk="JUSTIN">
+		Have they found Zara?</sp>
+         <sp spk="HAN">
+		They've taken her back to Townowi.  
+		The ship left nor more than ten 
+		hours ago.</sp>
+         <sp spk="SKYWALKER (to Han)">
+		Set up a perimeter around these 
+		starships.  Use as many men as 
+		you need.</sp>
+      </scene>
+      <scene n="157">
+         <setting>STAFF OFFICE - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Captain Valor and the general sit at a large table in the
+	deserted office of the Royal Chief of Staff.  The room is 
+	in a state of disarray;  papers are scattered everywhere. 
+	A-2 stands on a chair, projecting an image of the "death 
+	star" fortress orbiting Townowi, on the table top.</sd>
+         <sd>			 A-2
+		... and are connected to the 
+		central system by a series of 
+		crossing networks similar to 
+		section TB4 or F687.</sd>
+         <sd>The projection switches to a close-up view of the transformer. 
+	The general studies it carefully, then leans back in his chair. 
+	A-2 turns off the projector.</sd>
+         <sp spk="SKYWALKER">
+		I'm not going to stop you, but I 
+		think it's a reckless move. Even 
+		if you could get in, you'd never 
+		be able to get out.  Just be patient.  
+		We now have enough ships to attack 
+		in force.</sp>
+         <sp spk="JUSTIN">
+		But no pilots.</sp>
+         <sd>Han and Boma enter the office.</sd>
+         <sp spk="HAN">
+		Still no contact with Huu Tho 
+		or the kids.  I'm afraid some-
+		thing's happened.</sp>
+         <sp spk="SKYWALKER">
+		Have Boma send two of his best 
+		warriors out there to get them.</sp>
+         <sd>Han relates this to Boma.  The general turns back to
+	Captain Valor, who watches Boma leave the room.</sd>
+         <sp spk="JUSTIN (mocking)">
+		They're fierce warriors  but you'll 
+		never teach them to fly.</sp>
+         <sd>The general gives him a stern look.</sd>
+         <sp spk="SKYWALKER">
+		They'll fly  and Townowi will be 
+		free.</sp>
+         <sp spk="JUSTIN">
+		May the force of others be with 
+		you.</sp>
+         <sd>The general embraces the young Dai.</sd>
+         <sp spk="SKYWALKER">
+		Bring her back safely.</sp>
+      </scene>
+      <scene n="158">
+         <setting>OUTPOST RUNWAY - STARSHIP - YAVIN</setting>
+         <sd>Captain Valor, dressed as an royal skyraider, and A-2 climb 
+	aboard one of the giant four-man starships.  A crowd of 
+	Jawas lead by Boma give a rousing cheer for the departing 
+	Dai.  Valor breaks into a smile and waves to the joyous 
+	warriors.  The general watches the proceedings from a bunker 
+	turret.  He is lost in thought.</sd>
+      </scene>
+      <scene n="159">
+         <setting>SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Three royal space transports dock inside the huge artificial 
+	moon.  The smaller convoy starships circle the larger craft 
+	until the three ships are safely inside the vast fortress.</sd>
+      </scene>
+      <scene n="160">
+         <setting>CONFERENCE ROOM - INTERIOR SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader of the Royal Space Fleet, hurries down a hall-
+	way, followed by a group of officers.  They enter the large 
+	conference room where Zara is held under heavy guard.  She 
+	appears well, but saddened.  Vader approaches her and bows  
+	before her.</sd>
+         <sp spk="VADER">
+		I pray you have been treated honorably?  
+		I am your servant, Darth Vader.  It 
+		won't be long before we will be able to 
+		return you to your people.  (to an aide)  
+		Are the chambers ready?</sp>
+         <sp spk="AIDE">
+		They are working on it, sir.</sp>
+         <sd>Zara stares defiantly at him.  She starts to speak, but a 
+	powerful electric shock engulfs her body  and she whines 
+	in extreme pain.</sd>
+         <sp spk="VADER">
+		Just relax, and everything will be fine.  
+		(to guards)  Take her to section twenty-
+		five.</sp>
+         <sd>Zara is forcibly taken from the room.</sd>
+         <sp spk="VADER (to officer)">
+		What time do the doctors from Granicus 
+		arrive?</sp>
+         <sp spk="OFFICER">
+		Sixty-five hours, sir.</sp>
+         <sp spk="VADER">
+		Put all security stations on alert 
+		until they arrive.</sp>
+         <sd>The officer salutes smartly and exits.</sd>
+      </scene>
+      <scene n="161">
+         <setting>ROYAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>A huge air tank rumbles along the approach to the royal 
+	outpost.  The pilot sits on the main hatch of the tank, 
+	talking to his crew by headphones.</sd>
+         <sp spk="PILOT">
+		Any contact yet?. It appears 
+		deserted.  I don't like it.</sp>
+         <sd>The tank enters the outpost perimeter and smoking rubble 
+	from the recent battle comes into view   The pilot becomes 
+	alarmed.</sd>
+         <sp spk="PILOT">
+		There has been an attack!  
+		Reverse direction.</sp>
+         <sd>The tank comes to a grinding halt  but before it can start 
+	up again  it is surrounded by the Jawa army.  From out of 
+	no-where a Jawa is on the back of the airtank and has the 
+	pilot in a powerful armlock.</sd>
+         <sd>A Jawa chieftan rushes from a bunker, followed by an excited 
+	jabbering warrior.  They reach the captured airtank just as 
+	the last crewman is hauled out  and little Oeta pokes his 
+	head out of the hatch.  He is frightened.  His younger 
+	brother Puck follows him out of the tank.  Below them, the 
+	Jawas bully the captured crewmen.</sd>
+         <sp spk="PUCK">
+		What will they do to us?</sp>
+         <sp spk="OETA">
+		I don't know  but it don't look 
+		good.</sp>
+         <sd>C-3 pulls himself out of the airtank, followed by Han Tho 
+	and his wife.  The Jawa chieftan climbs on board and starts 
+	to jabber at the group   The Jawa carries on for some time 
+	gesturing wildly and continually pointing at the sky.  The 
+	two boys are too scared to say anything.  Finally, the Jawa 
+	kneels before them.  C-3 politely returns a short bow.</sd>
+         <sp spk="OETA">
+		I don't get it.</sp>
+         <sd>The Jawa rises and again gestures skyward, just then a starship 
+	wildly buzzes the field, upside-down.  All the Jawas run for 
+	cover.  The chief Jawa points to the crafts, and jabbers 
+	incessantly.</sd>
+      </scene>
+      <scene n="162">
+         <setting>INTERIOR - ROYAL STARSHIP - SKY OVER YAVIN</setting>
+         <sd>Boma sits at the controls of a four-man starship.  His face 
+	is a twisted combination of complete panic and an awesome 
+	religious experience.  The general  sitting next to him 
+	calmly switches a few buttons on the control panel, as Han 
+	watches from the seat directly behind the Jawa.</sd>
+         <sp spk="SKYWALKER">
+		You'll get the hang of it.</sp>
+         <sd>Han also gives the Jawa a few words of encouragement.</sd>
+         <sp spk="SKYWALKER">
+		Now, let's see if we can get into 
+		orbit.  Push this, then ease her up.</sp>
+         <sd>Boma follows the instructions  but pulls back on the lever 
+	too fast and the ship being to vibrate and bounce violently. 
+	Boma thinks it's funny and begins to laugh hysterically.  Han 
+	becomes nervous and upset.</sd>
+         <sp spk="SKYWALKER">
+		Not so fast.  Back off!  Back off!</sp>
+         <sd>Han yells at the Jawa, who can't respond because he is 
+	laughing so hard.  The general pulls back on the lever.  Han 
+	shakes his head and gives the general a worried look.</sd>
+         <sp spk="SKYWALKER">
+		Don't worry.  Ignorance is on 
+		their side.</sp>
+         <sd>Han is beginning to look a little sick.  He gets up and 
+	rushes to the back of the ship.</sd>
+      </scene>
+      <scene n="163">
+         <setting>ROYAL SPACE FORTRESS - DOCKING AREA - TOWNOWI</setting>
+         <sd>The canopy on the starship pops open and A-2 and the young 
+	Dai  disguised as a starraider, climb out onto the docking 
+	platform.  An officer and two groundcrew approach him and 
+	salute.  Captain Valor hands him his papers.</sd>
+         <sp spk="JUSTIN">
+		I'm here to check the vent ports in 
+		the rim tracks.</sp>
+         <sp spk="OFFICER">
+		Your ship is from Yavin.  We've 
+		lost all contact with them.  What's 
+		going on out there?</sp>
+         <sp spk="JUSTIN">
+		There is a fierce invasion just east of 
+		Bull Pup station.  It's really a mess 
+		out there.</sp>
+         <sd>The officer smiles and the ground crew starts to check out 
+	the starship.  Valor heads for the main docking exit, followed 
+	by A-2.  He remembers something as he passes the control 
+	station and calls out to the officer.</sd>
+         <sp spk="JUSTIN">
+		Do you mind if I use your com-link?</sp>
+         <sp spk="OFFICER">
+		No.  Go ahead.</sp>
+         <sd>Valor walks into the small control area and pretends to talk 
+	on an intercom system.</sd>
+         <sp spk="JUSTIN (to A-2)">
+		Find the highest security area.</sp>
+         <sd>A-2 punches his claw arm into a computer socket and the brain 
+	comes to life, feeding information to the little robot.</sd>
+         <sd>Captain Valor watches the officer as he directs the crewmen 
+	in the securing of the starship.  A-2 removes his arm from 
+	the computer and the duo leave the control station.</sd>
+         <sd>			 A-2
+		Station 325 is the highest security 
+		area on board.  It's a detention area.</sd>
+         <sd>They disappear into a chamber lock hallway.</sd>
+      </scene>
+      <scene n="164">
+         <setting>ELEVATOR TUBE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor, trying to look inconspicuous, waits for a horizontal 
+	elevator.  Troops and fortress personnel come and go, but 
+	no-one seems to pay any attention to the pair.  Finally  a 
+	small car arrives  and Valor follows A-2 into the podlike 
+	vehicle  and it takes off through a vacuum tunnel.</sd>
+      </scene>
+      <scene n="165">
+         <setting>DETENTION AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor and A-2 enter a security station.  Guards and electronic 
+	cutters are everywhere.  An officer approaches Valor and checks 
+	his papers.</sd>
+         <sp spk="OFFICER">
+		The B-23 can't enter this station.</sp>
+         <sp spk="JUSTIN">
+		But I need him.</sp>
+         <sp spk="OFFICER">
+		Sorry.  No mechanical personnel. 
+		It's restricted.</sp>
+         <sd>Valor watches helplessly as A-2 is led into a waiting area.</sd>
+         <sp spk="OFFICER">
+		You may proceed  but you'll have 
+		to be escorted.</sp>
+         <sd>A trooper joins Valor and leads him through a series of 
+	hallways.  Valor carefully surveys the area as he follows 
+	the guard.</sd>
+         <sp spk="TROOPER">
+		Mathusians just beat the PDRs again.  
+		They should be in another league.  Do 
+		you follow the ecometrics?</sp>
+         <sd>The guard turns to discover that Captain Valor has dis-
+	appeared.  He is stunned, then manages to pull out a small 
+	ring radio.</sd>
+         <sp spk="TROOPER">
+		Code six - alert.</sp>
+      </scene>
+      <scene n="166">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - YAVIN</setting>
+         <sd>Six Jawas sit before Han and the general, listening to Han 
+	explain something about space fighting.  Tho approaches the 
+	general.</sd>
+         <sp spk="THO">
+		We've made contact with the under-
+		ground on Townowi.  Things are 
+		tighter.  They can only get one 
+		man out.  Datos is on his way.</sp>
+         <sp spk="SKYWALKER">
+		We should be ready by the time he 
+		arrives.</sp>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+		They're ready to go up.</sp>
+         <sd>The general makes a short statement to the Jawas in their 
+	own language.  They let out a loud cheer and run for the row 
+	of starships.</sd>
+      </scene>
+      <scene n="167">
+         <setting>STARSHIP - SPACE - YAVIN</setting>
+         <sd>The general sits next to Boma as he leads two other Jawa- 
+	piloted starships in a tight formation.  They head for a 
+	small cluster of asteroids orbiting near the planet's surface. 
+	The general quietly gives Boma some reassuring instructions. 
+	Han leads a second formation of three ships, following Bomas 
+	group.  The two formations of starships make an attack run on 
+	the asteroids.  The general watches as Boma lines up and fires 
+	at an asteroid blowing it into a million pieces.  The general 
+	smiles and slaps Boma on the back.  The Jawas excitedly 
+	chatter among themselves over the intercom system.</sd>
+      </scene>
+      <scene n="168">
+         <setting>DETENTION AREA HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>A patrol of ten men marches through one of the long hallways 
+	in the detention area.  They stop at an intersection.  The 
+	officer in charge reports on the intercom.</sd>
+         <sp spk="OFFICER">
+		Ben Five to Boma.  All clear.</sp>
+         <sd>The troops relax; some stand in groups, others wander a
+	distance away, poking into the various small alleyways 
+	running off the main hallway.  One trooper notices a small 
+	reflected light in one of the narrow corridors  and carefully 
+	moves down the dark passageway to check it out.  Out of no-
+	where, a fist knocks the trooper unconscious and drags him 
+	into a small alcove.</sd>
+         <sd>The officer finishes his report on the intercom and yells 
+	for the troops to fall-in.  Men scurry in all directions 
+	and out of a narrow corridor emerges Captain Valor, dressed 
+	in the uniform of a royal startrooper.  He joins the platoon 
+	and they march away.</sd>
+      </scene>
+      <scene n="169">
+         <setting>GENERAL'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader and several officers watch the progress of the 
+	search on TV monitors.  The general speaks into an intercom.</sd>
+         <sp spk="VADER">
+		Have them clear the area.  Bring 
+		in the seekers.
+		
+	On the monitors the troops are assembled in the main entry-
+	way and several small chrome balls are thrown into the hall-
+	way.  Small antennae pop from the chrome surface  and the 
+	small balls float down the hallways.  Dodona, once a proud 
+	legionnaire, enters wearing the uniform of a stormtrooper. 
+	He snaps to attention before the general and hands him a 
+	report.  Vader gives Dodona a sly grin.</sp>
+         <sp spk="DODONA">
+		Contact has been lost with the ship 
+		carrying the doctors from Granicus.  
+		The princess' treatment will have to 
+		be delayed.</sp>
+         <sp spk="VADER">
+		We've just trapped your old friend 
+		Captain Valor.  Watch us accomplish 
+		what you found to be impossible.</sp>
+         <sd>Dodona is humiliated but stays at attention.  Vader gets an 
+	emergency call on the intercom.</sd>
+         <sp spk="VADER">
+		Yes. Yes.  Put it on the view screen.</sp>
+         <sd>One of the TV monitors switches to an image of the unconscious 
+	trooper Captain Valor stripped.</sd>
+         <sp spk="VADER">
+		Get me the Captain of the Guard.</sp>
+      </scene>
+      <scene n="170">170  DETENTION AREA - MAIN ENTRY - SPACE FORTRESS - TOWNOWI
+
+	<sd>Three squads of troops, including Captain Valor, stand at
+	attention in the main entrance to the detention area, while 
+	the Captain of the Guard gets new orders over his head-
+	phones.  Valor studies the situation carefully, looking for 
+	a way out of his predicament.  The Captain of the Guard calls 
+	up the platoon sergeants and gives them a series of orders. 
+	They return to their squads and begin to inspect the troops. 
+	Valor begins to get worried.</sd>
+         <sd>The sergeant works his way down the line until he gets to 
+	the trooper next to Valor.  He sees no chance of escape, but 
+	surprise.  Suddenly, he bolts from the ranks and races down 
+	the hallway.</sd>
+         <sp spk="CAPTAIN OF THE GUARD">
+		Squad leaders!</sp>
+         <sd>Ten troopers break out of the ranks and take up the chase. 
+	Captain Valor runs down a corridor and rounds a corner, 
+	reaching a dead end.  The troops round the corner and 
+	confront the trapped Dai.  The sound of igniting lazer-
+	swords fills the hallway.  Valor takes a defensive stance, 
+	his huge lazersword buzzing loudly.  The troops attack. 
+	They fight with skill and bravery  but are eventually all 
+	cut down by the invincible Dai warrior.</sd>
+         <sd>Captain Valor breaks away from the troops and runs down a 
+	long hallway.  A safety door slides shut, closing off his 
+	escape.  He turns around in time to see another door seal 
+	off the opposite end of the hallway.  Before he can make 
+	any attempt to pry open the door, gas fills the sealed 
+	corridor.  Valor collapses in a heap on the floor.</sd>
+      </scene>
+      <scene n="171">
+         <setting>GENERAL'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Vader laughs as he watches the unconscious Valor on the TV 
+	monitors.  All of the other officers in the room are laughing 
+	and joking, except Dodona, who remains grimly at attention.</sd>
+         <sp spk="VADER (to Dodona)">
+		Take him to the special section.</sp>
+         <sd>Dodona salutes, and exits the offices.  Vader laughs again.</sd>
+      </scene>
+      <scene n="172">
+         <setting>STARSHIP RUNWAY - ROYAL OUTPOST - TOWNOWI</setting>
+         <sd>Nine gleaming starships sit in a row along the edge of the 
+	vast jungle runway.  Bizarre and colorful Jawa designs have 
+	been painted across the large deflector fins of the space-
+	craft.  Some designs transform the ships into huge and 
+	grotesque animals, while others create unique mosaic patterns.  
+	The four-man Jawa crews stand proudly at attention in front 
+	of their ships.  The general, along with Han and the under-
+	ground leader, Datos, review the assembled Jawas.   In one of 
+	the Jawa crews, a pilot is picking fleas off the back of his 
+	tail gunner.  When the general passes  he snaps to attention.  
+	There is a gleam in the general's eye as he shows off his 
+	strike force to the crusty old underground leader.  When 
+	they've inspected the last starship, Datos turns to the 
+	general.</sd>
+         <sp spk="DATOS">
+		I'm speechless.  It's amazing.  A 
+		most impressive display.  For the 
+		first time since the take-over, I 
+		feel real hope.</sp>
+         <sp spk="SKYWALKER">
+		Will your people be ready?</sp>
+         <sp spk="DATOS">
+		Our forces have already started 
+		sabotaging their com-link set 
+		ups.  A refugee camp on Mananyo 
+		has been conducting raids on 
+		shipping from Granicus.  That's 
+		how we intercepted those doctors.</sp>
+         <sp spk="SKYWALKER (to Han)">
+		Get them in the ships.  We're on 
+		our way.  (to Datos)  Send the 
+		code signal.</sp>
+      </scene>
+      <scene n="173">
+         <setting>DETENTION CELL - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>General Vader and Dodona watch as a medic revives Valor, 
+	who has been strapped to an upright slab protected by 
+	cutter-rays.</sd>
+         <sp spk="MEDIC">
+		He's coming round.</sp>
+         <sd>The medic backs away and throws the switch which activates 
+	the cutters.  A blue glow surrounds Valor as he wakes up 
+	and sees Vader and Dodona.</sd>
+         <sp spk="VADER">
+		For all the myths and the trouble 
+		you don't seem like much.</sp>
+         <sd>He laughs and leaves Dodona alone in the room with the young 
+	Dai.  Dodona appears sad and frustrated at the capture of the 
+	noble warrior.  They stare at one another for a few moments.</sd>
+         <sp spk="DODONA">
+		You were insane to come here.  The 
+		security on this...this thing is 
+		impossible.  Why?  For her?  I can't 
+		believe your loyalty is that strong. 
+		You're a great warrior, but you're a 
+		greater fool.  This is a place for 
+		androids - no codes, no honor.  Our 
+		ways are useless here.  Why couldn't 
+		you have stayed away?
+		
+	He storms out of the cell.  Captain Valor struggles to free
+	himself.</sp>
+      </scene>
+      <scene n="174">
+         <setting>SLUM DWELLING - GORDON SPACEPORT - TOWNOWI</setting>
+         <sd>The young partisan, Occo, listens to a small transmitter in 
+	a secret closet behind the main room in a slum dwelling.  He 
+	jumps up and runs  into the main room  where Quist and 
+	several other men are sitting around a table covered with 
+	maps and plans.</sd>
+         <sp spk="OCCO">
+		It's Datos.  We've got the go 
+		ahead.</sp>
+         <sd>The men cheer and starts hugging and slapping each other on 
+	the back.  Finally  they settle down.</sd>
+         <sp spk="QUIST">
+		Go to your organizations. (to Occo)  
+		What's the code time?</sp>
+         <sp spk="OCCO">
+		Zero three thirty.</sp>
+         <sp spk="QUIST">
+		May the force of others be with you.</sp>
+         <sd>The men solemnly shake hands and leave the room.</sd>
+      </scene>
+      <scene n="175">
+         <setting>GOVERNOR'S OFFICE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor stands on a small platform before Governor
+	Horus and the High Consul.  His hands are held behind his 
+	back by electric bonds.</sd>
+         <sp spk="HORUS">
+		... and I'm sure the King will 
+		enjoy your execution.  I only 
+		regret I won't be there myself. 
+		This should end the Dai Nogas 
+		myth once and for all.  Take 
+		him to Granicus.</sp>
+         <sd>Dodona steps forward with a squad of stormtroopers and
+	escorts the prisoner away.  Vader and the governor seem 
+	very pleased with themselves.  Dodona looks back in disgust.</sd>
+      </scene>
+      <scene n="176">
+         <setting>CONTROL CENTER - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>In the large central control room, two officers sit above 
+	a row of monitors and giant readouts.</sd>
+         <sp spk="FIRST OFFICER">
+		Look!  That whole sector just 
+		went dead.  We're losing contact 
+		with the surface.  Use the IF 
+		link and find out what's going 
+		on.</sp>
+      </scene>
+      <scene n="177">
+         <setting>DOCKING AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Dodona halts the squad guarding Captain Valor on an 
+	observation deck overlooking a starship docking port. 
+	Dodona reports to the officer in charge.</sd>
+         <sp spk="DODONA">
+		Where is the ship?</sp>
+         <sp spk="OFFICER">
+		It's on its way in.  It will just 
+		be a few minutes.</sp>
+         <sd>Dodona returns to his squad and watches the large starship 
+	slowly move into the docking area.  He glances at Valor, 
+	who stands defiant, ready to meet his fate.</sd>
+         <sd>Dodona continues to study Valor.  The young Dai returns his 
+	gaze.  Slowly  the spacecraft locks onto the docking port 
+	with a loud jolt.  The troops snap to attention  but Dodona 
+	grabs two lazerswords and in one swift move  switches off 
+	Valors bonds and tosses him one of the lazerswords.  Valor 
+	assumes a defensive stance, as the troops realize what has 
+	happened and draw their swords.</sd>
+         <sp spk="DODONA">
+		This way!</sp>
+         <sd>The two warriors fight their way through a side exit.  The 
+	door slides closed behind them, and Dodona throws the lock, 
+	trapping the troops on the observation platform.  They race 
+	down the hallway and stop at an intersection.</sd>
+         <sp spk="DODONA">
+		This way!   We can get a starship 
+		and be out of here before they've 
+		discovered...</sp>
+         <sp spk="JUSTIN">
+		I'm not leaving without the princess.</sp>
+         <sp spk="DODONA">
+		It's impossible;  there are traps 
+		everywhere.  You're mad!</sp>
+         <sd>Valor just grins and runs down the passageway leading to the 
+	detention area.  Dodona rushes and catches up.  An alarm 
+	signal wails through the hallways.</sd>
+      </scene>
+      <scene n="178">
+         <setting>JAWA STARSHIPS - SPACE</setting>
+         <sd>The general leads three squads of starships toward the glowing 
+	planet of Townowi.</sd>
+         <sp spk="SKYWALKER">
+		There she is.  Activate your deflection 
+		 shields.</sp>
+      </scene>
+      <scene n="179">
+         <setting>DETENTION AREA - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Dodona talks with the Captain of the Guard.  He gestures wildly 
+	like something important had happened.  Four troops run into 
+	the central detention area leading the bound princess.  The 
+	captain salutes Dodona and the legionnaire, followed by the 
+	four troops and Zara, leave the main area.</sd>
+      </scene>
+      <scene n="180">
+         <setting>DETENTION HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Valor appears boldly at the end of the hallway facing Dodona 
+	and the troops.</sd>
+         <sp spk="DODONA">
+		Get him!</sp>
+         <sd>The troops rush for Valor, swords drawn.  They are no match 
+	for the skilled Dai.  He makes short work of them,  as Dodona 
+	frees the princess.  The trio then run into another hallway. 
+	The princess embraces Valor.</sd>
+         <sp spk="DODONA">
+		We have only a few seconds before they 
+		find us.  All of these hallways are 
+		sealable.</sp>
+         <sd>Valor spots a small garbage chute on the corridor wall.  He 
+	goes and looks into it.</sd>
+         <sp spk="JUSTIN">
+		Is this pressurized?</sp>
+         <sp spk="DODONA">
+		They're power sealed. We'll have to 
+		find another way, or some way to shut 
+		the power off.</sp>
+         <sd>They search the smooth-walled room for another exit.</sd>
+      </scene>
+      <scene n="182">
+         <setting>GOVERNOR'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Governor Horus watches General Vader as he supervises the 
+	hunt for Valor and Dodona.  They watch troops move through 
+	the detention area via TV monitors.  Seekers buzz through 
+	the hallways.  The general gets a report from an officer 
+	on another monitor.</sd>
+         <sp spk="OFFICER">
+		We've lost contact with the surface.  
+		There is a good probability of an 
+		uprising.  Even the IF links are out.</sp>
+         <sp spk="VADER">
+		Use a substandard relay and put all 
+		units on alert.</sp>
+         <sd>The officer disappears from the monitor and is replaced with 
+	the Captain of the Guard.</sd>
+         <sp spk="CAPTAIN">
+		All sections D through P-12 are clear.  
+		We have reason to suspect they escaped 
+		through the disposal system.  We are
+		checking.  (he is interrupted by an 
+		excited trooper who tells him something) 
+		We've found them in Receptacle B-29. 
+		You should...</sp>
+         <sd>A red light flashes on one of the other monitors.</sd>
+         <sp spk="VADER">
+		Hold on.</sp>
+         <sd>A controller appears on the second monitor.</sd>
+         <sp spk="CONTROLLER">
+		Starships approaching, three squads 
+		of royal design, but no clearance.</sp>
+         <sp spk="GENERAL">
+		Full alert.  Battle stations...</sp>
+         <sd>The general turns back to the Captain of the Guards.</sd>
+         <sp spk="CAPTAIN">
+		You should have them on your 
+		screen.</sp>
+         <sd>Alarms sound throughout the fortress.  Lights flash a
+	warning.</sd>
+      </scene>
+      <scene n="182">
+         <setting>GARBAGE RECEPTACLE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>A floodlight switches on  revealing Dodona and Valor 
+	attempting to cut open the door.  The princess stands up 
+	and stares into the floodlight.  Vader's voice comes over 
+	an intercom.</sd>
+         <sp spk="VADER">
+		I'm afraid I have no more time to 
+		deal with you.  A senseless and 
+		futile attack by your friends has 
+		forced me to take a rather un-
+		pleasant course of action.  Your 
+		execution will have to be expedited.</sp>
+         <sd>The intercom clicks off and a loud rumbling begins to shake 
+	the room.  With a loud shriek, the princess points to the 
+	far wall;  it has started to move toward the trio.  The 
+	situation looks desperate.</sd>
+      </scene>
+      <scene n="183">
+         <setting>SPACE - JAWA STARSHIPS - TOWNOWI</setting>
+         <sd>Lazerfire from the space fortress creates a wall of death, 
+	which the three squadron of Jawa starships miraculously 
+	emerge through undamaged.  The general barks orders to the 
+	Jawa craft and Boma and his squadron break off and start an 
+	attack dive.  Lazerfire from Bomas brightly colored ship 
+	hits one of the prime power terminals on the fortress sur-
+	face.  It explodes, creating weird electric arcs as it goes.</sd>
+         <sd>Han and the general also concentrate fire on the distinctive 
+	black power terminals.  Two more are destroyed in an arcing 
+	spectacle.  A chain reaction is set off, creating a series of 
+	explosions leaping across the surface of the fortress from 
+	power terminal to power terminal.</sd>
+      </scene>
+      <scene n="184">
+         <setting>GARBAGE RECEPTACLE - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>The shock of the explosion can be felt over the rumbling of 
+	the trash masher.  The wall has moved within a few yards of 
+	squashing Dodona, Valor and the princess.  They are still 
+	frantically trying to somehow stop the relentless wall, to 
+	no avail.  The lights blink off, then on again  and the 
+	moving wall rumbles to a halt.  Zara breathes a sigh of 
+	relief.</sd>
+         <sp spk="VALOR">
+		They must have knocked the power 
+		out.</sp>
+         <sd>Dodona runs over to the door  and kicks it open.  They rush 
+	out of the would-be death trap.</sd>
+      </scene>
+      <scene n="185">
+         <setting>SPACE - JAWA STARSHIPS - TOWNOWI</setting>
+         <sd>One of the Jawa starships is caught in a crossfire and dis-
+	appears in a cloud of smoke.  Another ship for some unknown 
+	reason dives headlong into the surface of the fortress, 
+	creating a huge explosion.</sd>
+      </scene>
+      <scene n="186">
+         <setting>MAIN HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Captain Valor, Dodona and the princess are thrown to a hallway 
+	floor by the explosion.  They get up and start down the hall-
+	way again.  A voice calls out from a connecting corridor.</sd>
+         <sd>			 A-2
+		Hey!  Over there.
+		
+	The trio turn and see little A-2 standing at the other end of 
+	the corridor.  He waves his claw arm at them and wobbles over
+	to them.</sd>
+         <sd>			 A-2
+		The power core has exceeded the 
+		normal stress quotient by point 
+		eight.  The magnetic fusion pods 
+		have evaporated.  There appears 
+		to be an immediate danger.</sd>
+         <sp spk="DODONA">
+		There is a lifepod station at the 
+		other end of this section.  Hurry.</sp>
+         <sd>The group followed by A-2, make a dash for the lifepod, 
+	but are knocked to the ground by another explosion which 
+	rocks the hallway.  A hole is ripped in one wall, sucking 
+	debris into space.  Everyone holds on to wall fixtures for 
+	dear life.</sd>
+      </scene>
+      <scene n="187">
+         <setting>GOVERNOR'S QUARTERS - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>Aides and officers rush through the office, as Vader tries 
+	to keep things under control.  Governor Horus remains calm, 
+	watching the progress of the battle.  Vader turns to the 
+	governor.</sd>
+         <sp spk="VADER">
+		They've pinpointed every terminal.
+		It's impossible.  What are they?  
+		Where did they come from?  An 
+		electromagnetic transfer has started.
+		There's no stopping it.</sp>
+         <sp spk="GOVERNOR">
+		Continue the fight.</sp>
+         <sp spk="VADER">
+		We've already lost control of the 
+		planet.  We must abandon ship while 
+		there is still time.  Conditions are 
+		much worse than...</sp>
+         <sp spk="GOVERNOR">
+		Continue the fight.  This fortress 
+		is invincible.  I will not give up.</sp>
+         <sd>A giant explosion sweeps through the office.</sd>
+      </scene>
+      <scene n="188">
+         <setting>SPACE - JAWA STARSHIPS</setting>
+         <sd>The tiny starships race the chain reaction explosions across 
+	the surface of the fortress.  Lazerfire is everywhere.  One 
+	of the starships skimming across the surface lags behind and 
+	is caught in an explosion and disappears.</sd>
+         <sp spk="SKYWALKER">
+		Han!  Get everyone out of here. 
+		The whole thing's going to go.
+		Return to Gordon.  Get them out.</sp>
+         <sd>Han relays the order to the Jawas, and then starships pull 
+	away from the crippled fortress.</sd>
+      </scene>
+      <scene n="189">
+         <setting>MAIN HALLWAY - SPACE FORTRESS - TOWNOWI</setting>
+         <sd>The group has made their way past the hole in the wall and 
+	are climbing into the lifepods.  Captain Valor helps the 
+	princess into one, while Dodona and A-2 get into the other. 
+	Warning sirens scream throughout the hallways.  Three troops 
+	run toward the lifepods, firing lazerpistols.  dodona returns 
+	the fire, stopping the oncoming troops.  Hatches are closed 
+	and the lifepods eject into space.</sd>
+      </scene>
+      <scene n="190">
+         <setting>LIFEPODS - SPACE - TOWNOWI ORBIT</setting>
+         <sd>The two lifepods drift toward the calm of the planet's
+	surface.  Captain Valor and the princess embrace  and he 
+	kisses her tenderly.  They watch the ominous fortress grow 
+	smaller and smaller as they drift away.  Suddenly, a great 
+	flash replaces the fortress and rubble streaks past the 
+	lifepods.  Several giant explosions follow, then there is 
+	only a smoke cloud where the mighty fortress once orbited 
+	Townowi.</sd>
+      </scene>
+      <scene n="191">
+         <setting>THRONE ROOM - PALACE OF LITE - TOWNOWI</setting>
+         <sd>Queen Zara, in all her grandeur, sits on the magnificent
+	throne of Townowi.  Captain Valor and the general stand to 
+	her right.  Several old advisors stand to her left.  Han 
+	presents Boma and a delegation of Jawas with a treaty, 
+	gifts, and a medal of honor.  They bow and exit.  Han moves 
+	to one side of the crowded court.  Dodona stands next to 
+	him.  They watch as the two robots, A-2 and C-3 approach 
+	the Queen and bow.</sd>
+         <sp spk="ZARA">
+		Your service to Townowi is greatly 
+		appreciated.  You are designated 
+		class A-4, and will serve Justin 
+		Valor, the new Lord Protector of 
+		Townowi.  Rise!</sp>
+         <sd>The robots rise and exit through the long entrance hall to 
+	\he throne.  The Queen turns and smiles at Valor and the 
+	general.  The general and Valor salute their new Queen.</sd>
+         <sd>									FADE OUT</sd>
+         <sd>			 END CREDITS</sd>
+      </scene>
+   </body>
+</xml>

--- a/scripts/ANHDraftsXML/XSLT/transform1/ANHroughDraft.xml
+++ b/scripts/ANHDraftsXML/XSLT/transform1/ANHroughDraft.xml
@@ -1,0 +1,5278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+   <metadata>
+      <title>The Star Wars</title>
+      <author>George Lucas</author>
+      <draft>Rough Draft [First of four major screenplay drafts]
+Lucasfilm Ltd.</draft>
+      <date>5/74</date>
+   </metadata>
+   <body>
+      <sd>  FADE IN:</sd>
+      <scene n="1">
+         <setting>SPACE</setting>
+         <sd>A sea of stars is broken by the vast blue surface of the planet, Utapau.  Five
+small moons slowly drift into view from the far side of the planet.  The main
+titles are followed by a roll-up:</sd>
+         <sd>Until the recent Great Rebellion, the Jedi Bendu were the most feared warriors
+in the universe.  For one hundred thousand years, generations of Jedi
+perfected their art as the personal bodyguards of the emperor.  They were the
+chief architects of the invincible Imperial Space Force which expanded the
+Empire across the galaxy, from the celestial equator to the farthest reaches
+of the Great Rift.</sd>
+         <sd>Now these legendary warriors are all but extinct.  One by one they have been
+hunted down and destroyed as enemies of the New Empire by a ferocious and
+sinister rival warrior sect, the Knights of Sith.</sd>
+         <sd>A small silver spacecraft emerges from behind one of the Utapau moons.  The
+deadly little fightercraft speeds past several of the moons, until it finally
+goes into orbit around the fourth moon.</sd>
+      </scene>
+      <scene n="2">
+         <setting>  WASTELAND - FOURTH MOON - UTAPAU</setting>
+         <sd>A harsh gale blows across the bleak grey surface of the Fourth Moon.  The
+leaden sky presses down on a lone figure, Annikin Starkiller, a tall, heavy-
+set boy of eighteen.  He slowly makes his way across the canyon floor.  The
+heavy winds whip at him and make the going extremely difficult.  His face is
+covered by a breath mask and goggles.  He stops for a second to adjust the
+shoulder strap on his chrome multiplelaser rifle.  Something in the sky
+catches his eye, and he instinctively grabs a pair of electrobinoculars from
+his belt.  He stands transfixed for a few moments, studying the heavens, then
+turns and rushes back in the direction from which he came.</sd>
+      </scene>
+      <scene n="3">
+         <setting>  SUPPLY HUT - FOURTH MOON - UTAPAU</setting>
+         <sd>A spacecraft, half buried in the dust, rests next to the remains of an
+abandoned supply shack.  Annikin makes his way across the colorless landscape
+and rushes into the crumbling building.  The interior of the hut is shabby,
+but manages to abate the howling winds.  Seated in front of a thermoheater are
+Annikin's father, Kane, and his young brother, Deak.  Kane is a large, burly
+man, wearing the distinctive robes of a Jedi.  Deak is ten years old, with
+dusty blond hair and a large scratch on his cheek.  Annikin slams the door and
+removes his gear.  His ruggedly handsome face is caked with many layers of
+dust.</sd>
+         <sp spk="ANNIKIN">
+
+Dad!  Dad!...They've found us!</sp>
+         <sd>Deak looks up from a small cube he has been studying.  His father whacks him
+across the shoulder with a braided wire connector.</sd>
+         <sp spk="KANE">
+
+Continue with the problem.  Your concentration is worse than your brother's.
+(to Annikin) How many?</sp>
+         <sp spk="ANNIKIN">
+
+Only one this time.  A Banta Four.</sp>
+         <sp spk="KANE">
+
+Good.  We may not have to repair this old bucket after all.  Prepare yourself.</sp>
+         <sp spk="DEAK">
+
+Me too!</sp>
+         <sp spk="KANE">
+
+Do you have the answer?</sp>
+         <sp spk="DEAK">
+
+I think it's the Corbet dictum:  "What is, is without."</sp>
+         <sd>Kane smiles.  This is the correct answer.  Annikin is strapping on a utility
+belt with chrome laserpistols and lasersword.  Kane rises and starts for his
+equipment.</sd>
+         <sp spk="DEAK (Con't)">
+
+Ahhh, Pop...</sp>
+         <sp spk="KANE">
+
+Deak, do you feel you're ready?</sp>
+         <sp spk="DEAK">
+
+Yes, sir.  I've outmarked Annikin in twelve disciplines.  I'm as good...</sp>
+         <sp spk="KANE">
+
+All right, son, get your gear.</sp>
+         <sd>Deak jumps up with the enthusiasm available only to a ten-year-old and grabs
+his gear.  His father frowns and shakes his head.</sd>
+      </scene>
+      <scene n="4">
+         <setting>  WASTELAND BLUFF - FOURTH MOON - UTAPAU</setting>
+         <sd>Kane Starkiller and his two sons carefully make their way up a rock bluff
+overlooking the parked silver Sith spacecraft.  Kane inspects the craft with
+his electrobinoculars.</sd>
+         <sp spk="KANE">
+
+No tracks.  Bi-lock hasn't been opened....Interior systems are still on....</sp>
+         <sp spk="ANNIKIN">
+
+Are we going to wait for him to come out?</sp>
+         <sp spk="KANE">
+
+He's not in there....He's baiting us.  I'm surprised they only sent one this
+time.  We must be wearing them down, or they must think this knight is
+something special....Stay on guard, and keep hidden.  I'm going to work my way
+across the ridge and call his bluff.  Better we meet in open combat than wait
+for him to ambush us....Keep your guard!</sp>
+         <sd>Kane leaves his two sons and  moves off along the obscured ridge.  Annikin and
+Deak watch him intently.  Annikin throws down his multiplelaser rifle in
+disgust.</sd>
+         <sp spk="ANNIKIN">
+
+He should have let me go with him....He's getting too old to make an open
+challenge.</sp>
+         <sp spk="DEAK">
+
+He's not too old to realize you'd just get in the way.</sp>
+         <sd>Annikin ignores his little brother's remark and sneaks a look over the ridge
+at the Sith spacecraft.  Kane moves out of the rocks some distance away and
+starts toward the starship.  Deak moves to the ridge next to his brother, his
+chrome laserrifle sparkling in the reflected light of Utapau.</sd>
+         <sp spk="DEAK">
+
+He's making his move....</sp>
+         <sp spk="ANNIKIN">
+
+Watch your guard...and cover that weapon.  It shines like a beacon.</sp>
+         <sd>Deak reluctantly move away and watches the other direction.  Kane has almost
+reached the Sith spacecraft and still there is no sign of its occupant.</sd>
+         <sp spk="DEAK">
+
+What's happening?</sp>
+         <sp spk="ANNIKIN">
+
+Nothing.  I don't like it.</sp>
+         <sd>Kane carefully moves to the main hatch of the starship.  He kicks a valve and
+the hatch drops open with a loud clank and rushing gas.  Annikin becomes more
+tense as his father carefully moves inside the spacecraft.  Everything is
+still.  Even the continual winds seem to have died down.  Moments pass with no
+sign of activity inside the enemy starship.  Annikin watches the craft with
+his electrobinoculars.  The waiting becomes unbearable.</sd>
+         <sp spk="ANNIKIN">
+
+Something's happened!  He's been in there too long.</sp>
+         <sp spk="DEAK">
+
+Let me look!  Stand my guard.</sp>
+         <sd>Deak takes the electrobinoculars from his brother and studies the silent
+spacecraft.  Annikin impatiently scans the opposite horizon.</sd>
+         <sp spk="DEAK">
+
+I think the power just went off.  We'd better wait here until someone comes
+out.</sp>
+         <sp spk="ANNIKIN">
+
+What if he needs help?</sp>
+         <sp spk="DEAK">
+
+The power went back on again....</sp>
+         <sd>With the aid of the electrobinoculars, Deak watches the running lights of the
+starship flash on and off.  Suddenly, something huge moves in front of his
+field of view.  Before either of the two young boys can react, a large,
+sinister Sith warrior in black robes and a face mask looms over them.  He
+carries a long lasersword which cuts young Deak down before he or his brother
+are able to raise their weapons.  The startled Annikin backs away in horror,
+then settles down and ignites his lasersword, which creates an eerie red glow.</sd>
+         <sd>He stumbles over rocks as he attempts to avoid the charging Sith knight.  The
+evil warrior swings his mighty lasersword, but Annikin manages to deflect the
+intended deathblow.</sd>
+         <sd>Finally, Annikin is able to assume a defensive stance, and the two warriors
+stand, sizing up each other.  The black knight is at least seven feet tall,
+and dwarfs the young Jedi.  They stand for a few moments, almost frozen, then
+in a flurry of blows, laserswords clash with the sound of electric snapping
+and popping.  Annikin is barely able to hold his own against the experienced
+knight.  Many blows are exchanged before the Sith warrior is able to back
+Annikin up against a deep crevasse.  Annikin stumbles and almost falls over
+the cliff to his death.</sd>
+         <sd>The black knight suddenly senses something behind him and whirls around to
+face Annikin's father, Kane Starkiller, a Jedi Bendu master.  The Sith warrior
+raises his lasersword, but is cut in two before he can bring it down again.
+Kane moves to the fallen black knight, and studies him carefully.  Annikin,
+still a little wobbly from the whole experience, attempts to stand.  Kane sees
+his dead son Deak, and goes to him.  He lifts him into his arms and begins to
+weep.  Annikin stands bewildered, watching his father cradle his dead brother.</sd>
+      </scene>
+      <scene n="5">
+         <setting>  INTERIOR SITH STARSHIP - WASTELAND CANYON - UTAPAU</setting>
+         <sd>Kane Starkiller slides into one of the four seats of the small Sith starship.
+Through the front viewing canopy, he watches Annikin drag his younger
+brother's body to a small crevasse.  Annikin places a small locket around his
+brother's neck, makes a complicated sign with his hand, and dumps the body
+into the shallow depression.  The giant engines of the spacecraft begin to
+whine, kicking up large clouds of dust.</sd>
+         <sd>Annikin climbs into the seat beside his father and removes his breath mask and
+goggles.  There are tears in his eyes.  Father and son look out across the
+wasteland towards Deak's grave.  The thunderous clap of an explosion is
+followed by a small mushroom cloud rising out of the depression.  Annikin
+throws a container down in a fit of rage.</sd>
+         <sp spk="ANNIKIN">
+
+How many more of them are there?  I want to finish it, once and for all!  I'm
+sick of running...when will it stop?</sp>
+         <sd>Annikin's father waits silently until his son's tirade is finished.  Annikin
+sits silently for a few moments.</sd>
+         <sp spk="ANNIKIN (con't)">
+
+I'm sorry.</sp>
+         <sp spk="KANE">
+
+Son, plot a course for Aquilae.</sp>
+         <sd>Annikin lights up like a Bantha at feeding time.</sd>
+         <sp spk="ANNIKIN">
+
+Aquilae!!  You mean we're going home?</sp>
+         <sp spk="KANE">
+
+We both need a rest.</sp>
+         <sd>Kane pulls back on the throttle, and the powerful spaceship lifts off the
+surface of the Fourth Moon of Utapau.</sd>
+      </scene>
+      <scene n="6">
+         <setting>  CLOUD SEA - ALDERAAN</setting>
+         <sd>A title card appears over a sea of billowing clouds on the gaseous planet of
+Alderaan:</sd>
+         <sd>Alderaan:  Capital of the New Galactic Empire.</sd>
+         <sd>The towering white oxide clouds pass, revealing the Imperial city of Alderaan.</sd>
+         <sd>The magnificent domed and gleaming city is perched, mushroom-like, on a tall
+spire, which disappears deep into the misty surface of the planet.  The
+peacefulness of this nebulous idyll is broken by the increasing wail of ion
+engines.   Four sleek stardestroyers, from the Imperial Third Fleet, burst
+from one of the huge cumulus range.  The craft are flying in a tight formation
+as they bank steeply, and head toward the Imperial capital of the galaxy.</sd>
+      </scene>
+      <scene n="7">
+         <setting>  INTERIOR OF STARDESTROYER - ALDERAAN</setting>
+         <sd>Stardestroyers are two-man spacecraft crammed with sophisticated electronic
+weaponry.  The pilot and gunnery officers sit side-by-side, surrounded by
+lighted readouts and switches.  They wear the gleaming black uniforms of the
+Empire.</sd>
+         <sp spk="PILOT">
+
+Tok-One to chicks:  Shape it up.  Let's make it good.</sp>
+         <sp spk="CHICK-ONE">
+
+Does that glare bother you?</sp>
+         <sp spk="PILOT">
+
+Use your face shield, Chick-One.</sp>
+         <sd>The pilot is cold and professional as he maneuvers his craft closer to the
+others.  The positions of the ships are displayed on a readout, along with a
+graphic representation of the city.  The pilot gives the gunner a quick look
+before he flips his sunshield over his eyes.</sd>
+         <sp spk="PILOT">
+
+Here we go.  Count:  three, two, one, now!</sp>
+      </scene>
+      <scene n="8">
+         <setting>  REVIEW STAND - PLAZA OF THE DADERS - ALDERAAN</setting>
+         <sd>On a huge, austere platform stands the dark Cos Dashit, Lord of Alderaan,
+Consul to the Supreme Tribunal, and ruler of the Galactic Empire.  He is a
+thin, grey-looking man, with an evil mustache which hangs limply over his
+insipid lip.  Standing at rigid attention on his right are several generals,
+dressed in the black and grey uniform of the realm.  Five members of the
+Supreme Tribunal sit off to the side.  On the emperor's left stands Crispin
+Hoedaack, newly appointed Governor of the Aquilaean Systems, a young,
+treacherous man with stone-cut, angular features and piercing grey eyes.</sd>
+         <sd>They all gaze skyward, as the four gleaming stardestroyers scream low overhead
+in an impressive barrel-roll formation.  As the sound of the spacecraft
+resonates throughout the glass canyon of the Plaza, the group of dignitaries
+return their attention to the parade of Imperial shock troops, and giant air
+tanks (which ride magically two to three feet above the ground).</sd>
+         <sd>The Plaza of the Daders is filled with a hundred rows of troops as the last
+brigade marches into position.  The sound of a thousand men snapping to
+attention is followed by a strange silence.  A light wind blows the great red
+banner of the Empire, creating a subtle flapping sound.  The emperor's
+amplified voice startles many of the troops as it cuts through the quiet.</sd>
+         <sp spk="EMPEROR">
+
+Upon this battle depends the survival of the Galactic Empire.  Upon this
+battle depends the life and long continuity of our civilization.  Not since
+the great Jedi Rebellion has our destiny been placed in such a balance.  This
+is to be the most magnificent campaign of all!  You have never been called
+without doing something to be remembered, something notable and striking.  The
+conquering of the Aquilaean System, the last of the independent Systems, and
+the last refuge of the outlawed, vile sect of the Jedi, will have such
+important and lasting consequences, that I can't but consider it as an epoch
+in history.</sp>
+         <sd>To the rear of the Plaza, watching the spectacle over the shoulder of a
+curious bureaucrat, stands Clieg Whitsun, a tall, blond young man about twenty
+years old.  He seems interested in what the emperor has to say, but keeps
+looking around nervously as if someone were after him.  His arm rests across
+his head, as he carefully but coolly adjusts a glowing blue ring on his index
+finger.  The emperor nears the end of his speech.
+        Crispin Hoedaack has moved up to stand next to the sinister monarch.
+The troops shout an Imperial salute in response to a particularly partisan
+statement.</sd>
+         <sp spk="EMPEROR (con't)">
+
+...I have personally asked the Aquilaeans to accept this Treaty of Alliance.
+During the long period of negotiation, they have only decided to be undecided.</sp>
+         <sd>We will barter no longer.  Governor Hoedaack has been appointed the First Lord
+of the Aquilaean System and Surrounding Territories.  This is the last
+frontier and the final stone in the great wall of the Galactic Empire.</sd>
+         <sd>The troops cheer, ad the emperor escorts Hoedaack inside.  Whitsun moves
+quickly away from the Plaza, passing through several check stations, where he
+is forced to show his identification.</sd>
+      </scene>
+      <scene n="9">
+         <setting>  NIGHT CLUB - ALDERAAN</setting>
+         <sd>Whitsun walks into the glass and chrome splendor of one of the famous
+nightclubs of Alderaan.  He moves to the long mirrored bar, and sits next to a
+rough-looking man, Bail Antilles, dressed in the distinctive gold and furs of
+the Galactic traders.</sd>
+         <sp spk="WHITSUN">
+
+Your glass is empty.</sp>
+         <sd>Whitsun speaks into a small intercom on the bar front.</sd>
+         <sp spk="WHITSUN (con't)">
+
+A dantic and...</sp>
+         <sd>He looks in Antilles' glass.</sd>
+         <sp spk="ANTILLES">
+
+No thanks, Whitsun.  I've had enough.</sp>
+         <sp spk="WHITSUN">
+
+Just a dantic then.  Bail, it's not like you to refuse a drink.  You're going
+to give Galactic traders a bad name.</sp>
+         <sd>A drink appears magically from a small elevator in the bar.  Whitsun takes it,
+and then places a pen-like transmitter he has taken from his pocket next to
+the intercom.  It creates a low electronic buzz.</sd>
+      </scene>
+      <scene n="10">
+         <setting>  BAR OBSERVATION CENTER - ALDERAAN</setting>
+         <sd>A controller sitting in front of a row of monitors taps his headphones, then
+flips a switch back and forth a couple of times.  He is obviously annoyed.</sd>
+         <sp spk="CONTROLLER">
+
+Number eighteen is out again.  Give me a maintenance check.</sp>
+         <sd>The controller yawns and puts his feet up on the control panel.</sd>
+      </scene>
+      <scene n="11">
+         <setting>  NIGHTCLUB - ALDERAAN</setting>
+         <sd>Whitsun leans in close to Antilles.  He is suddenly very serious.</sd>
+         <sp spk="ANTILLES">
+
+Whitsun, we've got problems.  They've just grounded all spacecraft, including
+trade frigates.  Even the ships under Imperial registry can't move.  Something
+big is up.</sp>
+         <sp spk="WHITSUN">
+
+I'm afraid they're not waiting for the Alliance Treaty.  They're already
+moving against the System.  I've got to get word back.</sp>
+         <sp spk="ANTILLES">
+
+The chrome companies are protesting the embargo, but it's going to take some
+time.</sp>
+         <sp spk="WHITSUN">
+
+Isn't anything moving?</sp>
+         <sp spk="ANTILLES">
+
+Military ships, but...</sp>
+         <sd>They are interrupted by an Imperial officer, and several stormtroopers.   The
+officer shouts over the P.A. system, as the troops rush to block the exits.
+Whitsun and the Galactic trader are tense, but remain cool.</sd>
+         <sp spk="OFFICER">
+
+Attention:  all Captains and First Officers of Guild Trade frigates will
+accompany me to the Ministry of Transport immediately.</sp>
+         <sd>Antilles gives Whitsun a hopeless look as the troops check their papers, and
+then take Antilles away.   A small fight breaks out in the back of the
+nightclub as one of the trader captains expresses his dislike of the Empire.
+Whitsun slams his glass to the bar in a gesture of hate and frustration.</sd>
+      </scene>
+      <scene n="12">
+         <setting>  GOVERNOR HOEDAACK'S QUARTERS - ALDERAAN</setting>
+         <sd>The large, white-on-white executive quarters resound with the high-pitched
+laugh of the evil Governor Hoedaack.  He slaps Darth Vader, a tall, grim-
+looking general, on the back, and the general's mouth makes the slightest
+gesture at a smile.</sd>
+         <sp spk="HOEDAACK">
+
+Success, I told you.  We are no longer under the control of the Great
+Families....We've gained a true advantage.</sp>
+         <sd>Vantos Coll, a member of the Supreme Tribunal, and a man of the grossest
+dimensions, appears to be a little worried.</sd>
+         <sp spk="COLL">
+
+A rather dangerous advantage.  You still have a System to conquer.</sp>
+         <sp spk="HOEDAACK">
+
+But this System will bring us more scientific wealth than that of any other
+House in the Tribunal.  We will easily gain control of the directorship.</sp>
+         <sp spk="COLL">
+
+Don't underestimate the armies of Aquilae.  They're lead by a Jedi.</sp>
+         <sp spk="HOEDAACK">
+
+I've told you about Commissioner Lars, General.  He worries a lot.</sp>
+         <sp spk="VADER">
+
+It's a myth that any Jedi still exist.</sp>
+         <sp spk="COLL">
+
+General Skywalker is no myth.  When I first arrived at court, he was the First
+Bodyguard to the emperor...He lead the Jedi Rebellion.</sp>
+         <sp spk="VADER">
+
+Seig Darklighter lead the Rebellion.</sp>
+         <sp spk="COLL">
+
+So the emperor would have you think, but I was there.</sp>
+         <sp spk="VADER">
+
+Then why wasn't he hunted down like the others?</sp>
+         <sp spk="COLL">
+
+Because he is too dangerous, too clever.  Besides, his presence on Aquilae is
+still only a rumor.</sp>
+         <sp spk="HOEDAACK">
+
+Then why do you believe it?</sp>
+         <sp spk="COLL">
+
+Because I knew him.  He's there, alright.  I can sense it.  Mark my words:
+Aquilae will not be easily conquered.</sp>
+      </scene>
+      <scene n="13">
+         <setting>  COURTYARD - PALACE OF LITE - AQUILAE</setting>
+         <sd>A low, sleek "landspeeder," (an auto-like transport which travels a few feet
+above the ground on a magnetic field), glides into the courtyard of the palace
+of Aquilae.  The planet is desert wilderness, but the palace is a sparkling
+oasis, with low concrete walls and great turrets spilling over with foliage
+from rooftop gardens.  The speeder stops before an enormous shaded corridor.
+Fountains line the beautiful and highly polished, tiled walkway.  Two young
+boys, Biggs (7) and Windom (5) are helped out of the speeder by Amber, a one-
+armed bodyguard dressed in the flowing white robes of the Aquilaean military.
+The two boys run through the long corridors, yelling and screaming, their
+little footsteps echoing throughout the palace.</sd>
+      </scene>
+      <scene n="14">
+         <setting>  The palace library is a dim, cool room projecting an aura of time-worn
+comfort and security.  In the distance, the children can be heard screaming
+through the corridors.  King Kayos, silver-haired but amazingly youthful under
+a tanned and leathery face, motions for one of his aides to shut the partially
+closed door.  He is in the middle of an emergency meeting of the Aquilaean
+High Senate.  The twelve men sit in overstuffed chairs, placed in a large
+circle.  A large, sallow-eyed Galactic trader named Aay Zavos fiddles
+nervously with a small scrap of leather as he speaks.</setting>
+         <sp spk="ZAVOS">
+
+My Lord, the chrome companies are with you in spirit, but you must understand,
+they can't openly support you.  Imperial trade restrictions are very
+unfavorable, and we, of course, favor your independence.</sp>
+         <sp spk="KAYOS">
+
+If there were to be war, would your frigates still supply us?</sp>
+         <sp spk="ZAVOS">
+
+Your bluntness is to be commended.  It could be arranged.</sp>
+         <sd>Count Sandage, a corrupt noble of the Senate, jumps to his feet in a rage.</sd>
+         <sp spk="SANDAGE">
+
+This is nonsense!  We have no choice but to approve the Treaty.  If there is
+war, the Empire will destroy our entire System with a snap of the finger.
+General Skywalker is a dreamer if he thinks he can mount any meaningful
+resistance....And you're dreamers if you believe him.  So much trust in one
+aged man.  You must see...</sp>
+         <sd>At that moment, all heads turn as someone enters the room.  It is General Luke
+Skywalker, Commander of the Aquilaean Starforce.  He is a large man,
+apparently in his early sixties, but actually much older.  Everyone senses the
+aura of power that radiates from this great warrior.  Here is a leader:  a
+Jedi general.  He looks weary, but is still a magnificent-looking warrior.
+His face, cracked and weathered by exotic climates, is set off by a close
+silver beard, and dark, penetrating eyes.  Sandage is somewhat embarrassed and
+quietly sits down.</sd>
+         <sp spk="GENERAL">
+
+Is there anyone here so naive he believes the Empire would even bother
+negotiating if they were contemplating destruction of this System?  Your
+Excellencies, this is more than a simple raid on your resources.  You must
+reach a decision.</sp>
+         <sd>Mir Nash, a thin, birdlike senator, turns to the general.</sd>
+         <sp spk="NASH">
+
+General Skywalker, war is a serious business...a deadly business.</sp>
+         <sp spk="GENERAL">
+
+Procrastination is a deadly business, Senator.  War is my business.  Have you
+approved my defense measures?</sp>
+         <sd>The Grande Mouff Tarkin wears the long, black robes of the Aquilaean religion.</sd>
+         <sd>He speaks with a high, cracking voice.</sd>
+         <sp spk="TARKIN">
+
+An actual war with the Empire is still only a remote possibility.  As a
+military treatise, your proposal has certain merits, but in the harsh light of
+reality, an attack against the Empire appears to be a somewhat extreme
+defense.</sp>
+         <sp spk="NASH">
+
+You must understand, General, we are interested in avoiding a war, not
+starting one.</sp>
+         <sp spk="GENERAL">
+
+There are times when offense makes the best defense.  If that Alliance Treaty
+isn't signed, we will need all of the advantage we can get.</sp>
+         <sp spk="KAYOS">
+
+Count Sandage, I want you to head the delegation to Alderaan.  You will leave
+tomorrow with our answer regarding the Treaty.  My decision will be
+forthcoming.</sp>
+         <sd>The senators whisper among themselves.</sd>
+         <sp spk="KAYOS (con't)">
+
+All right, then.  May the force of others be with you all.</sp>
+         <sd>The senators leave in a flurry of hushed conversation.  The general is lost in
+thought, and remains in his chair.  Biggs and Windom (Windy), the king's two
+young sons, storm through the existing senators and rush on to Kayos' lap.
+The king is obviously very proud of the two young princes.  He throws Biggs
+into the air, and then catches him again.</sd>
+         <sp spk="WINDY">
+
+Me too!  Me too!</sp>
+         <sp spk="BIGGS">
+
+Leia's leaving!  Leia's leaving and you gotta say good-bye.</sp>
+         <sd>The king picks up Windy and swings him around, then puts him down.</sd>
+         <sp spk="KAYOS">
+
+Okay, whippersnapper, go tell your mother and your sister that I'm on my way.</sp>
+         <sd>The two boys run out of the room and are heard yelling and screaming down the
+hallway.  The king starts out, but stops in front of the general.</sd>
+         <sp spk="KAYOS">
+
+Luke, my daughter is leaving for the academy at Chathos.  Won't you come and
+wish her well?  It would mean a lot to her.  She truly idolizes you, you know.</sp>
+         <sd>Come on, the war will wait.</sd>
+         <sp spk="GENERAL">
+
+Of course.  I'm sorry, My Lord.  Politics always seem to distress me.</sp>
+         <sd>The general rises, and as they head for the door, Kayos pats him on the back.</sd>
+         <sp spk="KAYOS">
+
+I know, Luke.  I feel the Force also.</sp>
+      </scene>
+      <scene n="15">
+         <setting>  COURTYARD - PALACE OF LITE - AQUILAE</setting>
+         <sd>A large, four-seat speeder sits gleaming in the sun-soaked courtyard.  The
+Princess Leia, about fourteen years old, possessing a soft beauty and iron
+will, is embracing her mother, Queen Breha, a warm, silver-haired matron.
+There are tears in the princess' blue eyes.  Biggs and Windy jump around
+inside the speeder, disrupting the efforts of the one-armed Amber to pack
+several plaxiform cases.</sd>
+         <sd>Leia embraces the king as he approaches with the general.</sd>
+         <sp spk="LEIA">
+
+Oh, Daddy, I'll miss you so.</sp>
+         <sp spk="KAYOS">
+
+The semester will be over before you know it.  You'll have a grand time.
+There are so many new things to learn.  I wish I were going.</sp>
+         <sd>He gives her a fatherly smile, and she hugs him again.  The general stands
+rather formally to one side.  The princess, her long auburn hair tied in
+braids, moves to the general and he bows before her.</sd>
+         <sp spk="GENERAL">
+
+May your studies do you honor.</sp>
+         <sd>Leia is somewhat embarrassed by the general's formality and can only manage an
+awkward smile before returning to her parents at the speeder.</sd>
+         <sp spk="BREHA">
+
+Hurry Leia.  You must make it to Yuell before nightfall.</sp>
+         <sd>The princess' maids-in-waiting, Alana, a short, stocky girl, and Mina, more
+comely (somewhat the same stature as Leia) with long dark hair, giggle and
+straighten Leia's dress before she enters the speeder.  The princess and Mina
+hug Alana, whose giggles have turned to tears.  The two boys scramble out of
+the speeder as Amber helps the princess and her maid into the back seat.  The
+speeder is piloted by a trooper of the First Order.  Amber jumps into the seat
+beside him, and the speeder starts with a low buzzing sound.  The princess
+waves to her family, and Mina waves to Alana as the speeder slowly glides out
+of the courtyard.</sd>
+      </scene>
+      <scene n="16">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The war room is a mass of glass enclosures, electronic wall displays,
+monitors, and computer stations.  General Skywalker enters a control station,
+followed by a covey of military aides of various ranks.  As the group hurry
+through the crowded room, men rise and salute the new arrivals.  The general
+stops before a giant display of the galaxy.  Small symbols flash on and off
+over various portions of the big board.  The general studies it intently.</sd>
+         <sp spk="GENERAL">
+
+Montross!</sp>
+         <sd>Captain Montross, one of the general's aides, snaps to attention.</sd>
+         <sp spk="MONTROSS">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+What's the TQ on this?</sp>
+         <sp spk="MONTROSS">
+
+The last frigate to leave the Imperial capital was at twenty-three forty, Sir.</sp>
+         <sp spk="GENERAL">
+
+Have any ships at all left the planet?  (to another aide)  Check with the
+Guild on Horton three.</sp>
+         <sp spk="MONTROSS">
+
+At twenty four hundred, a full battalion of stardestroyers left for what is
+projected to be Anchorhead, or a nearby System.</sp>
+         <sp spk="GENERAL">
+
+And no word from Whitsun.  He should have reported by now.  Captain Prue!</sp>
+         <sd>An older, academic looking aide, steps forward.</sd>
+         <sp spk="PRUE">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+What do you make of this?</sp>
+         <sp spk="PRUE">
+
+A battalion is invasion force...but the Empire controls that entire part of
+the galaxy....A revolution, maybe.  At any rate, they're going in the wrong
+direction to be any trouble for us.</sp>
+         <sd>The general ponders this for a few moments, then speaks almost to himself.</sd>
+         <sp spk="GENERAL">
+
+I don't know... It doesn't feel good.</sp>
+         <sp spk="MONTROSS">
+
+Sir?</sp>
+         <sp spk="GENERAL">
+
+Put 'em on alert.</sp>
+         <sd>A loud uproar is heard on the far side of the war room.  Everyone turns to see
+a foreign dressed warrior pushing his way past several guards and war-room
+bureaucrats.  The warrior, with his long hair tied in an odd bun on the top of
+his head, is Kane Starkiller.  He is followed by his son, Annikin, who rudely
+pushes the pesky bureaucrats out of the way.</sd>
+         <sp spk="BUREAUCRATS">
+
+It's restricted.  You'll have to wait...(etc.)</sp>
+         <sp spk="KANE">
+
+Get out of my way, boy, before I grind you into the surface...(etc.)</sp>
+         <sd>As the dauntless Starkiller approaches the general, the guards stop in
+bewilderment as General Skywalker rushes up to the warrior and embraces him.
+The two Jedi warriors laugh jubilantly and slap one another, as the aides and
+bureaucrats look on in amazement.</sd>
+         <sp spk="GENERAL">
+
+Kane Starkiller - you old muscle-rat!  What a sight!  We heard that you had
+been executed.</sp>
+         <sp spk="KANE">
+
+So the Empire would like to believe.  I've been in the Kessil System.  You
+remember little Annikin.</sp>
+         <sd>Kane puts his arms around his son, who has been making eyes at one of the cute
+young female aides.  He bows before the General.</sd>
+         <sp spk="GENERAL">
+
+He takes after his mother!  (They laugh)  It's so good to see you.</sp>
+         <sp spk="KANE">
+
+It's wonderful to be with another Jedi again.  There are so few of us left.</sp>
+         <sd>The cute aide goes back to her duties, flirting with Annikin as she passes.
+The young warrior pinches her on the ass, which startles her, but she goes on
+like nothing happened.</sd>
+         <sp spk="GENERAL">
+
+What a sight!</sp>
+         <sd>The two Jedi stand looking at one another, hardly believing the other is real.</sd>
+         <sd>Finally, the general realizes his aides are standing around, gawking at the
+duo.</sd>
+         <sp spk="GENERAL (to the aids)">
+
+Wake up, gentlemen.  You're on alert.  Keep me posted on that battalion.</sp>
+      </scene>
+      <scene n="17">
+         <setting>  CONTROL STATION - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general, Starkiller, and his son enter a small glass enclosed control
+office.  They sit, and an awkward silence passes as each man waits for the
+other to speak.</sd>
+         <sp spk="KANE">
+
+I've come for your help.</sp>
+         <sp spk="GENERAL">
+
+Anything you ask.  You're a Jedi brother.  We're one.</sp>
+         <sp spk="KANE">
+
+My friend, we've been through much together...I've been through much since we
+parted.  I've lost much... The Empire has chased us half way across the
+galaxy... There is no refuge.  One day they will come here... Take my son as
+your Padawan Learner.  He would be a Jedi.  I've trained him from birth.  He's
+reached the fifth stage.  He fought in the Kessilian civil wars and commanded
+a Hubble expedition to the Cone Systems.  He's a good boy, Luke, and one hell
+of a fighter.</sp>
+         <sd>The general looks down, somewhat embarrassed.  He scratches his head, then
+smiles.</sd>
+         <sp spk="GENERAL">
+
+Old friend, you do me too much honor.  I was never a match for you.  Why don't
+you finish his training yourself?</sp>
+         <sp spk="KANE">
+
+I'm too old, Luke.  I can't go on... You must finish it.</sp>
+         <sp spk="GENERAL">
+
+What kind of talk is this?  You're not the old Starkiller I remember.  Too
+old?!?</sp>
+         <sd>Starkiller suddenly ignites in a rage and swings his left forearm down with a
+mighty blow across the solid chrome desk the general is sitting on.  The old
+Jedi warrior's forearm cracks in two, spewing forth wires, and many fine
+multicolored electronic components.  The artificial limb flops lifelessly to
+Starkiller's side.  The warrior rips open his tunic, revealing a plastic chest
+stuffed with flashing electric parts.</sd>
+         <sp spk="KANE (angrily)">
+
+I'm not the same.  There is nothing left but my head and right arm... I've
+lost too much, Luke...I'm dying.</sp>
+         <sd>The general bows his head in sorrow for one of the greatest warriors in the
+galaxy and a dear friend.</sd>
+         <sp spk="GENERAL">
+
+I'm sorry...</sp>
+         <sp spk="KANE">
+
+I'm sorry.  I keep losing control.  I'm very tired...Take my son!  The Jedi-
+Bendu must survive.  We must pass it on.  Only a Jedi can stop the Empire.
+We're very old, Luke.  A new generation of Jedi must be started.  Take him;
+teach him the way of the Jedi-Bendu...</sp>
+         <sd>Captain Montross bursts into the office and somewhat excitedly salutes the
+general.</sd>
+         <sp spk="MONTROSS">
+
+Sir, we have picked up something!  An asteroid, or solid comet moving away
+from the Anchorhead System.</sp>
+      </scene>
+      <scene n="18">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general rushes out of the control station and back to the giant Galactic
+display.  He is followed by Montross, Starkiller and his son.</sd>
+         <sp spk="GENERAL">
+
+Are you sure it's not the battalion?</sp>
+         <sp spk="MONTROSS">
+
+A solid object.  It's as big as our Third Moon.</sp>
+         <sp spk="PRUE">
+
+It's too large to be man-made, and it's too slow to be a comet.</sp>
+         <sp spk="GENERAL">
+
+Analysis?</sp>
+         <sp spk="MONTROSS">
+
+It's too far out.</sp>
+         <sp spk="GENERAL">
+
+I'll be with the king.  Report as soon as you can get a reading on it.
+(turning to Kane's son)  Captain Starkiller, from now on you stick close to
+me.</sp>
+         <sd>The older Starkiller smiles, and puts his good arm around his old friend.</sd>
+      </scene>
+      <scene n="19">
+         <setting>  DINING CHAMBER - PALACE OF LITE - AQUILAE</setting>
+         <sd>King Kayos moves his arm around Breha's waist as they stand on a balcony
+watching the giant twin suns of Aquilae disappear behind a distant dune range.</sd>
+         <sd>The general enters, rather in a rush, followed by the young Starkiller, who is
+now dressed in the white uniform of the Aquilaean starforce.  (He still wears
+the distinctive Kessilian hair knot.)  They bow before the king.</sd>
+         <sp spk="KAYOS (pointing to the suns)">
+
+Aren't they beautiful, General?  "Always and never the same."  You're just in
+time for dinner.</sp>
+         <sp spk="GENERAL">
+
+I have come for other reasons.  Could....</sp>
+         <sp spk="KAYOS">
+
+Relax, General.  We will discuss it, but over dinner.  There are times, Luke,
+when I find you a bit too rigid.  Is this your new disciple?</sp>
+         <sd>Starkiller is ill at ease and bows again.</sd>
+         <sp spk="STARKILLER">
+
+Annikin Starkiller, Sir.</sp>
+         <sp spk="KAYOS">
+
+Where's Kane?</sp>
+         <sp spk="GENERAL">
+
+He left for the spaceport at Gordon to visit an old friend, Han Solo, the
+Ureallian.</sp>
+         <sp spk="KAYOS">
+
+We are becoming quite a refuge.</sp>
+         <sd>The group sits at a large table, and food is brought in by servants.  They
+eat.  Starkiller is nervous and watches the general, to make sure he is being
+proper.</sd>
+         <sp spk="GENERAL">
+
+My Lord, several events have occurred which lead me to believe we are in
+imminent danger of attack.  There is no longer time for discussion and
+debate...</sp>
+         <sp spk="KAYOS">
+
+What events?</sp>
+         <sp spk="GENERAL">
+
+Whitsun, our best agent, has disappeared in the Imperial capital.  There is
+unusual military traffic in the S-4 sectors...</sp>
+         <sp spk="KAYOS">
+
+Unless you have direct, concrete proof of a pending attack, there is nothing I
+can do.</sp>
+         <sp spk="GENERAL">
+
+By the time we have proof, it may be too late.</sp>
+         <sp spk="KAYOS">
+
+Luke, I'm leaving tonight for Amsel.  I'm meeting with the full assembly first
+thing in the morning.  I am not going to approve the Alliance Treaty, and I
+will get your defense measure approved.  Just be patient.  You will have the
+war code.</sp>
+         <sp spk="GENERAL">
+
+Tomorrow may be too late.  My Lord, I need the war code now.  We must get our
+forces into space.</sp>
+         <sp spk="KAYOS">
+
+But it must be done legally, with everyone's approval.  Tomorrow you will have
+that.  I doubt the Empire would attack before receiving our answer.  The
+separation of war powers is the one condition upon which you assumed command
+of our forces.  You're a friend, Luke, and  I trust you.  But you're also an
+outlander who controls a great deal of power.  I can't forsake my oath any
+more than you can.  Just be patient.  You will have the code tomorrow.</sp>
+         <sd>Captain Montross enters the large chamber and bows before the king.</sd>
+         <sp spk="MONTROSS">
+
+I bring a report to General Skywalker, My Lord.</sp>
+         <sp spk="KAYOS">
+
+You may deliver it.</sp>
+         <sp spk="MONTROSS">
+
+Sir, the asteroid has disappeared from our scopes.  There is no trace of it.</sp>
+         <sp spk="GENERAL">
+
+Were they able to analyze it?</sp>
+         <sp spk="MONTROSS">
+
+It never came within range, Sir.</sp>
+         <sd>The general rises, quickly followed by Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Excuse us, My Lord.  We'd better get back.  I will wait patiently for the
+approval.</sp>
+         <sd>The general and Montross exit the chamber.  Starkiller takes one last bite of
+his dinner, then dashes after his mentor.</sd>
+      </scene>
+      <scene n="20">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general sits rigidly, facing the big Galactic display board.  Several
+aides and bureaucrats rush to and fro, ignoring the general.  he is asleep.
+Captain Prue approaches the general and snaps to attention.  The general's
+eyes open.</sd>
+         <sp spk="GENERAL">
+
+What are the results?</sp>
+         <sp spk="PRUE">
+
+Negative, Sir.</sp>
+         <sp spk="GENERAL">
+
+Are you sure?</sp>
+         <sp spk="PRUE">
+
+Absolutely.</sp>
+         <sp spk="GENERAL">
+
+It's just not possible.  Something that size can't just disappear without a
+trace...Check it again.</sp>
+         <sp spk="PRUE">
+
+That's the tenth negative, Sir.</sp>
+         <sp spk="GENERAL">
+
+I said check it again.</sp>
+         <sd>Captain Prue retreats to a computer station.  The general looks around for
+Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Starkiller!</sp>
+         <sd>Everyone near the general turns, but Starkiller doesn't show.</sd>
+         <sp spk="GENERAL">
+
+Where is that boy?  Montross!</sp>
+         <sd>Montross rushes to the general and snaps to attention.</sd>
+         <sp spk="GENERAL">
+
+Page Starkiller.</sp>
+         <sd>Montross goes back to his station and a few moments later, Starkiller is paged
+over the P.A. system.  The general waits, watching the big board.  Eventually,
+Starkiller stumbles out of an enclosed computer closet, fastening his pants
+and tucking in his tunic.  A moment later, the cute female aide rather
+sheepishly exits the computer closet.  She is also in the process of putting
+her uniform back together.  Starkiller rushes up to the general and snaps to
+attention.</sd>
+         <sd>The general lets him stand there for a moment, not acknowledging his presence;
+then, suddenly, without warning and in one masterful flash motion, the general
+stands, grabs a small baton attached to his belt (which immediately ignites
+into a four-foot glowing lasersword,) and swings at the young warrior's head.
+In an equally quick movement, Starkiller ignites his lasersword and blocks the
+general's blow.  Everyone in the war room is surprised and startled.  After a
+moment, they rush to the general.  Starkiller and the general stand motionless
+for a few moments, with laserswords locked in mid-air, creating a low buzzing
+sound.  Finally, the general grins, and Starkiller hesitantly relaxes.  They
+lower their swords and turn them off.</sd>
+         <sp spk="GENERAL">
+
+You are trained well, but remember, a Jedi must be single-minded, a discipline
+your father obviously never learned, hence your existence.  Clean yourself up.</sp>
+         <sd>Discipline is essential.  Your mind must follow the way of the Bendu.</sd>
+         <sp spk="STARKILLER">
+
+It won't happen again, Sir.  There are many new....</sp>
+         <sd>P.A.
+General Skywalker, white com.</sd>
+         <sd>The general moves to a control station and picks up a phone.</sd>
+         <sp spk="PHONE VOICE">
+
+Sir, Captain Whitsun has just been admitted to Med Vac.</sp>
+         <sp spk="GENERAL">
+
+What's his condition?</sp>
+         <sp spk="PHONE VOICE">
+
+No data, Sir.</sp>
+         <sp spk="GENERAL">
+
+I'm on my way.</sp>
+      </scene>
+      <scene n="21">
+         <setting>  MED VAC EMERGENCY ROOM - UNDERGROUND FORTRESS</setting>
+         <sd>Captain Starkiller waits in an outer chamber as General Skywalker rushes into
+the Med Vac emergency room where several doctors are working on the prostrate
+Whitsun.</sd>
+         <sp spk="GENERAL">
+
+What's his condition?  Is he conscious?</sp>
+         <sp spk="DOCTOR">
+
+Partially.  He's be all right - a few bruises, primary exhaustion....</sp>
+         <sd>Whitsun thrashes around in a semi-conscious state.  He sees the general.</sd>
+         <sp spk="GENERAL">
+
+What happened, boy?  What's going on?</sp>
+         <sp spk="WHITSUN (with difficulty)">
+
+The Imperial Starforce is already on its way, not far behind me... They're
+going to attack.</sp>
+         <sp spk="GENERAL">
+
+Are you sure?</sp>
+         <sp spk="WHITSUN">
+
+I have tapes...A giant space fortress....</sp>
+         <sd>He struggles to give General Skywalker his ring.</sd>
+         <sp spk="GENERAL">
+
+As big as our Third Moon?</sp>
+         <sp spk="WHITSUN">
+
+Bigger.  It's unlike anything I've ever seen.  Sophisticated deflection
+systems.... work in opposition to the suns.</sp>
+         <sp spk="GENERAL">
+
+They will show up on our screens at sunrise.  They'll attack before that.</sp>
+         <sd>The general rushes into the outer chamber where Captain Starkiller is waiting
+for him.</sd>
+         <sp spk="GENERAL">
+
+Take the fastest landspeeder to Chathos.  Pick up Princess Leia... and only
+Princess Leia.  Return by way of the Great Reef.  Most speed.</sp>
+         <sd>Starkiller exits and the general goes to an intercom and pushes several
+buttons.</sd>
+         <sp spk="GENERAL">
+
+Montross.</sp>
+         <sp spk="MONTROSS">
+
+Sir!</sp>
+         <sp spk="GENERAL">
+
+Full alert....everything!  Get the Royal Family back here.</sp>
+         <sp spk="MONTROSS">
+
+The princess is at Chathos.  There are no transports....</sp>
+         <sp spk="GENERAL">
+
+I've already sent Captain Starkiller for her!  Contact the king, first
+priority.  He's probably still en route to Amsel.  Use the scan com.  I'm on
+my way.</sp>
+      </scene>
+      <scene n="22">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The war room is on full alert.  Everyone is at attention, waiting for the
+command that will put them into action.  The general enters a communication
+center, followed by many aides.  Captain Montross and the com aide salute.</sd>
+         <sp spk="MONTROSS">
+
+We're having a problem getting through, Sir.  There is a great deal of
+interference.</sp>
+         <sp spk="PRUE">
+
+It could be jamming.</sp>
+         <sp spk="GENERAL">
+
+Try a surface link through Amsel.</sp>
+         <sd>The aides go back to the com-link system to try to get a line through to the
+king.</sd>
+         <sp spk="PRUE">
+
+We should be able to spot them at sunrise....That's not too far off.</sp>
+         <sp spk="GENERAL">
+
+They'll attack with sunrise.  Until the king gives us that code to start the
+war computers, we'll just have to sit tight.</sp>
+         <sp spk="PRUE">
+
+All units are on alert, Sir.</sp>
+         <sp spk="GENERAL (to Montross)">
+
+Have you made contact yet?  (to himself)  This is one hell of a way to run a
+war.</sp>
+         <sp spk="PRUE">
+
+Sir?</sp>
+      </scene>
+      <scene n="23">
+         <setting>  COURTYARD - ACADEMY OF CHATHOS - AQUILAE</setting>
+         <sd>A landspeeder roars into a courtyard of the Academy at Chathos.  Starkiller
+jumps out, and runs up to the large, heavy doors of the academy.  They are
+locked.  He bangs madly on the carved metallic door, until finally an old
+woman manages to swing it open.  Starkiller rushes past her into the main
+courtyard where Princess Leia and her hand-maiden, Mina, struggle with two
+large cases.  They are followed by two very old matrons, dragging several more
+cases.</sd>
+         <sp spk="STARKILLER">
+
+Forget the cases - we've no time.</sp>
+         <sp spk="LEIA">
+
+These are my things.  They must...</sp>
+         <sp spk="STARKILLER">
+
+I said forget them, and hurry...</sp>
+         <sp spk="LEIA">
+
+Just who do you think you are?</sp>
+         <sd>Starkiller grabs the princess by the arm, and hauls her to the speeder.  Mina
+and the old women run after them.</sd>
+         <sp spk="LEIA">
+
+I will not be treated like this!   You bring my things.... My father will have
+your head... (etc.)</sp>
+         <sd>Leia struggles to break away from the young warrior's grasp as he opens the
+door of the speeder.</sd>
+         <sp spk="STARKILLER">
+
+Settle down!</sp>
+         <sd>When the door to the speeder is opened, Mina starts in, and Starkiller stops
+her.</sd>
+         <sp spk="STARKILLER">
+
+You must stay.  Here, take the Crest.</sp>
+         <sd>Starkiller rips the royal crest from the princess' neck, and hands it to the
+startled handmaiden.  The old women gasp in horror.  The princess starts
+hitting Starkiller with little result.</sd>
+         <sp spk="PRINCESS">
+
+Mina's not staying...I'm not leaving her.  You can't....</sp>
+         <sd>Starkiller punches her square on the jaw and knocks her cold.  Mina is panic
+stricken, one of the old women faints, and another starts for Starkiller with
+a large staff.</sd>
+         <sp spk="STARKILLER">
+
+She'll be all right.  I'm taking her to safety...as ordered.  You will wear
+the crest and continue as before.</sp>
+         <sd>The authority of Starkiller's voice stops the old lady.  He places the
+princess into the speeder, and maneuvers it out of the courtyard.  Mina puts
+on the crest as the speeder races away from the academy.</sd>
+      </scene>
+      <scene n="24">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>Queen Breha, Biggs and Windy are escorted into a rest area of the war room.
+General Skywalker sits rigidly in a chair in the communications area,
+apparently asleep.</sd>
+         <sp spk="MONTROSS">
+
+Sir, we've made contact!</sp>
+         <sd>The general opens his eyes and takes the intercom mike.</sd>
+         <sp spk="KAYOS">
+
+What is it, General?</sp>
+         <sp spk="GENERAL">
+
+The Empire will attack on the rising of the sun.  My agent made it back.  I
+now have proof.  I need the war code...</sp>
+         <sp spk="KAYOS">
+
+I'll relay it directly to the computer.  Is Breha...?</sp>
+         <sp spk="GENERAL">
+
+The Royal Family is safe.  Starkiller has gone after Princess Leia...</sp>
+         <sp spk="KAYOS">
+
+I'm on my way back.</sp>
+      </scene>
+      <scene n="25">
+         <setting>  RED PLAINS - AQUILAE</setting>
+         <sd>The small caravan of four speeders sits motionless on the vast red plains of
+Aquilae.  The king returns the intercom to the pilot and takes a small
+metallic card from around his neck and gives it to the co-pilot.</sd>
+         <sp spk="KAYOS">
+
+Send this sub-land, priority one.  (to the pilot)  Get us back to Calvas
+immediately!</sp>
+         <sd>The four speeders turn around and scream away in the direction they had come.
+They pass a huge ultrasleek powerplow, planting green fungus in endless
+furrows.  Two clay-covered farmers, riding atop the ponderous machine, watch
+the speeders disappear over the horizon, and into the rising twin suns.  A
+bright object, twinkling in early morning heavens, catches the eye of the
+older of the two farmers, and he brings the machine to a lumbering halt.  The
+younger farmer also notices the object, and stares skyward, shading his eyes
+to get a better view.</sd>
+         <sd>Suddenly there is a huge, bright atomic flash on the horizon.  A few moments
+later, a thunderous shaking, followed by high winds, tumbles the older farmer
+from his perch.  A second flash on the opposite horizon brings another jolting
+earthquake, and the younger farmer collapses, terror frozen on his face.</sd>
+      </scene>
+      <scene n="26">
+         <setting>  READYROOM - SPACEPORT OUTPOST - AQUILAE</setting>
+         <sd>Chaos.  Red scramble lights are flashing.  Alert horns and attack buzzers
+create an unbelievable cacophony.  Air warriors, with the distinctive circle
+and cross medallion on their white space suits, scramble out of the low,
+concrete readyroom, grabbing helmets and spacepacks as they race out of the
+door.</sd>
+      </scene>
+      <scene n="27">
+         <setting>  ATTACK RUNWAY - SPACEPORT OUTPOST - AQUILAE</setting>
+         <sd>Twelve pilots and navigators dash in unison to a line of waiting two-man
+starships of the destroyer class.  Ground crews scurry back and forth, loading
+last-minute armament, and unlocking power couplings.  Pilot Leader, a rugged,
+handsome boy of twenty, gives his ground crew a signal that his is okay.  He
+has a winning smile and a distinctive scar along the side of his face.  His
+crew chief pats him on the back.</sd>
+         <sp spk="CHIEF">
+
+Knock them all the way back to Alderaan.</sp>
+         <sd>The canopy is closed and the powerful starship moves onto the runway.  Other
+crewmen say good-bye to their pilots, some grin, some kidding - all with a
+great deal of hidden emotion.  The din of two dozen retrorockets cuts through
+the uproar, and six silver spacecraft leave the runway, and disappear into the
+morning cloud cover.</sd>
+      </scene>
+      <scene n="28">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general stands before a giant display of the Aquilaean solar system.
+Montross signals the general.</sd>
+         <sp spk="MONTROSS">
+
+They're away, Sir.  Six from Gordon.  All other spaceports were hit.  The king
+hasn't arrived yet.</sp>
+         <sp spk="GENERAL">
+
+Keep checking.  Put those fighters' intercom over the P.A.</sp>
+         <sd>The general sits at one of the intercom panels, and puts on a headphone.  A
+row of monitors is before him.  He turns to Montross.</sd>
+         <sp spk="GENERAL">
+
+Where are they?</sp>
+      </scene>
+      <scene n="29">
+         <setting>  SPACE - AQUILAE IN ECLIPSE</setting>
+         <sd>The eerie, reddish-yellow planet of Aquilae slowly drifts into view from total
+eclipse.  A small, bright speck, orbiting the planet, sparkles in the light of
+the twin suns.  The six deadly Aquilaean starships settle ominously into the
+foreground, moving swiftly toward the orbiting speck.  As the sleek starships
+move closer, the orbiting speck is revealed to be a gargantuan space fortress.</sd>
+         <sd>The moon-sized satellite fortress dwarfs the approaching fighters.  Every few
+moments, explosions create blinding flash on the planet's surface, as the
+fortress bombards the planet with a fusillade of laser bolts.</sd>
+      </scene>
+      <scene n="30">
+         <setting>  AQUILAEAN STARSHIP - INTERIOR</setting>
+         <sd>Pilot Leader, in the first ship, signals to his navigator who sits in a small,
+isolated glass bubble to the rear of the craft.  General Skywalker is seen on
+one of many monitors.  A view of the space fortress is on another.  The rest
+are filled with various computer readouts and displays.  One of the other
+starships reports to Pilot Leader.</sd>
+         <sp spk="DEVIL SIX (intercom)">
+
+Look at the size of that thing!  Hey, Bowman, I hope you remembered to bring
+your pop gun, 'cause I think we caught us a big one this time....</sp>
+         <sp spk="PILOT LEADER">
+
+Cut off, Devil Six....Stand by.</sp>
+         <sp spk="GENERAL (monitor)">
+
+It looks like they're still using the basic quad-tristation configuration.
+Use a "ranger defense."  Concentrate on breath ports and lock areas.</sp>
+         <sp spk="PILOT LEADER">
+
+Affirmative base...Copy and transmit....Devil Two, check your rotation plates.</sp>
+         <sp spk="DEVIL TWO">
+
+Roger, Boss.  We're getting a threshold disturbance on gyro-three.</sp>
+         <sp spk="GENERAL (monitor)">
+
+Switch over, Five, cover it! ...Devil pack, generate a spread six
+formation...May the force of others protect you.</sp>
+         <sp spk="PILOT">
+
+Settle in...Devil pack, stand by.  Mark five...break off.  Here we go.  God
+save us all.</sp>
+      </scene>
+      <scene n="31">
+         <setting>  SPACE - AQUILAEAN STARSHIP</setting>
+         <sd>Fuel pods are jettisoned.  The half-dozen fighters break off into a powerline
+attack on the huge fortress.  Multiple laserbolts streak from the starships,
+creating small explosions on the complex surface of the fort.</sd>
+      </scene>
+      <scene n="32">
+         <setting>  INTERIOR MAIN CORRIDOR - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The chaos of battle echoes through the vast corridors of the fortress.  Walls
+buckle and cave in, sucking debris and personnel into the vacuum of outer
+space.  Alarm sirens scream as soldiers scramble to large turbo-powered laser
+gun emplacements.  Sergeants yell orders through the smoke and confusion.  Men
+and robots of various shapes and sizes run to their battle stations.</sd>
+      </scene>
+      <scene n="33">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The monitors with pictures from the starships suddenly go blank.  Technicians
+check channels as others in the war room silently listen to the action over
+the intercom.  The general remains calm, but concerned.</sd>
+         <sp spk="PILOT LEADER (intercom)">
+
+Tighten it up... Devil Two, tighten it up.  Watch those towers....</sp>
+         <sp spk="DEVIL TWO (CHEWIE)">
+
+Heavy fire, Boss.  Twenty-three degrees.</sp>
+         <sp spk="PILOT LEADER">
+
+I see it.  Pull in... we're picking up some interference.</sp>
+         <sp spk="DEVIL SIX">
+
+Wow, I've never seen such fire power.</sp>
+         <sp spk="PILOT LEADER">
+
+Pull in, Devil Two...Pull in!  Chewie???!!</sp>
+         <sp spk="DEVIL TWO (CHEWIE)">
+
+I'm all right, Boss.  I've got a target.</sp>
+         <sp spk="DEVIL SIX">
+
+There is too much action, Chewie.  Get out!</sp>
+         <sp spk="PILOT LEADER">
+
+Break off, Chewie....Acknowledge.  Devil Six, can you see Devil Two?</sp>
+         <sp spk="DEVIL SIX">
+
+I've lost him.  There's a very heavy fire zone on this side.  My radar's
+jammed.</sp>
+         <sp spk="DEVIL FIVE">
+
+He's gone....no, wait.  There he is...Fin damage, but he's all right.</sp>
+         <sd>A sigh of relief sweeps across the war room.  The monitors flash on, then off
+again.</sd>
+         <sp spk="DEVIL FOUR (intercom)">
+
+Watch your back, Boss!  Watch your back!!</sp>
+      </scene>
+      <scene n="34">
+         <setting>  AQUILAEAN STARSHIP</setting>
+         <sd>The speedy little fighters dart back and forth across the soft underbelly of
+the fortress, leaving a trail of destruction behind them.</sd>
+         <sp spk="PILOT LEADER">
+
+Converge on south axis point, point three nine four.  It appears accessible.
+I'm going to map the surface.  Devil Four, cover me!</sp>
+         <sd>Pilot Leader and Devil Four dive in unison through a forest of radar domes,
+antennae, and gun towers.  Devil Four fires into the protrusions as the two
+starships criss-cross the surface of the fortress.  Suddenly, a dense barrage
+of laserfire erupts from a tower, catching Devil Four broadside.  The
+spacecraft bursts into a million flaming pieces.  Pilot Leader reacts to the
+loss of his wing man, but continues on his mission.</sd>
+      </scene>
+      <scene n="35">
+         <setting>  SUB-HALLWAY - IMPERIAL SPACE FORTRESS</setting>
+         <sd>Constant explosions rock the interior of the fortress.  Civilians, including
+women and children, scurry for safety in the panic-ridden hallways.  Two
+construction robots, Artwo Detwo (R2D2) and See Threepio (C3P0), are blown,
+slipping and sliding across the hallway floor into some freight canisters.
+Both robots are rather old and battered.  Artwo is a short, (three feet) claw-
+armed tri-pod.  His face is a mass of computer lights, surrounding a radar
+eye.  Threepio is a tall, gleaming android of human proportions.  He is thin,
+with a totally metallic surface of an Art Deco design.  The robots attempt to
+get out from under the canisters, but rushing gas from a broken pipe keeps
+knocking them over.</sd>
+         <sp spk="THREEPIO">
+
+This is madness; we're going to be destroyed.  I'm still not accustomed to
+space travel.</sp>
+         <sp spk="ARTWO">
+
+The external bombardment does appear to be concentrated in this area.  The
+structure has exceeded the normal stress quotient by point four, although
+there appears to be no immediate danger.</sp>
+         <sp spk="THREEPIO">
+
+No immediate danger!  You're faulty.  This is madness!</sp>
+         <sd>Artwo gives Threepio a sheepish look and clings to a siderail for dear life,
+as debris flies through the hallway.</sd>
+      </scene>
+      <scene n="36">
+         <setting>  AQUILAEAN STARSHIP</setting>
+         <sd>Devil Two (Chewie), a young hotshot of about sixteen years, miraculously dives
+his ship through a virtual wall of laser fire, and blasts a huge radar disc
+into dust.  Chewie signals his navigator, who lets out a whooping cheer, as
+the craft veers into a victory roll.</sd>
+         <sp spk="PILOT LEADER">
+
+Great moves, Chewie.  Regroup at point two, zero one.  Coincide, Devil Six.</sp>
+         <sp spk="GENERAL">
+
+Mace, your map projection shows a weak point at south portal:  niner point
+six.  Concentrate the attack on that point.  Coordinate.</sp>
+         <sp spk="PILOT LEADER">
+
+I see it... It looks good.</sp>
+         <sd>Devil Five and Devil Three bob and weave in formation toward a giant
+transformer jutting from the fort's surface.</sd>
+         <sp spk="DEVIL THREE">
+
+I've got a... We're hit.  We're hit.</sp>
+         <sp spk="PILOT LEADER">
+
+Eject...Eject.  Babs, Babs, do you read?</sp>
+         <sp spk="DEVIL THREE">
+
+I'm okay.  I can hold it.  Clear me a little, Devil Five... Watch it!  Watch
+it!</sp>
+         <sd>Devil Three wobbles a little, then drops away sharply, plowing into a lasergun
+emplacement, causing a hideous series of chain reaction explosions.</sd>
+      </scene>
+      <scene n="37">
+         <setting>  SUB-HALLWAY - IMPERIAL SPACE FORTRESS</setting>
+         <sd>A huge explosion rips a large hole in the ceiling of a subhallway.  Artwo and
+Threepio are in a state of shock as they scramble through the rubble.  There
+is a constant sound of creaking and snapping as the sections of the hallway
+resettle in the fortress superstructure.</sd>
+         <sp spk="ARTWO">
+
+You're a mindless, useless philosopher... Come on!  Let's go back to work; the
+system is all right.</sp>
+         <sp spk="THREEPIO">
+
+You overweight glob of grease.  Quit following me.  Get away.  Get away.</sp>
+         <sd>Suddenly, the hallway lurches, and a dead trooper falls through a gaping hole
+in the ceiling.  The foot of the carcass is caught in the rubble and it hangs
+upside down, staring at the two robots.  Artwo grabs Threepio, and they cling
+to each other in terror.</sd>
+         <sp spk="ARTWO">
+
+We're lost.  We're destroyed.</sp>
+         <sd>Three sharp blasts from an airhorn send the two androids running for cover in
+a burned-out doorway.  Five grim-faced troopers riding small rocket platforms
+pass the two mechanical men.</sd>
+      </scene>
+      <scene n="38">
+         <setting>  GOVERNOR'S QUARTERS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The five troopers race through several hallways, and finally stop in front of
+an important looking office complex.  Two officers dismount and enter the
+complex.  They pass through several heavily guarded doorways until they reach
+the main chamber.  Seated behind a large, cluttered desk surrounded by
+generals and attaches is Governor Hoedaack.  General Vader paces in front of a
+row of blank monitors.  The two officers salute General Vader.</sd>
+         <sp spk="FIRST OFFICER">
+
+All com-link power is out.  Twenty-two transformer sections have been
+destroyed.  The situation is grave on all southern levels.  Com-link
+communication should be repaired shortly.</sp>
+         <sd>The officers salute, turn and leave the chamber.  The general turns to
+Governor Hoedaack, who looks a little worried.</sd>
+         <sp spk="VADER">
+
+Don't look so worried.  Not even a Jedi could penetrate this fortress...We've
+already wiped out most of their forces.</sp>
+         <sp spk="HOEDAACK">
+
+If it goes on too long, we'll run over budget.  When do the landings begin?</sp>
+         <sp spk="VADER">
+
+As soon as the attack has been broken:  not long.</sp>
+         <sd>A short, stocky attache salutes the general.</sd>
+         <sp spk="ATTACHE">
+
+Contamination has set in on quadrants B-5 and R-4.  All sections are sealed.
+We've lost two major power stations in the southern quadrants.  That puts
+section 5-1 in serious trouble.</sp>
+         <sd>The general turns away in controlled anger and embarrassment.</sd>
+      </scene>
+      <scene n="39">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general sits in a glass enclosed computer station, watching the battle
+progress on several monitors.  An officer enters and salutes the general.</sd>
+         <sp spk="OFFICER">
+
+Analysis reports those ZQ configurations are definitely power
+transformers...Everything in the southern sectors of the fortress is out.</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+I'm surprised they are still using external power units.  It's a definite weak
+point.  Concentrate on searching for the main crosslink transformer.</sp>
+         <sd>The officer exits as Montross rushes in.</sd>
+         <sp spk="MONTROSS">
+
+The senate has voted to end the war.</sp>
+         <sp spk="GENERAL">
+
+They can't do anything without the king's approval; which gives us a little
+time...Have you been able to regain contact with the king?</sp>
+         <sp spk="MONTROSS">
+
+No, Sir.  All ground communications are jammed.</sp>
+         <sp spk="GENERAL">
+
+Send four men..from third squad, to meet the king, and escort him back.  Let
+me know before he arrives.  Is Starkiller back with the princess?</sp>
+         <sp spk="MONTROSS">
+
+No, Sir.  They're long overdue.</sp>
+         <sd>Pilot Leader checks in over the intercom.</sd>
+         <sp spk="PILOT LEADER">
+
+All right, base one, we're in position.</sp>
+         <sd>An officer with headphones looks to the general.  He signals to attack.</sd>
+      </scene>
+      <scene n="40">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>All four starships dive in formation toward a main transformer area, flanked
+by several solar towers.</sd>
+         <sp spk="PILOT LEADER">
+
+Hold your fire until we're within point zero five four... Make it count.</sp>
+         <sd>Several ack-ack lasers begin to open fire on the approaching spacecraft.  The
+starships direct their fire at a large black transformer, which when hit,
+spurts bright blue and white electrical arcs.  One of the starships (Devil
+Five) explodes and careens out of formation, leaving an erratic trail of
+smoke, before eventually crashing into a solar panel.</sd>
+      </scene>
+      <scene n="41">
+         <setting>  SUB-HALLWAYS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>The impact of the exploding starship can be felt throughout the giant
+fortress.  The tall, gleaming Threepio races through several corridors,
+yelling at Artwo, who struggles vainly to e keep pace with his stubby
+mechanical feet.</sd>
+         <sp spk="THREEPIO">
+
+....I don't care what you do, but I'm getting out.  All the power's out.
+Those explosions are coming from the reactor section.  This is the end.
+Abandon ship.</sp>
+         <sp spk="ARTWO">
+
+Our work - we can't leave!  It's desertion.  It's not possible.  It's not
+possible.</sp>
+         <sp spk="THREEPIO">
+
+Your programming is so limited.  My first order is preservation.  You stay.
+I'm going to eject before the whole thing goes up.</sp>
+         <sd>Threepio breaks open the seal on an emergency lifepod.  A red warning light
+begins to flash, and a low hum is heard.  The lanky chrome android works his
+way into the cramped four-man craft.</sd>
+         <sp spk="ARTWO">
+
+These lifepods aren't for us!  It's not right!</sp>
+         <sd>A new explosion, this time very close, sends dust and debris through the
+narrow passageway.  Flames lick at the two robots.  The runt-sized Artwo jumps
+into the lifepod.</sd>
+         <sp spk="ARTWO">
+
+It's the end.  Eject.  Eject.</sp>
+         <sd>The safety door snaps shut, and the pod ejects from the fortress.</sd>
+      </scene>
+      <scene n="42">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>The terrified androids in the lifepod speed away from the fortress, and pass
+the attacking starships.</sd>
+         <sp spk="DEVIL TWO">
+
+Object approaching.  Attack bearing...</sp>
+         <sp spk="DEVIL FOUR">
+
+It's a lifepod.  Forget it.  We've got...</sp>
+         <sd>Devil Four is hit by laser fire, and disintegrates, leaving a trail of flaming
+particles.  The two remaining craft continue the assault.  Chewie and Pilot
+Leader watch the remains of Devil Four disappear.  The general appears over
+one of the monitors.</sd>
+         <sp spk="GENERAL">
+
+Analysis indicates transformer code zero three is the main relay.  Hit it, and
+the whole thing goes dead.</sp>
+         <sp spk="PILOT LEADER">
+
+We're on our way.</sp>
+      </scene>
+      <scene n="43">
+         <setting>  GOVERNOR'S QUARTERS - IMPERIAL SPACE FORTRESS</setting>
+         <sd>A row of monitors and the main overhead lights go on, and a trooper appears on
+one of the screens.</sd>
+         <sp spk="TROOPER">
+
+Internal relays operative.  All power restored.  All contaminated areas
+sealed.</sp>
+         <sd>An officer appears on another monitor.</sd>
+         <sp spk="OFFICER">
+
+Only two enemy craft remain operative.  We calculate victory by zero three
+hundred.</sp>
+         <sd>General Vader switches to another monitor.</sd>
+         <sp spk="VADER">
+
+Alert the invasion forces.  (turning to the governor).  The planet is ours.  A
+three hour war.  You expected longer.  Jedi or not, we've beaten him, and the
+culture is intact.</sp>
+         <sp spk="HOEDAACK">
+
+A truly great prize for the Empire.  They have a treasure of biotic science.
+Genetics, cloning - they've added two-hundred years to a lifespan.  Remember,
+you must capture at least one member of the Royal Family alive.  The Aquilae
+family has ruled this system for ten thousand years.  The people will follow
+no other.  If the royal line is broken, there is a good chance the entire
+population will destroy themselves and their knowledge before submitting to
+our rule.</sp>
+         <sd>The general is interrupted by a call on one of the monitors.</sd>
+         <sp spk="OFFICER (on monitor)">
+We've received a message from the planet....</sp>
+      </scene>
+      <scene n="44">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker watches a giant computer display of the space fortress
+mapped by the starships.  An aide approaches.</sd>
+         <sp spk="AIDE">
+
+Sir!  The king's convoy has destroyed at Caldin.  All the bodies were
+contaminated.</sp>
+         <sp spk="GENERAL">
+
+I will audience with the queen.... Who knows of this?</sp>
+         <sp spk="AIDE">
+
+Many.  It came through civilian sources.</sp>
+         <sp spk="GENERAL">
+
+Confine Senator Sandage to his quarters.  Use any pretext.  Where is the
+senator now?</sp>
+         <sd>Sandage and several other senators enter the computer station.</sd>
+         <sp spk="SANDAGE">
+
+Right here, General...It's over.  We've already relayed peace terms to the
+Empire, and they've been accepted.  Your war has ended.</sp>
+         <sd>The general is angry and stands pointing at the senators.  They jump back, as
+if the general were pointing a gun at them.</sd>
+         <sp spk="GENERAL">
+
+Senator, this war isn't over.  It's just begun.  I take my commands from the
+Royal Family.</sp>
+         <sp spk="SANDAGE">
+
+The queen concurs.  I have her written decree.  It is to be implemented
+immediately..... I order you to cease the attack.</sp>
+         <sp spk="GENERAL">
+
+Not likely...</sp>
+         <sp spk="SANDAGE">
+
+Treason?  Revolution?  The people won't follow you, General...nor will your
+troops.  I suggest you follow your orders.</sp>
+         <sd>General Skywalker stands angrily pondering the situation.  Sandage and the
+other senators are tense, a little afraid that he might cut them down on the
+spot.</sd>
+         <sp spk="SANDAGE">
+
+Well, General?</sp>
+      </scene>
+      <scene n="45">
+         <setting>  LIFEPOD - SKY OVER AQUILAE</setting>
+         <sd>The reddish-yellow mass of Aquilae seems to engulf the tiny lifepod containing
+the two fleeing androids.</sd>
+         <sp spk="ARTWO">
+
+It's desertion.  They'll destroy us.  How could this happen?</sp>
+         <sp spk="THREEPIO">
+
+That's funny.  The damage doesn't look as bad from out here.</sp>
+      </scene>
+      <scene n="46">
+         <setting>  AQUILAEAN STARSHIPS</setting>
+         <sd>Pilot Leader and Devil Two make a second dive on the now smoldering
+transformer area.  All firing from the fortress suddenly stops.  Pilot Leader
+looks back to his navigator, who is equally puzzled.  The two fighters
+continue to attack the now silent fortress.</sd>
+         <sp spk="CHEWIE (DEVIL TWO)">
+
+I don't get it.  What do you think, Boss?</sp>
+         <sd>General Skywalker appears on the monitors.</sd>
+         <sp spk="GENERAL (with difficulty)">
+
+Base one to Devil Leader...Scramble code niner.  Break your attack, and return
+to base.  Repeat, break your attack.  Confirm.</sp>
+         <sp spk="PILOT LEADER">
+
+They're hurt, Sir, but they still have power.  We should finish....</sp>
+         <sp spk="GENERAL">
+
+Break off.  The war is over.  Run on white lights.  Get back here, Mace.
+We're going to need you.</sp>
+         <sp spk="PILOT LEADER">
+
+Confirmed, base one.  We're on our way.  Did you copy, Chewie?</sp>
+         <sp spk="DEVIL TWO">
+
+Roger, Boss.</sp>
+         <sd>The two starfighters break off the attack and start back toward the planet.
+Without warning, the fort directs concentrated fire at the two starfighters.
+Devil Two instantly bursts into flames, then disintegrates.  Pilot Leader's
+tail section is hit, and the ship pinwheels toward the planet.  Blood covers
+Pilot Leader's immobile face.</sd>
+         <sp spk="PILOT LEADER'S NAVIGATOR">
+
+We're under fire...They're still shooting.  I thought it was over.  We're hit!</sp>
+         <sd>We're hit!  Pilot is dead....Ejecting.</sd>
+         <sd>The dead "Pilot Leader" is jettisoned free of the craft, but the navigator's
+eject panel is dead.  He struggles with it, then bangs on the canopy to no
+avail.  The navigator is still trapped in the craft when it explodes, leaving
+only a puff of pink smoke reflected in the rim light of the planet.</sd>
+      </scene>
+      <scene n="47">
+         <setting>  DESERT NEAR OUTPOST - AQUILAE</setting>
+         <sd>Pilot Leader's dead body drifts toward his arid mother-planet.  Automatic
+rockets kick-in occasionally, to direct and soften the landing.  Two grey-clad
+troopers stand next to a military "landspeeder;" watching the descending
+airwarrior through electrobinoculars.  Mace's corpse hits the ground rather
+hard, creating a whirlwind of dust, and the two troopers rush over to the
+pilot.  The younger of the two troopers, a young boy in his teens, cradles the
+dead starpilot in his arms and begins to cry.</sd>
+      </scene>
+      <scene n="48">
+         <setting>  WAR ROOM - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker sits alone, meditating in the deserted war room.  Montross
+approaches the contemplative general.</sd>
+         <sp spk="MONTROSS">
+
+No sign of Starkiller or the princess.  There was much damage in that
+area...The queen will see you at ten hundred.</sp>
+         <sd>The general doesn't reply.</sd>
+      </scene>
+      <scene n="49">
+         <setting>  ASSEMBLY - DEPARTURE AREA - IMPERIAL SPACE FORTRESS</setting>
+         <sd>General Vader stands behind a row of men at computer control panels.  A
+commander reports to the general.</sd>
+         <sp spk="COMMANDER">
+
+All enemy craft destroyed.  First and fifth division, troops and equipment
+standing by.</sp>
+         <sd>The general gives a sly smile of approval and takes a microphone from one of
+the computer technicians.  He speaks to the troops and pilots waiting in their
+huge war machines for the invasion order.</sd>
+         <sp spk="VADER">
+
+The war is won.  With the conquering of this System we have ushered in a new
+millenium for the Empire; which will echo throughout the universe.  Our reward
+is the knowledge this system possesses.  This planet must be controlled with a
+minimum of force, but you must not think lightly of this enemy.  They have
+exacted a heavy toll.  Today you will make the Empire complete.  Do so with
+pride and care.</sp>
+         <sd>Vader puts down the mike, and turns to his commander.</sd>
+         <sp spk="GENERAL">
+
+Let the invasion begin.</sp>
+      </scene>
+      <scene n="50">
+         <setting>  EDGE OF THE DUNE SEA - AQUILAE</setting>
+         <sd>Jundland, or "no man's land," where the rugged desert mesas meet the
+foreboding dune sea.  The two helpless astro robots kick up clouds of dust as
+they clumsily work their way across the desert coastline.  The short Artwo
+struggles desperately to keep up with the long-legged Threepio.</sd>
+         <sp spk="ARTWO">
+
+It's not possible.  We're not built for this.  You're nothing more than a dim-
+witted, emotion-brained intellectual.  Why you were created is beyond my logic
+systems.  Thanks to you, we're deserters, and will probably be destroyed on
+sight.  And on top of that, you're going the wrong way!  All this filth is
+getting....</sp>
+         <sd>The towering Threepio stops short and turns on the blabbering mechanical runt.</sd>
+         <sp spk="THREEPIO">
+
+I've had enough of you, you pragmatic, nearsighted scrap pile.  You go your
+own way.</sp>
+         <sd>He picks up the tiny robot and tosses him several feet into a large sand dune.</sd>
+         <sd>Threepio starts off in the direction of the dune sea.  Artwo struggles to his
+feet, and shakes a metallic claw arm at his disappearing ex-partner.</sd>
+         <sp spk="ARTWO">
+
+You'll be malfunctioning within a day.  You're going the wrong way, but your
+way is always the wrong way.</sp>
+         <sd>Threepio stops and yells to the smaller android.</sd>
+         <sp spk="THREEPIO">
+
+And don't let me catch you following me, begging for help, because you won't
+get it from me.</sp>
+         <sd>Artwo's reply is a rather rude sound, which only an electronic person could
+make.  He turns and trudges off in the opposite direction into the rocky
+desert mesas.</sd>
+      </scene>
+      <scene n="51">
+         <setting>  DUNE SEA - AQUILAE</setting>
+         <sd>Threepio, hot and tired, struggles up over the ridge of a dune, only to find
+more dunes, which seem to go on for endless miles.  He looks back in the
+direction he came.</sd>
+         <sp spk="THREEPIO">
+
+You little malfunctioning twerp.  This is all your fault.  You tricked me into
+going this way, but you'll do no better!</sp>
+         <sd>He sits in a huff of anger and frustration, knocking the sand from his joints.</sd>
+      </scene>
+      <scene n="52">
+         <setting>  DESERT MESA - AQUILAE</setting>
+         <sd>Artwo stumbles through a narrow canyon until he climbs over a small boulder
+and sees before him a sight he first thinks is a mirage.  Nestled in a rock
+formation is a deserted landspeeder.  Once the little robot is convinced that
+he is alone, he approaches the battered speeder and begins to analyze it.  He
+climbs into the pilot's seat, and attempts to start the unfamiliar transport.
+He hears a sound, and stops for a moment.  He sees nothing, so he continues to
+fiddle with the control panel until the speeder lurches forward with a start,
+banging into a large rock.  The stubby android is shaken, but neither he, nor
+the speeder, seems to be damaged.</sd>
+         <sd>Shivers run down Artwo's metal spine, and again he has an eerie feeling that
+he is being watched.  He slowly looks around, and sees a large man, Captain
+Starkiller, standing directly behind him.  He is startled, then terrified.</sd>
+         <sp spk="STARKILLER">
+
+Where is your master?</sp>
+         <sd>The little robot clicks and rattles, but doesn't speak.</sd>
+         <sp spk="STARKILLER (Con't)">
+
+Can't you speak?  How do you relate your data?  You're of Karollian
+manufacture...You should be able to talk.  Are you damaged?</sp>
+         <sd>Starkiller pokes at the machine, but doesn't see any damage.  Artwo eyes him
+suspiciously.  The robot turns with a start and discovers a young girl,
+Princess Leia, has been standing next to him for some time.</sd>
+         <sp spk="PRINCESS (sarcastic)">
+
+Well, General, who's your friend?</sp>
+         <sp spk="STARKILLER">
+
+I don't know.  He doesn't seem to be able to talk.  Damaged,
+probably....Jettisoned from a damaged ship...</sp>
+         <sp spk="PRINCESS">
+
+What do you intend to do with it?</sp>
+         <sp spk="STARKILLER">
+
+We'll take it with us.  Could be a storehouse of valuable information.</sp>
+         <sd>Starkiller guides the android into the small luggage area behind the front
+seat, then hops into the driver's seat.</sd>
+         <sp spk="PRINCESS">
+
+I don't want to ride with that hing.  I order you to destroy it immediately.</sp>
+         <sp spk="STARKILLER">
+
+Get in!  We've got to hurry if we're going to get across the "dunehedge" by
+nightfall...You're coming, one way or the other.  Will you join us peaceably?</sp>
+         <sd>The princess reluctantly gets into the speeder, and it starts with a jolt.</sd>
+      </scene>
+      <scene n="53">
+         <setting>  LANDSPEEDER - DESERT MESAS - AQUILAE</setting>
+         <sd>The speeder flies along, a foot or so above the landscape.</sd>
+         <sp spk="PRINCESS">
+
+You are such a barbarian.  I'll have my father cut you into little pieces when
+we get back...and I'll take pleasure in feeding you to the Gonthas....a little
+bit each day.  I may save your eyes though.  I'll have them petrified and made
+into a necklace.</sp>
+         <sp spk="STARKILLER">
+
+Your sweetness is only surpassed by your beauty.  Just try to remember, I'm
+only following orders.</sp>
+         <sp spk="PRINCESS">
+
+... to beat me and abuse me?</sp>
+         <sp spk="STARKILLER">
+
+I'm afraid I've only learned one way to treat wild animals.</sp>
+         <sd>Artwo thrashes about, trying to relieve the pressure on his crumped legs.</sd>
+         <sp spk="PRINCESS">
+
+You stay out of this.</sp>
+      </scene>
+      <scene n="54">
+         <setting>  DUNE SEA</setting>
+         <sd>Threepio struggles to the top of a large dune.  He is dirty and hot.  His
+plight seems hopeless.  He searches the horizon for any sign of life.  A glint
+of reflected light in the distance reveals an object speeding toward him.  The
+chrome android waves frantically, and yells at the approaching speeder.  The
+sleek landspeeder races past him about a hundred yards away.  He runs after
+it, screaming in desperation, until he stumbles and falls head over heels down
+an enormous sand dune.  Silently, the speeder sweeps around in a circle and
+stops behind the immobile robot.  Starkiller jumps out of the landspeeder and
+is quickly followed by Artwo.</sd>
+         <sp spk="PRINCESS">
+
+We're in a hurry, remember!  If you're going to stop for everyone unfortunate
+along the way, we'll never get back.  We're lucky you got the speeder running
+as it is.</sp>
+         <sd>Artwo waddles up to his fallen partner and starts pulling on his leg, then
+runs up and starts pulling on his arm.</sd>
+         <sp spk="ARTWO">
+
+Function!  Function!  It's me.  Come on, function.</sp>
+         <sp spk="STARKILLER">
+
+Well, my little friend, you've found your tongue.</sp>
+         <sp spk="ARTWO">
+
+We must help him... We've been lost.</sp>
+         <sp spk="STARKILLER">
+
+Where did you come from?</sp>
+         <sd>The little robot runs around his fallen partner giving him small electric
+charges from his claw hand.  Threepio shudders from head to toe, then regains
+consciousness.</sd>
+         <sp spk="THREEPIO">
+
+What happened?</sp>
+         <sp spk="ARTWO">
+
+You're overheated.</sp>
+         <sp spk="STARKILLER">
+
+Where did you come from?</sp>
+         <sp spk="ARTWO">
+
+We were jettisoned from six twenty-nine, P.R. one.</sp>
+         <sp spk="STARKILLER">
+
+I'm unfamiliar with that ship.  What type is it?</sp>
+         <sp spk="THREEPIO">
+
+It's a class M station, not a conventional craft.</sp>
+         <sd>Threepio then stands and shakes the young Jedi's hand.</sd>
+         <sp spk="THREEPIO (Con't)">
+
+I'm Seethreepio, Human-Cyborg Relations.  Your kindness is greatly
+appreciated.</sp>
+         <sd>Starkiller and the two robots walk back to the speeder.</sd>
+      </scene>
+      <scene n="55">
+         <setting>  Both Artwo and Threepio are stuffed into the tiny luggage compartment.
+It is late in the day when the speeder rumbles to a stop in a small desert
+canyon surrounded by steep cliffs and broken boulders.</setting>
+         <sp spk="STARKILLER">
+
+We'll rest here.</sp>
+         <sp spk="THREEPIO">
+
+At last.  The transport is welcome but my joints are frozen.</sp>
+         <sd>Everyone climbs out of the low-slung speeder.  Starkiller watches the two
+androids as they stretch their mechanical limbs.</sd>
+         <sp spk="ARTWO">
+
+I've got a bad case of dust contamination.  I can barely move.</sp>
+         <sp spk="THREEPIO">
+
+What a foresaken place this is.  We seem to be made to suffer.  It's our lot
+in life.  Sir, could you tell....</sp>
+         <sd>Threepio turns and notices that Starkiller and the princess have disappeared.
+He looks all around.</sd>
+         <sp spk="THREEPIO">
+
+Where did they go?  They've disappeared.</sp>
+         <sp spk="ARTWO">
+
+Maybe they were attacked!  I sense danger!</sp>
+      </scene>
+      <scene n="56">
+         <setting>  HIDDEN FORTRESS ENTRANCE - DESERT CANYON - AQUILAE [scene number - sic]</setting>
+         <sd>Captain Starkiller and Princess Leia hurry through a maze of large boulders,
+until they reach a sheer rock face.  Starkiller looks around to see if they
+were followed.  Suddenly, a large section of the rock slides away, revealing a
+well-lit corridor carved out of the rock.  They enter, and are greeted by two
+jubilant guards.  Starkiller gives them some orders and points in the
+direction of the speeder.  The secret rock door silently slides closed.</sd>
+      </scene>
+      <scene n="57">
+         <setting>  MAIN HALLWAY - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>Starkiller and the princess are greeted by General Skywalker and Montross.
+They bow before the princess.</sd>
+         <sp spk="PRINCESS (angrily pointing at Starkiller)">
+
+General, I want you to do something with this..this barbarian.  Where's my
+father?</sp>
+         <sp spk="GENERAL">
+
+The king is dead, Your Highness.</sp>
+         <sd>All anger suddenly drains from the princess.  She almost timidly asks the next
+question.</sd>
+         <sp spk="PRINCESS">
+
+My mother?... and brothers?</sp>
+         <sp spk="GENERAL">
+
+She's here.  She's safe...so are your brothers.  They're in the main chamber.</sp>
+         <sd>Leia, now looking more like a frightened young girl than a vindictive
+princess, runs down the hallway toward the main chamber.  She vainly attempts
+to hold back the tears.</sd>
+      </scene>
+      <scene n="58">
+         <setting>  DESERT CANYON - AQUILAE</setting>
+         <sd>The two puzzled androids sit on the landspeeder, pondering the disappearance
+of their saviour.</sd>
+         <sp spk="THREEPIO">
+
+Do you suppose we're in danger?</sp>
+         <sp spk="ARTWO">
+
+The logic of this environment escapes me.</sp>
+         <sd>As night begins to fall, and the shadows begin to lengthen, the two robots
+begin to get a little edgy.  The sound of approaching feet startles Artwo, and
+he ducks behind his taller friend.  Two guards approach the robots.</sd>
+         <sp spk="GUARD">
+
+You will remain calm, and you will remain here.</sp>
+         <sp spk="THREEPIO">
+
+Certainly.  I'm Seethreepio, Human-Cyborg Relations.  Your kindness is
+gratefully appreciated.</sp>
+         <sd>Artwo sits rather suspiciously behind his extroverted friend.</sd>
+      </scene>
+      <scene n="59">
+         <setting>  ROYAL CHAMBER - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>General Skywalker bows low before Princess Leia.  She sits on a raised
+platform, dressed in the royal robes of a planetary ruler.  The queen sits off
+to one side on a smaller platform.  The princess waits for a few moments
+before she allows the general to rise.</sd>
+         <sp spk="QUEEN">
+
+The senate has been corrupted.</sp>
+         <sp spk="GENERAL">
+
+They cannot rule without your wish...</sp>
+         <sp spk="QUEEN">
+
+I rule by marriage.  With the king dead, I am not strong enough to stop
+them... Leia is now the true queen... She must be protected.  The line must be
+preserved.  I am placing the future of our people in your hands.  You must
+deliver Leia and her brothers to the Ophuchi System.  They will be safe there.</sp>
+         <sd>General, you must understand, I had no alternative but to condone an end to
+the hostilities.  I deeply believe your campaign could have been successful,
+but there are things that...</sd>
+         <sp spk="GENERAL">
+
+I understand, Your Highness...</sp>
+         <sp spk="QUEEN">
+
+The chrome companies on Ophuchi have offered to supply you with the men and
+ships necessary to return Leia to the throne.</sp>
+         <sp spk="GENERAL">
+
+Can the chrome companies be trusted?</sp>
+         <sp spk="QUEEN">
+
+The price for their cooperation is high.  It is waiting for you in Med Center
+blue.  Guard it as you would the princess herself.  No-one must know of this
+mission.  There are those among the trusted who would wish us ill.  Take only
+two of your best officers with you, the most loyal.  May the force of others
+be with you.</sp>
+         <sp spk="LEIA">
+
+Mother, you must not stay.</sp>
+         <sp spk="QUEEN">
+
+I am too old for such a journey.  The Empire already controls the spaceport
+cities.  You have a long way to travel.  It won't be easy.</sp>
+         <sp spk="GENERAL">
+
+We will have to travel in disguise.  I must have full command.  No-one can
+suspect wealth or royal training.  I fear the new queen will not stand for
+this.</sp>
+         <sp spk="LEIA (angry)">
+
+Do not put words into my mouth.  I will stand for what is necessary.</sp>
+         <sd>The general simply smiles.</sd>
+      </scene>
+      <scene n="60">
+         <setting>  SUB-HALLWAY - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general walks briskly through an isolated hallway, closely followed by
+Montross.</sd>
+         <sp spk="GENERAL">
+
+How is Captain Whitsun's recovery?</sp>
+         <sp spk="MONTROSS">
+
+Very good; he's up and around.</sp>
+         <sp spk="GENERAL">
+
+Fine!  Have Whitsun and...ah, Starkiller report at zero three hundred.  I want
+two converted transports:  agricultural type, two days' provisions, travel
+papers, weapons.  Contact Han Solo at the Gordon spaceport...I'll talk to
+him... with speed!</sp>
+         <sd>Montross turns and rushes down another hallway.</sd>
+      </scene>
+      <scene n="61">
+         <setting>  MEDICAL CENTER BLUE - UNDERGROUND FORTRESS - AQUILAE</setting>
+         <sd>The general enters a stark white waiting area filled with scholarly looking
+gentlemen.  An attendant greets General Skywalker and takes him into a small
+observation chamber overlooking a large operating theatre.  An elderly doctor
+greets him.</sd>
+         <sp spk="DOCTOR">
+
+Good to see you, General.  I'm afraid we're not quite ready yet.  Thank God
+you'll be the one taking them, though.</sp>
+         <sd>An attendant brings in one of the scholars from the waiting area and places
+him on a large operating table surrounded by strange looking equipment.  An
+ominous looking clamp is placed on the man's head.</sd>
+         <sp spk="GENERAL">
+
+How many are going?</sp>
+         <sp spk="DOCTOR">
+
+Thirty-three of the greatest scientific minds in our System...A high price for
+freedom.</sp>
+         <sp spk="GENERAL">
+
+Thirty-three scientists!  Transporting a group that size, undetected... I
+don't...</sp>
+         <sp spk="DOCTOR">
+
+Don't worry, General.  All you'll be taking are their minds.</sp>
+         <sd>The doctor moves over to a safe-like cabinet guarded by two attendants.  The
+doctor gingerly picks up a small clear vial filled with grey fluid.  It has a
+label which reads:  Faubun, Astro-dynamics...In the background the scholar on
+the operating table is undergoing a form of mechanized brain surgery.</sd>
+         <sp spk="GENERAL">
+
+"Bloodory's distillation?"</sp>
+         <sp spk="DOCTOR">
+
+Yes.  It has been greatly perfected.  The brain is condensed into five ounces
+of fluid.  Cloning cell samples are included so that a structural duplicate of
+the scientist can be reproduced.  When the duplicate child reaches the age of
+six, he or she begins a series of injections of the brain fluid.  By the age
+of ten years, they have received all the knowledge and memory of an
+experienced scientist:  an old mind in a young body.  We have prepared a
+special shock-belt to carry the vials.</sp>
+         <sd>In the background, the limp body of the scholar on the operating table is
+removed and another scientist is escorted into the operating threatre.  Dr.
+Bloodory, a portly doctor in his forties, enters the room and shakes hands
+with the general.</sd>
+         <sp spk="DOCTOR">
+
+General, this is Doctor Bloodory.  He'll be making the trip with you.</sp>
+         <sp spk="BLOODORY">
+
+It's an honor to meet you, General.  I'm sure I couldn't be in safer hands.</sp>
+         <sp spk="GENERAL">
+
+The chrome companies are exacting a high prince indeed.  Politics will be the
+ruin of us all.</sp>
+         <sp spk="BLOODORY">
+
+Careful.  If we could rid ourselves of the politicians, generals would no
+longer be necessary.</sp>
+         <sp spk="DOCTOR">
+
+We should be ready by zero three hundred.</sp>
+         <sd>The doctors exit, leaving the general alone to watch the huge machine extract
+another brain.</sd>
+      </scene>
+      <scene n="62">
+         <setting>  SPACEPORT - OBSERVATION DECK - AQUILAE</setting>
+         <sd>Governor Hoedaack, General Vader walk down a boarding ramp to an observation
+deck overlooking the conquered city of Gordon.  They are followed by a number
+of aides and officers from the Imperial fleet.  Below them air tanks and other
+military equipment and supplies are being unloaded.</sd>
+         <sp spk="VADER">
+
+Not much of a planet.</sp>
+         <sp spk="HOEDAACK">
+
+Darth, you've done well.  Do you think you will have the Royal Family by
+nightfall?</sp>
+         <sp spk="VADER">
+
+An advance expedition is already on its way to their underground hideaway.
+They should reach it by nightfall... but only if this Count Sandage can be
+trusted.</sp>
+         <sp spk="HOEDAACK">
+
+A man hungry for power can always be trusted... to betray those in power.  I'm
+sure his information is correct.</sp>
+      </scene>
+      <scene n="63">
+         <setting>  HIDDEN FORTRESS CANYON</setting>
+         <sd>The huge rock face of the canyon opens, and two shabby agricultural
+landspeeders are pushed into the late afternoon sun.  Artwo and Threepio stand
+on the far side of the canyon with their guards, watching in amazement.  The
+general and Captain Starkiller walk behind the men pushing the landspeeders.</sd>
+         <sp spk="GENERAL">
+
+We'll take them with us.  They know more about that fortress than any ten men.</sp>
+         <sd>They will be very useful.</sd>
+         <sp spk="STARKILLER">
+
+Can they be trusted?</sp>
+         <sp spk="GENERAL">
+
+Loyalty can't be programmed.  They can be trusted never to harm a living
+creature, and to always give accurate information...as they know it, to anyone
+who asks.  You just have to remember not to tell them anything that you don't
+want to fall into the wrong hands.</sp>
+         <sd>The general approaches the two robots.  Artwo shyly moves around his taller
+companion.</sd>
+         <sp spk="GENERAL">
+
+Greetings.  I'm Luke:  Agricultural Engineering.  We're going to be travelling
+together.  You're going with us to help set up a hortastation on Banth.</sp>
+         <sd>Threepio shakes hands with the general.</sd>
+         <sp spk="THREEPIO">
+
+I'm Seethreepio:  Human Cyborg relations.  Your kindness is greatly
+appreciated.</sp>
+         <sd>Threepio and the general both look down at Artwo.  Threepio gives the smaller
+android a little kick.</sd>
+         <sp spk="ARTWO">
+
+Artwo Detwo:  Fusion Repair.</sp>
+         <sp spk="GENERAL (to Starkiller)">
+
+Load them into one of the speeders.</sp>
+         <sd>Captain Whitsun, walking with a slight limp, emerges from the underground
+fortress with the Royal Family.  A small group of guards and aides are lined
+up, standing at attention.  The two young princes, Biggs and Windy, hug and
+kiss their mother good-bye, then jump into the back of the larger four-man
+speeder.  The princess bows before her mother, then embraces her.  Tears roll
+down her cheeks.  Her mother wipes them away.</sd>
+         <sp spk="QUEEN">
+
+You must learn strength.</sp>
+         <sd>The princess turns and moves to the larger speeder where she is helped aboard
+by Captain Starkiller.</sd>
+         <sp spk="PRINCESS (fuming)">
+
+I don't need your help, thank you.</sp>
+         <sd>She gives the general an angry look.</sd>
+         <sp spk="GENERAL">
+
+I'm afraid he's necessary.</sp>
+         <sd>A commotion erupts at the mouth of the underground fortress.  Count Sandage,
+several senators and ten to twelve troopers rush into the canyon and block the
+speeders.</sd>
+         <sp spk="SANDAGE">
+
+Where are you going?  What is this?</sp>
+         <sd>In one quick movement the general moves between Sandage and the queen.
+Whitsun and Starkiller assume defensive positions in front of the princess and
+her brothers.</sd>
+         <sp spk="QUEEN">
+
+Leia and the boys are being taken to safety.  It is my wish.</sp>
+         <sp spk="SANDAGE">
+
+The Empire has assured their safety.  They must stay.</sp>
+         <sp spk="QUEEN">
+
+It is not my wish....</sp>
+         <sp spk="SANDAGE">
+
+General, you've gone too far this time.  (to the troops) Arrest him.</sp>
+         <sd>Five troops start to move on the general, as Sandage draws his laserpistol.
+Before anyone can complete his action, the general ignites his lasersword and
+cuts the senator in two.  He drops to the ground in a heap, and the
+approaching troops stop in their tracks.</sd>
+         <sp spk="QUEEN">
+
+Stop this!</sp>
+         <sd>The general, Starkiller, and Whitsun replace their swords, and bow low to the
+queen.  All of the troops, senators, and aides do the same.  The formalness of
+the occasion is broken when the queen embraces the general.  She then turns
+and embraces each of the captains.  They are both flustered, and somewhat
+embarrassed.</sd>
+         <sp spk="QUEEN">
+
+May the force of others be with you.</sp>
+         <sd>The general and his captains head for the speeders, while the queen and all
+the others return to the underground fortress.</sd>
+      </scene>
+      <scene n="64">
+         <setting>  DESERT BLUFF - AQUILAE</setting>
+         <sd>The two speeders edge their way onto a bluff overlooking the hidden fortress
+canyon.  They stop for one last reflective moment.  Forced to leave their
+closest friends and relatives, the group is deeply moved.  The two robots, for
+the most part, are puzzled.  Suddenly, there is a huge atomic flash, followed
+by a loud rumble, and the entire canyon collapses into a large crater.  The
+group quietly watches the dust settle.  The hidden fortress and all its
+inhabitants have been destroyed.  The general watches the princess, who
+appears to take it well.</sd>
+         <sp spk="GENERAL">
+
+It was the only way we could be safe from treachery.</sp>
+      </scene>
+      <scene n="65">
+         <setting>  DUNE SEA - AQUILAE</setting>
+         <sd>The two sleek landspeeders glide effortlessly through the vast hills and
+valleys of the dune sea.  At the base of the towering dune ridge, the four-man
+speeder stops.  The smaller speeder, with Starkiller and the two robots, makes
+its way to the top of the ridge.  Captain Starkiller stops the speeder just
+short of the top of the ridge.  He gets out and continues the rest of the way
+on foot.  The young captain peeks over the dune ridge into the canyon below.
+Muted sounds and large dust clouds rise from the canyon floor.  Starkiller
+immediately ducks back behind the ridge with an amazed look on his face.  He
+quickly returns to the speeder, and picks up the intercom.</sd>
+         <sp spk="STARKILLER">
+
+Sir, you'd better take a look at this.  But come easy.</sp>
+         <sd>The four-man speeder starts with a crack, and slowly moves up the side of the
+imposing dune.  It stops next to the smaller speeder.  The general and Whitsun
+get out and make their way to the top of the ridge, where they join
+Starkiller.  Far in the distance, crossing the endless dune sea, is the
+Imperial invasion army.  It is immense.  A convoy of giant tanks, troop
+carriers, and supply ships stretch from horizon to horizon.  Cavalry, mounted
+on giant dune birds, ride the line from one end of the convoy to the other.
+Hundreds of troops ride one-man jet-sticks in precision formation.  Their
+lances form a giant pin-cushion.  It is an awesome sight.</sd>
+         <sp spk="GENERAL SKYWALKER">
+
+They're heading toward the fortress.</sp>
+         <sp spk="WHITSUN">
+
+What will they do when they find it destroyed?</sp>
+         <sp spk="GENERAL">
+
+They won't stop looking for us...They're coming from the spaceport at
+Anchorhead, which means they control everything between here and the spaceport
+at Gordon.</sp>
+         <sp spk="STARKILLER">
+
+Can we go around them?</sp>
+         <sp spk="GENERAL">
+
+No.  We'll have to wait for them to pass.  Starkiller, see if you can monitor
+any of their communications on the com-link in the big speeder.</sp>
+         <sd>Starkiller returns to the speeder.  He collapses in the large speeder next to
+the princess, and flips on the com-link radio, moving back and forth across
+the dial.</sd>
+         <sp spk="PRINCESS">
+
+Must you do that?</sp>
+         <sd>Starkiller smiles rather sarcastically.</sd>
+         <sp spk="STARKILLER">
+
+Orders...The invasion force has cut us off.  We'll probably be here for some
+time.  You ought to stretch a bit.</sp>
+         <sp spk="PRINCESS">
+
+Is that a command, General?  Maybe I feel like watching after my brothers.</sp>
+         <sd>Starkiller looks back at the two sleeping boys.</sd>
+         <sp spk="STARKILLER">
+
+They're not going anywhere.  They're asleep.</sp>
+         <sp spk="PRINCESS">
+
+I want to stay with them.</sp>
+         <sp spk="STARKILLER">
+
+What's the matter?  You afraid I might eat them?</sp>
+      </scene>
+      <scene n="66">
+         <setting>  LIBRARY - PALACE OF LITE - AQUILAE</setting>
+         <sd>The king's old library has been converted into an office for General Vader.
+He is sitting behind his desk as Prince Valorum, the black knight of Sith,
+enters and salutes.  The black knight is dressed in the fascist black and
+chrome uniform of the legendary Sith One Hundred.  The general returns his
+salute.</sd>
+         <sp spk="VADER">
+
+Welcome, Prince Valorum.  Your exploits are legendary.  I have long waited to
+meet a Knight of the Sith.  If there is any way I can assist you, my entire
+command is at your bidding.</sp>
+         <sp spk="VALORUM">
+
+I want a tie-in to your computer network, a control center, and communication
+access.</sp>
+         <sp spk="VADER">
+
+Right away!  I'll also transfer all information we have on the general.  His
+command post was self-destroyed, but we believe he is still alive.... Do you
+really believe he's a Jedi?</sp>
+         <sp spk="VALORUM">
+
+If he was not a Jedi, I wouldn't be here.</sp>
+      </scene>
+      <scene n="67">
+         <setting>  WASTELAND - AQUILAE</setting>
+         <sd>The speeders make their way across the grey desert.  It is dawn.  The twin
+suns have yet to rise over the distant hills.  The speeders are coated with
+dust and grime, indicating that they have travelled far.  The two captains
+drive through the night as everyone else sleeps.  Starkiller calls Whitsun on
+the intercom.</sd>
+         <sp spk="STARKILLER">
+
+How are your fuel packs?  I'm reading minus four.</sp>
+         <sp spk="WHITSUN">
+
+I'm too low to transfer any.</sp>
+         <sd>The general, who appeared to be asleep, opens his eyes, and takes the
+microphone from Whitsun.</sd>
+         <sp spk="GENERAL">
+
+There is a fuel station fourteen degrees by two meters.  The occupation force
+should have control of it by now, so hide your weapons...but keep them within
+reach.</sp>
+      </scene>
+      <scene n="68">
+         <setting>  FUEL STATION - AQUILAE</setting>
+         <sd>A series of low concrete structures rise out of the desert.  The speeders stop
+in front of an old weather-beaten block house.  The rusted hulk of a
+landspeeder lies half-buried to one side of the building.  Starkiller and
+Whitsun jump out of the speeder and go into the block house.</sd>
+      </scene>
+      <scene n="69">
+         <setting>  INTERIOR - FUEL STATION - AQUILAE</setting>
+         <sd>The two young captains, dressed as farmers, enter the dingy little fuel
+station.  It is quiet.  A few power packs line the walls and a dismantled
+speeder rests in the repair bay.  There is a sharp dripping sound coming from
+the speeder.  It appears that no-one is there.</sd>
+         <sp spk="STARKILLER">
+
+Greetings! ... Who's in charge here?</sp>
+         <sd>They look around the deserted station, but find no attendant.  An eerie quiet
+pervades the building.</sd>
+         <sp spk="WHITSUN">
+
+I don't get it...</sp>
+         <sp spk="STARKILLER">
+
+You don't have to.  It's abandoned.</sp>
+         <sd>Whitsun opens a door leading to a storage area, and stops short.</sd>
+         <sp spk="WHITSUN">
+
+Not quite abandoned...</sp>
+         <sd>Starkiller moves to the doorway and sees the attendant, his wife, and small
+daughter hanging upside down, tortured to death.  Whitsun cuts them down.</sd>
+         <sp spk="WHITSUN">
+
+They shouldn't have resisted.</sp>
+         <sd>Starkiller grabs two power packs from the shelf.</sd>
+         <sp spk="STARKILLER">
+
+Help me with these power packs.  We'd better move out of here.</sp>
+         <sd>Whitsun covers the family with an old work tarp.  He bows to the dead, then
+reluctantly grabs a couple of power packs and they start for the door.
+Whitsun stops for a moment.</sd>
+         <sp spk="WHITSUN">
+
+Hear that?  Someone's here.  (yelling)  We're friends.  Show yourself.</sp>
+         <sd>Silence.  Whitsun shrugs his shoulders and they start out the door, only to
+run straight into a burly stormtrooper.</sd>
+         <sp spk="STORMTROOPER">
+
+Get out of here!</sp>
+      </scene>
+      <scene n="70">
+         <setting>  FUEL STATION - AQUILAE</setting>
+         <sd>Whitsun and Starkiller are pulled out of the doorway and shoved into the
+center of a group of fifteen or twenty Imperial stormtroopers who have
+surrounded the two speeders.  Several troops have pulled General Skywalker out
+of the speeder.  He acts senile, like a man twice his age.</sd>
+         <sp spk="GENERAL SKYWALKER">
+
+I'm all right.  I can still move about by myself.</sp>
+         <sd>A rough looking sergeant grabs Whitsun.</sd>
+         <sp spk="SERGEANT">
+
+What are you doing here?</sp>
+         <sp spk="WHITSUN">
+
+We're out of power, sir.</sp>
+         <sp spk="SERGEANT">
+
+Let me see  your travel passes!</sp>
+         <sp spk="WHITSUN">
+
+I have it here, somewhere.  We've been relocated...to a Bantha hortastation,
+by Imperial order...</sp>
+         <sd>Whitsun fumbles to retrieve something from his pocket, and eventually pulls
+out a small, round disc.  The sergeant puts the disc in a small portable
+reader.  Various computer readouts are displayed on the monitor.  Starkiller
+starts to put a power pack into one of the speeders.</sd>
+         <sp spk="SERGEANT">
+
+What are you doing there?  All power has been restricted.</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+We've run out.  We must have power, or be forced to stay here....and become
+your responsibilities.</sp>
+         <sd>The sergeant thinks about this for a moment, as the old, wise general watches
+him.  Tension fills the air.  Starkiller shuffles around to a position where
+he can reach his weapon.  A trooper hands the sergeant a message.</sd>
+         <sp spk="SERGEANT (to Whitsun)">
+
+Take only two of those power packs, and then move out quickly.</sp>
+         <sd>The sergeant hurries to a military craft, where he takes a call on an
+intercom.  General Skywalker and his two young captains load the remaining
+power packs into the speeder, and roar away from the station.</sd>
+      </scene>
+      <scene n="71">
+         <setting>  WASTELAND - AQUILAE</setting>
+         <sd>The speeders race along through the rocky desert wasteland.  The general
+speaks into the intercom to Starkiller.</sd>
+         <sp spk="GENERAL">
+
+Keep a close watch.  If that sergeant runs an analysis on those passes, we
+might be seeing him again...We should be safely inside Gordon within the day.</sp>
+         <sd>Everyone is in good spirits.  The princess and her young brothers sing an
+Aquilaean melody, which is transmitted to Starkiller in the smaller speeder.
+The general takes little Windy, and lets him sit on his lap in the forward
+compartment of the speeder.  Artwo flexes Threepio's arm back and forth,
+attempting to discover the cause of a loud squeak.</sd>
+         <sp spk="ARTWO">
+
+Z-2 doesn't seem to help at all.</sp>
+         <sp spk="THREEPIO">
+
+It's all this filth and dust.  This environment is murderous.</sp>
+         <sd>Starkiller notices a small speck on the horizon.</sd>
+         <sp spk="STARKILLER (into intercom)">
+
+Object approaching, bearing three point two.</sp>
+         <sd>The general looks through an electrotelescope mounted in the speeder.  He
+spots a distant row of troopers riding strange dune birds.</sd>
+         <sp spk="GENERAL (to Starkiller)">
+
+It's a patrol.  It could mean trouble.  We'd better split up.  You stay on a
+direct course.  We'll meet you at the western edge of ravine 23-64.  Stay in
+contact.</sp>
+         <sd>The larger speeder makes a sharp left turn, speeding off across a deep ravine.</sd>
+         <sd>Starkiller can begin to distinguish the approaching troopers.</sd>
+         <sp spk="STARKILLER">
+
+It looks like there's ten of them.  They're heading right for me.... Wait a
+second.  They've disappeared!  I've lost them.</sp>
+         <sp spk="GENERAL">
+
+Continue on.</sp>
+      </scene>
+      <scene n="73">
+         <setting>  WASTELAND LAKEBED - AQUILAE</setting>
+         <sd>Whitsun deftly maneuvers the bulky speeder through a narrow, boulder strewn
+ravine.  They eventually come out on a dry lake bed, where they stop.
+Standing not more than a hundred feet away, apparantly waiting for the
+speeder, are five Imperial troops on their dune birds.</sd>
+         <sp spk="GENERAL">
+
+We've found them, five of them, anyway...Watch yourself.</sp>
+         <sd>The troops slowly ride their huge birds over to the speeder, and dismount.
+The officer in charge is a vicious looking warrior, with a large scar across
+his face.</sd>
+         <sp spk="OFFICER">
+
+Let me see your passes.</sp>
+         <sd>Whitsun hands him the small pass disc, and he places it in his reader.  He
+studies the computer readout for a few moments, and then returns the disc to
+Whitsun.</sd>
+         <sp spk="OFFICER">
+
+Have you seen any other transports in this area?</sp>
+         <sp spk="GENERAL SKYWALKER">
+
+We saw two heading south.  Goin' toward Ansel, look like to me.</sp>
+         <sp spk="OFFICER">
+
+All right.  Be on your way.</sp>
+         <sd>The officer mounts his dune bird, and the patrol moves away.  Whitsun winks at
+the princess, and smiles at the general, as the speeder starts off across the
+dry lake.  The general fiddles with the intercom.</sd>
+         <sp spk="GENERAL">
+
+S-2, are you clear?</sp>
+         <sp spk="STARKILLER">
+
+I have five troopers approaching.  Any problems on your end?</sp>
+         <sp spk="GENERAL">
+
+We came through all right.  You shouldn't have any trouble, but stay alert.</sp>
+         <sp spk="STARKILLER">
+
+Best wishes....Here they come.</sp>
+         <sd>Everyone rides along in silence, a little worried about Starkiller, especially
+the princess.</sd>
+         <sp spk="PRINCESS">
+
+..Do you think he'll be all right?</sp>
+         <sp spk="GENERAL">
+
+He can take care of himself.</sp>
+         <sd>Biggs is looking out the back window of the speeder.</sd>
+         <sp spk="BIGGS">
+
+Hey look!  They're coming back.</sp>
+         <sd>Everyone looks to see the patrol quickly gaining on them.</sd>
+         <sp spk="GENERAL">
+
+Stop!  They're faster.  Get your weapon.</sp>
+         <sd>The speeder screeches to a halt in a cloud of dust.  The general and his
+captain jump from the transport with laserpistols drawn.  The patrol bears
+down on them, swords drawn, at full charge.  Both the general and Whitsun
+fire.  Two of the troopers and their Dune birds explode in a cloud of smoke.
+The remaining three troopers are upon the duo in a matter of seconds.  The
+general ignites his lasersword and cuts down two of the troops as they pass.
+The last turns his bird around before reaching the speeder, and hightails it
+back toward the ravine.  The general jumps onto one of the riderless dune
+birds and takes off in pursuit.  Whitsun checks the dead troopers.</sd>
+      </scene>
+      <scene n="73">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The general rides at breakneck speed after the fleeing trooper.  His
+lasersword is raised high over his head, ready to deal a death blow.  The
+lumbering birds race through the winding ravine.</sd>
+      </scene>
+      <scene n="74">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The intercom warning buzzer begins to scream.  Whitsun rushes for it, but the
+princess gets there first.</sd>
+         <sp spk="PRINCESS">
+
+Are you all right?</sp>
+         <sp spk="STARKILLER">
+
+Two riders heading your way.  I got three, but two got away.  Watch
+yourselves!</sp>
+      </scene>
+      <scene n="75">
+         <setting>  WASTELAND RAVINE - AQUILAE</setting>
+         <sd>The general is riding neck and neck with the trooper.  He swiftly brings his
+sword down and the trooper drops from his saddle.  The momentum of his charge
+carries the general around a bend in the ravine, and right in the path of two
+more troops charging down on him.  The two troopers are taken by surprise.
+They stop their birds, and so does the general.  They stand there, about fifty
+yards apart, sizing up each other.  Suddenly, the two troopers start for the
+Jedi at full speed.  The general raises his sword, and starts for them.  The
+troopers are no match for the general, who kills them both before they are
+even able to swing their swords.</sd>
+      </scene>
+      <scene n="76">
+         <setting>  WASTELAND LAKEBED - AQUILAE</setting>
+         <sd>Starkiller stops near the larger landspeeder and gets out.  He is wounded.
+Blood streams from his left arm.  Whitsun rushes to help him.  The princess
+shows a great deal of concern.</sd>
+         <sp spk="WHITSUN">
+
+It looks worse than it is.  You'll be all right.</sp>
+         <sd>Whitsun motions to the princess, who looks a little relieved.</sd>
+         <sp spk="WHITSUN">
+
+Bring me the med aid pack.</sp>
+         <sp spk="PRINCESS">
+
+It he was clumsy enough to get hurt, maybe we ought to let him bleed to death.</sp>
+         <sd>She hands Whitsun the kit, as the general rides up and dismounts.  He moves to
+Starkiller.</sd>
+         <sp spk="GENERAL">
+
+You missed two.</sp>
+         <sp spk="STARKILLER">
+
+I know, I couldn't...</sp>
+         <sp spk="GENERAL">
+
+Don't let it happen again.  We'd better move out.  They might have reported
+in.</sp>
+      </scene>
+      <scene n="77">
+         <setting>  CONTROL ROOM - PALACE OF LITE - AQUILAE</setting>
+         <sd>The dark and sinister Valorum moves several markers on a large map readout to
+form a line from the destroyed underground fortress to the spaceport at
+Gordon.  An aide enters with General Vader.</sd>
+         <sp spk="AIDE">
+
+The patrol was lost, Sir.  All ten of them.</sp>
+         <sp spk="VALORUM">
+
+It's to be expected.</sp>
+         <sp spk="VADER">
+
+Have you found them?</sp>
+         <sp spk="VALORUM">
+
+They're heading for the spaceport at Gordon.  I'm going there.  Have all
+security doubled.  Make it an alert.</sp>
+      </scene>
+      <scene n="78">
+         <setting>  THE OUTSKIRTS OF GORDON - AQUILAE</setting>
+         <sd>The speeders stop on a bluff overlooking a small cantina on the outskirts of
+Gordon.  The spaceport can be seen in the distance.  The general and Captain
+Whitsun walk over to the smaller speeder.  Starkiller helps the two androids
+out of their cramped quarters.</sd>
+         <sp spk="THREEPIO">
+
+Your kindness is greatly appreciated.</sp>
+         <sp spk="STARKILLER (to general)">
+
+I'm fit enough to...</sp>
+         <sd>The general gives him a hard look and he shuts up.  Whitsun and the general
+climb into the speeder.</sd>
+         <sp spk="GENERAL">
+
+We'll make contact at zero four hundred.  If we're not back by fifty-five
+forty, get worried.</sp>
+         <sd>The speeder starts off toward the cantina.</sd>
+      </scene>
+      <scene n="79">
+         <setting>  SPACEPORT CANTINA - AQUILAE</setting>
+         <sd>The speeder pulls up in front of the low, blockhouse style cantina.  Various
+strange forms of transport are parked outside the bar.</sd>
+         <sp spk="GENERAL">
+
+Take care here.  If there is any trouble, get back to the others.</sp>
+         <sd>The general and Whitsun enter the shabby cantina.  The murky little den is
+filled with a startling array of weird and exotic alien creatures, laughing at
+the bar.  At first, the sight is horrifying.  One-eyed, thousand-eyed, slimy,
+furry, scaling arms, tentacles, and claws huddle over drinks.  The general
+looks over the patrons, but does not see the contact, Han Solo.  A large
+multiple eyed creature shoves the general.</sd>
+         <sp spk="CREATURE">
+
+Assha dughi wouldugga?</sp>
+         <sd>The general tries to ignore the creature, and turns back to his drink.  A
+short, grubby looking human, and an even smaller rodent-like creature join the
+first creature.</sd>
+         <sp spk="HUMAN">
+
+He doesn't like you.</sp>
+         <sp spk="GENERAL">
+
+I understood him.</sp>
+         <sp spk="HUMAN">
+
+I don't like you either.</sp>
+         <sp spk="GENERAL">
+
+I'm sorry.</sp>
+         <sd>The big creature is getting agitated, and yells at the general.</sd>
+         <sp spk="HUMAN">
+
+Don't insult us.  You just watch yourself.  We're wanted men.  I have the
+death sentence on twelve Systems.</sp>
+         <sp spk="GENERAL">
+
+I'll be careful then.</sp>
+         <sp spk="HUMAN">
+
+You'll be dead.</sp>
+         <sd>The short rodent yells something, and everything at the bar moves away.  The
+general assumes a defensive position.  His three adversaries ready their
+weapons.</sd>
+         <sp spk="GENERAL">
+
+You insist on a fight then.</sp>
+         <sp spk="HUMAN">
+
+Just try and kill us.</sp>
+         <sp spk="GENERAL">
+
+It will hurt a little.</sp>
+         <sp spk="HUMAN">
+
+We aren't cowards.</sp>
+         <sp spk="GENERAL">
+
+Then it can't be helped.</sp>
+         <sd>The general's lasersword sparks to life.  An arm lies on the floor.  The
+rodent is cut in two, and the large, multiple-eyed creature lies doubled, cut
+from chin to groin.  The general, with quiet dignity, replaces his sword in
+its sheath.  The entire fight has lasted only a matter of seconds.  A figure
+stands in the doorway watching the general.  As soon as the general notices
+him, he leaves.  The cantina goes back to normal, as if nothing had happened,
+although the general is given a respectable amount of room at the bar.  The
+Jedi finishes his drink, and then leaves.  Captain Whitsun follows.</sd>
+      </scene>
+      <scene n="80">
+         <setting>  SPACEPORT ALLEYWAY - GORDON - AQUILAE</setting>
+         <sd>General Skywalker embraces Han Solo, the underground contact.  Han is a huge,
+green skinned monster with no nose and large gills.</sd>
+         <sp spk="HAN">
+
+You old stardog.  Took a war to get you out here...</sp>
+         <sd>Whitsun arrives with Starkiller, the princess and her brothers, and the two
+puzzled androids.</sd>
+         <sp spk="GENERAL">
+
+It's been too long.  We've been through much together.  It will be good to
+have you out of retirement and back at my side.  How is Starkiller?  (putting
+his arm around the young Captain Starkiller)  This is his son.</sp>
+         <sp spk="HAN">
+
+You're all the old boy will talk about.  He's still holding up.  Come, let's
+get off the street.</sp>
+         <sd>The group enters a small doorway at the far end of the alleyway.  On the main
+street, within view of the doorway, giant Imperial air tanks and other
+military hardware rumble through the city.  Starving refugees sit in the
+gutters watching the immense display of force with a mixture of awe and
+terror.  The princess stops for a moment, and stares at her people, watching
+the might of the Empire.  The general escorts her through the doorway with the
+others.</sd>
+      </scene>
+      <scene n="81">
+         <setting>  SLUM DWELLING - LIVING AREA - AQUILAE</setting>
+         <sd>The seedy dwelling is dark and dingy.  The group is greeted by three
+underground leaders, and the old Jedi, Kane Starkiller.  Captain Starkiller
+embraces his father as the underground leaders bow before the princess.</sd>
+      </scene>
+      <scene n="82">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>The princess walks through the dining area followed by Whitsun and Starkiller,
+who carry the two sleeping princes.  The general sits at a large table
+finishing dinner with Han, Kane and the three underground leaders.  Whitsun
+returns from the bedroom.</sd>
+         <sp spk="GENERAL (to Whitsun)">
+
+Captain, why don't you take the androids into the other room for a game of
+chess? ... I'm sure they'd enjoy it.</sp>
+         <sp spk="THREEPIO">
+
+A wonderful idea.  Your kindness is greatly appreciated.</sp>
+         <sd>Whitsun escorts the two robots into the next room.  Datos, a thin, wizened old
+man, seems greatly relieved.</sd>
+         <sp spk="DATOS">
+
+You're taking a great risk travelling with them.  This whole operation sounds
+bad to me.  I don't trust the chrome companies.  Time is growing short.  The
+Empire's attempts at control have already caused a great deal of suffering to
+our people.</sp>
+         <sd>Occo, a brash young rebel, about the same age as Captain Starkiller, slams his
+fist on the table.</sd>
+         <sp spk="OCCO">
+
+It must happen now!  We are ready!  Each day the Imperial S.B.T. finds and
+destroys a few more in the organization.  We cannot wait any longer.</sp>
+         <sp spk="GENERAL">
+
+Any uprising without a coordinated attack on the death star is out of the
+question.</sp>
+         <sp spk="HAN">
+
+He's right.  As long as it's operational, any action down here would be
+meaningless.  We must proceed as planned.  Are the arrangements secure?</sp>
+         <sd>Quist, the third member of the underground, sparks to life, and places several
+discs and badges on the table.</sd>
+         <sp spk="QUIST">
+
+All passenger transport has been suspended, so we've arranged for you to
+travel as the crew of a Baltarian freighter.  The boys will have to be placed
+in suspended animation and hidden in shielded micro-packs.  It's the only way
+we will be able to get them past the scanners.</sp>
+         <sp spk="DATOS">
+
+Were you able to acquire the necessary power packs?</sp>
+         <sp spk="QUIST">
+
+It's become a serious problem.  All power supplies have been restricted.  S-4
+units are impossible to come by.</sp>
+         <sp spk="HAN">
+
+I know an agent who might be able to acquire them for us.  I'll check with
+him.  It will be risky, but we've no other choice.</sp>
+      </scene>
+      <scene n="83">
+         <setting>  SPACEPORT OBSERVATION DECK - AQUILAE</setting>
+         <sd>The dark figure of Valorum stands overlooking a group of Aquilaean partisans
+who are being tortured in the plaza below.  Two Imperial officers are
+finishing a report to the black knight.  They salute smartly, then leave the
+observation balcony, passing Kuro, one of General Vader's aides, who
+approaches Valorum, and bows low before him.  Kuro and the black knight carry
+on an animated conversation; it is inaudible over the screams of the tortured
+partisans.</sd>
+      </scene>
+      <scene n="84">
+         <setting>  SLUM DWELLING - ALLEYWAY - AQUILAE</setting>
+         <sd>Residents glance fearfully from their windows as six Imperial stormtroopers
+make their way through the crowded slum alleyway.  Han Solo and Captain
+Starkiller move cautiously past the Imperial patrol, and disappear into the
+shabby hideout of the partisan underground.</sd>
+      </scene>
+      <scene n="85">
+         <setting>  SLUM DWELLING - MAIN AREA - AQUILAE</setting>
+         <sd>The two men enter the dingy main room of the slum dwelling, and are
+immediately attacked by Biggs, wielding a toy sword.  Starkiller good-
+naturedly fends off the young prince, as Han in a more serious mood, goes into
+the other room.  Artwo and Threepio are helping Windy put together a block-
+like puzzle.  Princess Leia comes in to see what all the commotion is about,
+just as the young captain grabs Biggs by the foot and holds him upside-down.
+Starkiller and Biggs are laughing uproariously.  Leia gives the captain a
+stern, disapproving look, then returns to the other room.</sd>
+      </scene>
+      <scene n="86">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>General Skywalker, Captain Whitsun, and Datos are in the process of assembling
+two micro-packs on the kitchen table.  Han pulls a small silver powerpack from
+his pocket, and places it on the table.  The old Jedi, Kane Starkiller,
+reaches over with his one good arm and takes it.  He inspects it carefully.
+Princess Leia sits quietly behind the general.</sd>
+         <sp spk="HAN">
+
+We could only get one unit.  The Empire's methods are proving to be very
+effective.</sp>
+         <sd>Kane places the power-pack back on the table.  The pain from those simple
+movements shows on his face.</sd>
+         <sp spk="KANE">
+
+This will work fine.</sp>
+         <sp spk="HAN">
+
+One of the boys will have to stay.</sp>
+         <sp spk="DATOS">
+
+We can't hide him for very long....The risk is too great!  Whichever boy
+doesn't go must be destroyed.</sp>
+         <sd>The princess is alarmed, and looks to the general for support.  He gives her
+an understanding look.</sd>
+         <sp spk="GENERAL">
+
+Not while they're in my charge.  Find another way to get him through.</sp>
+         <sp spk="DATOS">
+
+There's no other way.  We've analyzed every possible alternative.  You can't
+jeopardize the enitre...</sp>
+         <sd>Captain Starkiller enters the room.</sd>
+         <sp spk="HAN">
+
+We have no time for discussion.  The freighters leave at zero three hundred.
+We must get started.</sp>
+         <sd>Through a break in the door, Whitsun watches Artwo and Threepio play with the
+two young princes.</sd>
+         <sp spk="WHITSUN">
+
+What about Artwo?  Could we lobotomize him, and use his energy pack?</sp>
+         <sp spk="GENERAL">
+
+They're not compatible.  We'd have to completely change the system...</sp>
+         <sp spk="HAN">
+
+It could work.</sp>
+         <sp spk="DATOS">
+
+There isn't enough time.  You can't do it...</sp>
+         <sp spk="KANE">
+
+You won't have to.  My power unit has more than half life.... Use it.</sp>
+         <sd>The withered Jedi opens his tunic revealing a metallic chest covered with
+electrodes.  With his one good arm, he grabs his chest and rips loose and
+miniature power unit similar to the one on the table.  Everyone is taken by
+surprise.  The general and the young Starkiller both rush to the side of the
+dying Jedi.  The old man turns to his son.</sd>
+         <sp spk="KANE">
+
+Trust my judgment, Son.  Serve your new teacher well.</sp>
+         <sd>The Jedi's breathing becomes more difficult as he turns to the general.</sd>
+         <sp spk="KANE (con't)">
+
+An honorable death, my friend.  May the force of others be with you....</sp>
+         <sd>Kane Starkiller passes on to the other world.  Everyone is stunned.  The
+general breaks the moment of silence.</sd>
+         <sp spk="GENERAL">
+
+May he be welcomed as a man above men.  Take him downstairs.</sp>
+         <sd>Starkiller takes his father in his arms and is followed out of the room by Han
+and Datos.</sd>
+         <sp spk="GENERAL">
+
+Prepare the boys!  We have little time.</sp>
+         <sd>Princess Leia and Captain Whitsun rush out of the room, as the general places
+the power units in the micro-packs.</sd>
+      </scene>
+      <scene n="87">
+         <setting>  SLUM DWELLING - MAIN AREA - AQUILAE</setting>
+         <sd>Biggs and Windy are not happy about being dragged away from their puzzle.
+Whitsun takes the robots into the sleep area.</sd>
+         <sp spk="LEIA">
+
+Now straighten up, Biggs.  Remember, father expects you to follow his ways.
+We are going on a trip.  There will be great danger.  You must go to sleep.
+When you wake, you will be in a strange land, so don't be alarmed.</sp>
+         <sp spk="BIGGS">
+
+Are you going to sleep too?</sp>
+         <sp spk="LEIA">
+
+I will be looking after you.  Now be good boys and stand still.  Lift your
+sleeve.</sp>
+         <sd>Windy lifts his sleeze and Leia injects him with a sleep serum.  Whitsun
+enters just as the little prince collapses into a deep sleep.  Quick as
+lightning, he catches the boy before he can hit the floor.  The princess
+injects her other brother, and he collapses into her arms.</sd>
+      </scene>
+      <scene n="88">
+         <setting>  SLUM DWELLING - DINING AREA - AQUILAE</setting>
+         <sd>The limp bodies of the two young princes are carried in by Leia and Captain
+Whitsun.  They are carefully squeezed into the hollowed out micro-cases.  Leia
+pensively watches as the general expertly attaches electrodes to her brother's
+skull.  Han and Datos return from the burial of Kane.  The general looks up
+from his operation.</sd>
+         <sp spk="HAN">
+
+He is at rest.  The Empire will never find him.  Are the systems working all
+right?</sp>
+         <sp spk="GENERAL">
+
+Full power...Is everything ready?</sp>
+         <sd>Datos nods yes, as the general closes the case holding Biggs.  The strain of
+watching her brothers placed in suspended animation is too great for Leia, and
+she retreats into the main room.</sd>
+      </scene>
+      <scene n="89">
+         <setting>  SLUM DWELLING - MAIN ROOM - AQUILAE</setting>
+         <sd>Captain Starkiller stands brooding near a window overlooking the crowded
+alleyway.  He does not acknowledge Leia's entrance.  She walks over to the
+window, and stands next to the young captain.  They are very close, but do not
+touch.</sd>
+         <sp spk="LEIA">
+
+I'm sorry.</sp>
+         <sd>He does not respond.  She is moved by his sorrow, and starts to touch the side
+of his face, but can't bring herself to do it.  Her royal training is too
+strong to let her show her true affection for Starkiller.  She breaks down and
+runs from the room.  The young Jedi continues his meditation.</sd>
+      </scene>
+      <scene n="90">
+         <setting>  SPACEPORT AT GORDON - SECURITY RAMP - AQUILAE</setting>
+         <sd>The spaceport is very crowded.  People rush about in a panicked rush as
+loudspeakers blurt out indiscernible announcements.  The Empire is in the
+process of changing the boarding procedures and the result is chaos.  Many
+flights are delayed, and people are running to and fro, switching boarding
+ramps.  Han guides the rebel group, dressed as a Baltarian crew, through the
+crowded terminal.  Whitsun and Starkiller carry the large micro-packs strapped
+to their backs.  The robots follow a few paces behind.</sd>
+         <sp spk="HAN">
+
+They're changing the boarding procedures.  I don't like it.</sp>
+         <sd>They are swept into a boarding gate and finally reach a security ramp scan
+station.  There are a great number of troops and guards standing around the
+security area.  An officer demands to see their passes and orders.  The
+tension builds as the officer confers with an aide about the passes.  The aide
+speaks quietly into a phone.</sd>
+         <sp spk="OFFICER">
+
+Where are your component receipts?</sp>
+         <sd>Starkiller and Whitsun hand the officer two additional discs which are placed
+in the computer.  A few moments later, the readout appears, and the group is
+motioned through the electron scanners.  On the other side of the scanner, new
+computer discs are issued to the group.  Everyone seems slightly relieved as
+they walk through several hallways leading to where the freighter is docked.
+Starkiller moves next to the general.</sd>
+         <sp spk="STARKILLER">
+
+I don't like the feel of this.</sp>
+         <sp spk="GENERAL">
+
+Your senses are strong.  It's a very small disruption.</sp>
+         <sp spk="STARKILLER">
+
+It's a Knight of the Sith.</sp>
+         <sp spk="GENERAL">
+
+Possibly.  Stay alert...Warn the others.</sp>
+         <sd>The group walks through the docking links and into the Baltarian spacecraft.
+Several Imperial guards pass them, and everyone is ready for the suspected
+trap, but nothing happens..</sd>
+      </scene>
+      <scene n="91">
+         <setting>  INTERIOR - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The group stops in a narrow electronics passageway near the bridge of the
+ship.  Starkiller and Whitsun unstrap the micro-packs containing the two young
+princes, and check the voltage packs.</sd>
+         <sp spk="WHITSUN">
+
+Little Biggs is losing power faster than normal.  I'd better check it out.</sp>
+         <sp spk="GENERAL">
+
+Wait until the situation is secure.  Stay here, and keep on your guard....Han!</sp>
+         <sd>The two young captains grow suspicious of several workmen gathering around the
+main exit hatch.  Han and the general enter the bridge area.  Several crewmen
+sit at elaborate controls and computer stations.</sd>
+         <sp spk="GENERAL">
+
+Where is your captain?</sp>
+         <sd>One of the crewmen directs him to a small chamber above the bridge.
+Starkiller and Whitsun strap on their micropacks as more workmen converge at
+the main hatch and begin to close it.  The two robots, Artwo and Threepio are
+confused about what is going on, and wear their gear in anticipation of
+moving.</sd>
+      </scene>
+      <scene n="92">
+         <setting>  PILOT CHAMBER - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Han and the general enter the small pilot's chamber and greet the captain,
+whose face is hidden in the shadows of a computer bank.</sd>
+         <sp spk="CAPTAIN">
+
+Welcome, gentlemen.  You must have had a difficult journey.  We'll be
+departing shortly....</sp>
+         <sp spk="">[p. 77 is all screwed up.  I attempt to interpret here:]</sp>
+         <sd>Four Imperial troopers silently enter the room behind the two [??] Their
+laserswords are drawn.</sd>
+         <sp spk="CAPTAIN (con't)">
+
+[?] I have been authorized to accept payment [?] the chrome company
+cooperation.  I [?] you've brought it with you.</sp>
+         <sp spk="">[?] moves out of the shadows, and is revealed to [be Valorum, F]irst Knight of
+the Sith.  Instantly, both Han and [the general] understand the situation.
+They turn, drawing their [laserswords? ?] the move, and cut down the four
+Imperial troopers.  [?] chamber instantly seals shut.  Valorum hasn't [?] and
+remains unusually calm.  The two Jedi turn [?]</sp>
+         <sp spk="VALORUM">
+
+[?] over, gentlemen.  The chamber is sealed.  [?] force me to release the Jai
+gas...</sp>
+         <sp spk="">[?] and the black knight turns to an intercom.</sp>
+         <sp spk="INTERCOM">
+
+[?]ion secure.  Prisoners taken to hold "B,"... [?] casualties.... gas was
+necessary.</sp>
+         <sp spk="">[?]eral relax and drop their weapons.  The door [?] behind them and six guards
+enter wearing face-[?]nd the two Jedi with chrome microcuffs.  A [?] creeps
+across Valorum's face.  General [?] unimpressed with the knightly trap.</sp>
+         <sp spk="VALORUM">
+
+[?] it's ended.  (to guard)  Take them [?] "G."  I don't want them with the
+others.  [?] for departure.</sp>
+         <sp spk="">[?esc]ort Han and the general out of the chamber [?] hallways.</sp>
+         <sp spk="">[?93.  INTERIOR - BALTA]RIAN FREIGHTERS - AQUILAE</sp>
+         <sp spk="">[?]ch Han and the general into the hold of the [?] near the main exit where
+Artwo and Threepio [?] looking lost.  Threepio sees the general pass [?]ay.</sp>
+         <sp spk="THREEPIO">
+
+[?]ere he is.  Come on.</sp>
+         <sp spk="">[end of p. 77]</sp>
+         <sd>The robots waddle off after the Jedi prisoners.  As the small procession
+passes detention cell B where the princess and the others are being held, Han
+and the general let out a horrifying Jedi scream, and leap to the corridor
+ceiling, thrusting their bound wrists into the lighting fixtures.  They land
+on top of the troops, instantly breaking the necks of four guards, with
+expertly placed Jedi blows.  The eight surviving guards are momentarily
+dumbfounded.  Han and the general grab laserswords from their victims, and
+swiftly cut down the remaining troops.  Han grabs a small card from one of the
+dead guards, and starts for detention cell B.</sd>
+         <sp spk="GENERAL">
+
+Watch it!  Those are cutters.</sp>
+         <sd>The general grabs one of the dead troopers and tosses him against the cell
+door.  Red rays engulf the body, and holds it there.  Han then places the card
+in a slot, and the door silently slides open.  Starkiller and Whitsun leap for
+the dead guard, then notice the death ray surrounding him.  General Skywalker
+grabs another body and throws it into the doorway.</sd>
+         <sp spk="GENERAL">
+
+Pass between them!</sp>
+         <sd>Starkiller squeezes between the slain guards, and is untouched by the rays.
+Whitsun and the princess quickly follow, picking up weapons as they leave.</sd>
+         <sp spk="STARKILLER">
+
+They've taken the cases.</sp>
+         <sp spk="GENERAL">
+
+Are they aware of the boys?</sp>
+         <sp spk="WHITSUN">
+
+I don't think so.</sp>
+         <sp spk="GENERAL">
+
+Find them!  Use your seeker.  We'll meet you at the main hatch.  Watch
+yourselves.  If an alarm is given, they'll gas the entire ship.</sp>
+         <sp spk="WHITSUN">
+
+Yes, Sir.</sp>
+         <sd>Whitsun and Starkiller each take a small humming device from their utility
+belts and head down a narrow hallway.  The general, Han and the princess
+continue toward the main hatch.  Artwo and Threepio have been completely
+confused by the turn of events.  They eventually follow the general toward the
+exit hatch.</sd>
+      </scene>
+      <scene n="94">
+         <setting>  ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The two young captains reach a storage area of the huge spacecraft.  They
+watch their seekers as they move along a row of electroclosets.  They quietly
+sneak past a group of workmen assembling a large gyro-housing.  A second row
+of micro-packs is searched to no avail.</sd>
+         <sp spk="WHITSUN">
+
+If they were discovered, they would have been sent to a medical station.</sp>
+         <sp spk="STARKILLER">
+
+There are more storage areas on the far side.</sp>
+      </scene>
+      <scene n="95">
+         <setting>  MAIN HATCH AREA - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Han and the general reach the main hatch, closely followed by Leia and the two
+robots.  Several lights over the hatch flash on and off.  The general cuts a
+camera off the wall with his lasersword.</sd>
+         <sp spk="HAN">
+
+They're going to take off....It's too late.</sp>
+         <sp spk="GENERAL">
+
+Threepio!  Come over here.</sp>
+         <sd>The lanky chrome man approaches the general, who is studying a complex
+computer control panel next to the hatch.</sd>
+         <sp spk="THREEPIO">
+
+Yes Sir.  May I be of service?</sp>
+         <sp spk="GENERAL">
+
+Get this hatch open.  Counterlock the departure pattern.</sp>
+         <sd>The robot immediately starts pushing buttons on the panel.</sd>
+      </scene>
+      <scene n="96">
+         <setting>  ELECTROCLOSET HALLWAY - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Starkiller and Whitsun reach a second series of electroclosets.  A signal
+appears on the seekers, and Starkiller cuts down the door of one of the small
+cabinets.  Whitsun stands guard.  Approaching troops are heard in the
+distance.  Starkiller quickly rummages through the electropacks until he spots
+the familiar cases containing the two boys.</sd>
+         <sp spk="WHITSUN">
+
+Troops!</sp>
+         <sd>Starkiller straps on one of the back packs, and hands the other to Whitsun, as
+they duck into a narrow passageway.  Four troops march through a nearby
+hallway.  After they have passed, the young captain checks to make sure the
+way is clear, then runs down a hallway toward the main hatch.</sd>
+      </scene>
+      <scene n="97">
+         <setting>  BRIDGE - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>As the crew makes the final preparations for the blast off, the main hatch
+light blinks on.  One of the pilots notices the light and begins to check it
+out.</sd>
+         <sp spk="PILOT (into intercom)">
+
+Is the main hatch secure?</sp>
+      </scene>
+      <scene n="98">
+         <setting>  MAIN HATCH - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The intercom sparks to life, and the general answers it.</sd>
+         <sp spk="GENERAL">
+
+Everything looks secure, but give me a minute to check it out.</sp>
+         <sp spk="PILOT">
+
+All right... Stand by.</sp>
+         <sd>The general gives a wink to Han, as Threepio continues his attempt to override
+the hatch computer.</sd>
+      </scene>
+      <scene n="99">
+         <setting>  HALLWAYS - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>Starkiller and Whitsun cautiously move down a long hallway, ever watchful of
+Imperial troops.  They reach an intersection, carefully check in all
+directions, then rush down a main hallway.  They are about half way down the
+hallway, when a squad of Imperial guards appears at the end of the hallway,
+facing them.  The troops start toward the two captains with lowered
+laserrifles.</sd>
+         <sp spk="STARKILLER">
+
+Here's where it gets tricky.</sp>
+         <sd>Starkiller, then Whitsun, quickly and smoothly draw their laserpistols and
+fire at the troops.  A giant explosion destroys the far end of the hallway.  A
+few laserbolts are returned, but streak harmlessly overhead, and explode out
+of range.  The exchange of gunfire lasts only a few moments.  When the smoke
+clears, the troops have been destroyed.</sd>
+      </scene>
+      <scene n="100">
+         <setting>  MAIN HATCH - BALTARIAN FREIGHTER - AQUILAE</setting>
+         <sd>The main hatch slowly begins to slide open, when the rumbling explosion of
+laserfire echoes through the hallways.  Han looks to the general, and they
+both instantly realize what has happened.  Han draws his weapons.  The hatch
+is now fully open.  Everyone stands silently, watching for the two captains.
+Alarms start screaming throughout the ship, and the giant hatch slowly begins
+to close.</sd>
+         <sp spk="GENERAL">
+
+Come on.  We can't wait.</sp>
+         <sd>The group reluctantly exits the spacecraft, giving one last look back to their
+lost friends.  The hatch continues to close slowly as the alarm sirens wail.
+Suddenly, Starkiller and Whitsun round a corner and head for the ever-closing
+hatch; battling several Imperial stormtroopers as they go.  Han and the
+general move up to the hatch and give cover fire.  Whitsun slips through the
+shrinking opening, and yells to Starkiller to hurry.  Many more troops bear
+down on the young Jedi as he squeezes through the very slim opening.  One of
+the troops dives after him, but is caught, and crushed by the emergency hatch.</sd>
+      </scene>
+      <scene n="101">
+         <setting>  BOARDING RAMPS - GORDON SPACEPORT - AQUILAE</setting>
+         <sd>The general leads the group through various corridors.</sd>
+         <sp spk="HAN">
+
+Once the alarm sounds, the entire spaceport will shut down.</sp>
+         <sd>They stop at a junction.  At the far end of one hallway, several troops guard
+a restricted passageway.</sd>
+         <sp spk="GENERAL">
+
+That's the military section.</sp>
+         <sp spk="STARKILLER">
+
+Fighter craft!</sp>
+         <sp spk="HAN">
+
+But it's very heavily guarded.  We can't take it with subtlety.</sp>
+         <sd>Before the general can answer, the acute scream of the spaceport alarm
+reverberates through the corridors.  The general, followed by his two young
+captains, charge toward the heavily guarded military passageway.  Han, with
+the princess and two robots, follow a safe distance behind.  A guard sees them
+coming, and orders them to stop.  Starkiller and the general fire their
+laserpistols at the passageway entrance and the troops disappear in a huge
+explosion.</sd>
+         <sd>The group jumps over the dead guards and smoking rubble, then runs through a
+series of hallways leading to a starship.  They stop just short of an
+intersection leading to a boarding ramp.  Starkiller peeks around a corner at
+two guards standing in front of the boarding ramp.</sd>
+         <sp spk="STARKILLER">
+
+Cutters!  We'll have to draw them out...A blast might alert the crew.</sp>
+         <sp spk="GENERAL">
+
+Artwo!  Come here.</sp>
+         <sd>The little robot waddles over to the old Jedi.</sd>
+         <sp spk="GENERAL (con't)">
+
+Move to that intersection and sound the alarm.</sp>
+         <sd>The mechanical dwarf dutifully marches into the intersection and lets out a
+high, electronic scream.  The guards shut off the deadly laser "cutters," and
+cautiously approach the wailing robot.</sd>
+         <sp spk="GUARD">
+
+What is it?  What's wrong?</sp>
+         <sd>With incredible speed, both guards are dropped by a few precision blows from
+the two young captains.  They immediately drag the unconscious guards into the
+starship.</sd>
+         <sp spk="GENERAL">
+
+Starkiller!  Whitsun!  Stand guard.  I'll signal at take-off minus
+thirty...And reverse that cutter!</sp>
+      </scene>
+      <scene n="102">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - AQUILAE</setting>
+         <sd>Han and the general, followed by Leia and the robots, enter the Imperial
+starship.  They rush through several narrow hallways leading to the bridge.
+Two crew members leaving a control station, stumble into the group and are
+quickly dispatched by Han.  The princess waits with the robots, as the general
+and Han enter the bridge.  The two pilots and navigator are taken by surprise
+and promptly are subdued.  Han switches on the intercom and listens.</sd>
+         <sp spk="HAN">
+
+How are we going to get them to open the silo cover?</sp>
+         <sp spk="GENERAL">
+
+Send Threepio in here.  Dispose of any crewmen left on board.</sp>
+      </scene>
+      <scene n="103">
+         <setting>  BOARDING RAMP - SPACEPORT - AQUILAE</setting>
+         <sd>Starkiller and Whitsun now wear the uniform of the Imperial guard.  Whitsun
+has removed a plate from the "cutter" machinism and is crossing a few wires.
+He replaces the "cutter" plate just as a squad of stormtroopers rushes toward
+the door.  An officer salutes them.</sd>
+         <sp spk="OFFICER">
+
+Have you seen them?</sp>
+         <sp spk="STARKILLER">
+
+No, Sir.</sp>
+         <sp spk="OFFICER">
+
+They're in this section somewhere.  I'm doubling all the guards.  Stay alert.</sp>
+         <sd>Two guards take up positions just outside the "cutter" areas, and the squad
+moves on to another starship.  Starkiller gives his partner a philosophical
+look.</sd>
+      </scene>
+      <scene n="104">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - AQUILAE</setting>
+         <sd>The gleaming chrome Threepio sits in the pilot's seat, talking on the intercom
+to a controller.  He breaks off his continual drone of take-off instructions
+to the controller and turns to the general, shaking his head.</sd>
+         <sp spk="THREEPIO">
+
+They won't buy it.  I think they're getting suspicious.</sp>
+         <sd>Han enters.</sd>
+         <sp spk="HAN">
+
+The crew is taken care of.</sp>
+         <sp spk="GENERAL">
+
+Well, they're not going to open the silo cover, so I'm afraid we'll have to
+take it with us.</sp>
+         <sp spk="HAN">
+
+We're going to sustain considerable damage if we blast off through that cover.</sp>
+         <sp spk="GENERAL">
+
+It's a thin shell.  There is no choice.  (to Threepio)  Signal the boys.</sp>
+      </scene>
+      <scene n="105">
+         <setting>  BOARDING RAMPS - SPACEPORT - AQUILAE</setting>
+         <sd>Warning lights flash and the main hatch to the starfighter slowly begins to
+close.  The two Imperial stormtroopers yell at Starkiller and Whitsun.</sd>
+         <sp spk="STORMTROOPER">
+
+Watch it!  Don't fire into those cutters!  (to Starkiller)  Shut down the
+cutters!</sp>
+         <sd>The two captains pretend to be confused, and not understand.  At the last
+minute, they leap aboard the starship.  The hatch slides closed, and the
+boarding ramp drops away.  Several more guards arrive, and give the troopers a
+special card, which turns the small cutter warning lights from red to green.
+The guards rush onto the boarding ramp and are wiped out by the reversed
+"cutters."</sd>
+      </scene>
+      <scene n="106">
+         <setting>  INTERIOR - STARSHIPS - AQUILAE</setting>
+         <sd>Everyone straps himself into the lifepods.  Threepio and the general troddle
+forward, and the giant ship shudders as it starts to lift off the launch pad.
+With tense expressions, everyone braces for the impact of the silo cover.</sd>
+      </scene>
+      <scene n="107">
+         <setting>  STARSHIP - SPACEPORT SILO - AQUILAE</setting>
+         <sd>The  mighty starship thunders out of the silo, crashing through the cover
+plate, sending shrapnel in all directions.  The ship leaps toward the heavens.</sd>
+      </scene>
+      <scene n="108">
+         <setting>  BOARDING CAMPS - SPACEPORT - AQUILAE</setting>
+         <sd>Imperial flight crews rush to their starships.   Pilots receive their
+clearances, and several giant silo covers swing away, revealing deadly hunter-
+destroyer spaceships.</sd>
+      </scene>
+      <scene n="109">
+         <setting>  INTERIOR - BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han and the general watch as five hunter-destroyers leave the spaceport at
+Gordon.</sd>
+         <sp spk="GENERAL">
+
+We suffered light damage to a deflector fin.  It will take them quite a while
+to catch up with us now.  Tell the boys to get some rest.</sp>
+      </scene>
+      <scene n="110">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Han retreats to the aft section of the ship, where the two captains are
+checking out the two main lasercannons mounted in large rotating bubble
+turrets.</sd>
+         <sp spk="HAN">
+
+The old boy says you two should get some rest... You've got some time before
+they catch up to us.</sp>
+         <sd>Han notices the packs containing the young princes.</sd>
+         <sp spk="HAN (con't)">
+Better store the boys in a lifepod.  Secure them well.</sp>
+         <sd>He heads back toward the bridge, followed by Whitsun.  Starkiller carries the
+two micro-packs to a lifepod, and straps them in.  He checks Biggs' energy
+supply.  It is low.  Leia approaches him.</sd>
+         <sp spk="LEIA">
+
+Couldn't we let them out now?</sp>
+         <sp spk="STARKILLER">
+
+It's better this way.  Things are going to get rough...</sp>
+         <sp spk="LEIA">
+
+Will we make it?  Is there any hope?  Stay with me.  [something deleted?]... I
+love you.</sp>
+         <sd>Starkiller is slightly shocked at this outburst.  The princess starts to cry
+and clings to him for support.</sd>
+         <sp spk="STARKILLER">
+
+No-one is going to die...so stop acting like a child, and start behaving like
+a queen.  What is this silly talk of love?  You belong to the people of
+Aquilae, and my job is to return you to them, nothing more.  Now straighten up
+and get into a lifepod.</sp>
+         <sd>She's deeply hurt by his callousness.  She breaks away from him and runs down
+a hallway into a lifepod.  He is tired, and angry at the whole incident.</sd>
+      </scene>
+      <scene n="111">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Threepio guides the starship toward the Ophuchi system.  The general watches
+the computer readout estimate the position of the Imperial hunter destroyers.</sd>
+         <sp spk="THREEPIO">
+
+Hostile craft will intercept at thirty plus.</sp>
+         <sp spk="GENERAL">
+
+What's the nearest star System?</sp>
+         <sp spk="THREEPIO">
+
+Yavin.</sp>
+         <sp spk="GENERAL">
+
+Set a course... Maybe we can lose them among the Systems.</sp>
+      </scene>
+      <scene n="112">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Starkiller rests in one of the lasercannon pod bays.  He is thinking about
+Leia.  Slowly a smile creeps across his face.  He makes a decision, jumps up,
+and hurries down a hallway.  He taps on the lifepod bulkhead, and Whitsun
+opens the door.  Starkiller is surprised.</sd>
+         <sp spk="WHITSUN">
+
+What is it?</sp>
+         <sp spk="STARKILLER">
+
+Where is Leia?</sp>
+         <sp spk="WHITSUN">
+
+She went forward.... What's going on with you two?</sp>
+         <sp spk="STARKILLER">
+
+We're in love.  She loves me, and I just realized,... I love her.</sp>
+         <sp spk="WHITSUN">
+
+[something whited out] You're asking for trouble... She's a queen... You're a
+warrior....Do you know what you're saying?</sp>
+         <sp spk="STARKILLER">
+
+I don't care... I've got to talk...</sp>
+         <sd>Whitsun just shakes his head, but before Starkiller can finish his sentence,
+the ship is rocked by a bombardment of proton torpedoes.  The intercom squawks
+to life.</sd>
+         <sp spk="GENERAL (over intercom)">
+
+Get to those guns!</sp>
+         <sd>Starkiller and Whitsun rush to the lasercannons, and jump into the protective
+suits and helmets.</sd>
+      </scene>
+      <scene n="113">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han enters the bridge and sits before a fire control center.  The general sits
+in a chair, slightly behind and above Threepio, directing the robot pilot.</sd>
+         <sp spk="GENERAL">
+
+Turn around!  Let's face them.</sp>
+         <sd>Artwo, sitting quietly in a corner, watches as Threepio punches new
+information into the computer and the giant starship swings around in a sharp
+circle.  Several torpedoes explode near the ship.  The general switches on the
+intercom.</sd>
+         <sp spk="GENERAL">
+
+Your boys ready?</sp>
+      </scene>
+      <scene n="114">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The captains adjust the lasercannon controls in front of them and check in
+with the general.</sd>
+         <sp spk="GENERAL">
+
+They should be within range in twelve seconds...</sp>
+         <sd>Starkiller adjusts his giant laser ack-ack cannon, searching his electronic
+tracking screen for the hunter destroyer.  Whitsun is having a problem with
+one of the rotating mechanisms on the huge gun.  He curses, climbs out of the
+chair, and attempts to fix it.</sd>
+         <sp spk="WHITSUN">
+
+My vertical rotating circuits are out...</sp>
+         <sd>The princess straps herself into a small lifepod.  [something whited out]
+Only the slightest hint of concern or worry shows in her face.  She listens to
+her protectors relay instructions as the enemy approaches.</sd>
+      </scene>
+      <scene n="115">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The starship shudders as the hunter-destroyers open fire.  Han relays the
+ship's status to the general, as Threepio struggles to keep up with the
+barrage of orders.</sd>
+         <sp spk="HAN">
+
+We're losing deflectors three thirty one and ten forty two...</sp>
+         <sp spk="GENERAL (to Threepio)">
+
+Cut hard to maridian nine zero six.  Level to three degrees...(into the
+intercom)  We're coming under one.  Wait for my signal!</sp>
+      </scene>
+      <scene n="116">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>The constant flashing of deflected laser bolts reflect in the interior of the
+lasercannon bubble.  Starkiller rechecks his firing swithces..Whitsun adjusts
+his headphones, and lowers a glare reflector.  He raps on the power rotation
+circuits, and gives them a little test burst.  The pod instantly rotates a few
+degrees.  The large starship heads directly toward the three enemy ships and
+at the last moment dives under the attacking craft.  Starkiller watches the
+smaller crafts pass overhead, aching to open fire.  He calls Whitsun on the
+intercom.</sd>
+         <sp spk="STARKILLER">
+
+I've got no signal.  I'm on target.  What's wrong?  What are they waiting for?</sp>
+         <sd>I've got an open shield!</sd>
+         <sd>The three Imperial craft are firing incessantly at point blank range.</sd>
+         <sp spk="WHITSUN">
+
+Wait for the signal.</sp>
+         <sd>But Starkiller has a perfect shot, and he can't wait.  He squeezes the trigger
+and the giant lasercannon, with a burst of smoke and electrical charge, opens
+up on the enemy craft.  Moments later, the signal lights flash on and Whitsun
+commences firing on the receeding hunter-destroyers.  Two of the Imperial
+craft break off, and prepare for another attack run.  The third is hit by a
+concentrated barrage from the two captains, and begins spinning out of
+control, until it finally explodes.  Whitsun gives Starkiller a victory wave,
+which Starkiller gleefully returns.  These moments of triumph are broken by
+the intercom.</sd>
+         <sp spk="GENERAL">
+
+Annikin, next run you wait for my signal.  We haven't much power to spare on
+your inaccurate grandstanding!</sp>
+         <sd>Starkiller's pride is wounded.  He resets his accelerators, as the two
+remaining hunter-destroyers begin a second run.</sd>
+      </scene>
+      <scene n="117">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+
+We have a weakened shield on the port turret...</sp>
+         <sp spk="GENERAL">
+
+Warn Starkiller.  Get him out of there.  (to Threepio)  Change your heading by
+point five.</sp>
+      </scene>
+      <scene n="118">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Princess Leia listens to Han warn Starkiller.</sd>
+         <sp spk="HAN">
+
+Your shield power is down.  Abandon that positions, and seal that section.
+Report!  Captain, do you hear me?  Captain?!!!</sp>
+         <sd>Leia becomes worried that something has happened to Annikin.  The young
+captain switches off the intercom system and signals to Whitsun that the
+system has gone dead.  Before Whitsun can answer, the two hunter-destroyer
+spacecraft are upon them once again.  Laser bolts flash all around them.  The
+general's signal flashes on, and the captain starts to return the fire.  One
+of the Imperial fighters concentrates its fire on Starkiller's weakened
+gunport.  A direct hit blows open a hole in the turret, and everything that
+isn't bolted down is sucked into outer space, including Starkiller.  He bangs
+against the side of the starship, held only by a weakened lifeline.</sd>
+         <sd>The princess hears Whitsun explain Starkiller's predicament, and rushes back
+to help him.  She is stopped by a pressure locked door leading to the gun
+emplacement.</sd>
+      </scene>
+      <scene n="119">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The general orders Threepio to swing the spacecraft around and start a new
+attack.  He turns to Artwo.</sd>
+         <sp spk="GENERAL">
+
+Use the aft port...See what you can do for Starkiller.</sp>
+         <sd>Artwo hurriedly waddles out of the bridge.  Threepio and Han simultaneously
+turn to the general.</sd>
+         <sp spk="THREEPIO">
+
+More craft approaching!</sp>
+         <sp spk="HAN">
+
+It looks like at least six or seven.</sp>
+         <sd>The general studies the radar scopes and then checks a Galactic map displayed
+on one of the monitors.</sd>
+         <sp spk="GENERAL">
+
+Change course to three point one.</sp>
+         <sp spk="THREEPIO">
+
+That will head us directly into the path of the Norton Asteroid Belt.</sp>
+         <sp spk="HAN">
+
+That Asteroid Belt is too dense to pass through...The ship won't make it!</sp>
+         <sp spk="GENERAL">
+
+We'll never defeat them in combat.  It's our only chance to lose them.</sp>
+         <sd>Threepio punches in new coordinates, and the starship veers away toward the
+treacherous asteroid belt.</sd>
+      </scene>
+      <scene n="120">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Whitsun fires on one ofthe two hunter-destroyers which is pacing the rebel
+starship.  Starkiller unsuccessfully tries to pull himself back inside the
+spacecraft.  The enemy craft maneuvers wildly in an attempt to get into a
+better position, to fire on Starkiller.  Whitsun blasts away, until the
+Imperial spacecraft spews forth equipment and personnel, careens off, and
+eventually explodes.</sd>
+         <sd>Artwo wobbles along the exterior of the ship, until he reaches the stranded
+captain.  He attaches a new lifeline to the young Jedi's spacesuit, and makes
+his way back inside the wounded craft.  Starkiller is pulled to safety just as
+the starship enters the asteroid belt.  A barrage of small and large asteroids
+begins to pelt the ship, causing a great deal of damage.</sd>
+         <sp spk="GENERAL (over intercom)">
+
+Secure yourselves.  We may have to eject.  Abandon the turrets.</sp>
+         <sd>The princess rushes back to her lifepod and straps herself in.  Whitsun and
+Artwo help Starkiller make his way out of the lasercannon turrets and through
+a series of locks, to the lifepod area.</sd>
+      </scene>
+      <scene n="121">
+         <setting>  BRIDGE - STARSHIP - SPACE</setting>
+         <sd>The asteroids hit hard.  The ship is buffeted to and fro as the general, Han,
+and Threepio struggle into their spacesuit-like lifepods.  The Imperial
+hunter-destroyer closest to the rebel ship explodes in the onrush of deadly
+asteroids.  The new reinforcement hunter-destroyers turn back and give up the
+pursuit.  They disappear from the tracking monitors.  The asteroid bombardment
+becomes almost unbearable.  Warning lights begin to flash.  Extending foils,
+antennae, and armament pods are scraped away from the starship hull.  A
+baseball-sized hole is punched through the midsection, and hundreds of objects
+are sucked into space.  A large locker eventually plugs the opening.  The
+starship and her passengers shudder and sway under the punishment of the
+asteroid storm.</sd>
+         <sp spk="THREEPIO">
+
+The ship is breaking up.</sp>
+         <sp spk="HAN">
+
+We're almost clear of the storm.</sp>
+         <sp spk="THREEPIO">
+
+We'll never make it.  Eject, we must eject.</sp>
+         <sd>The general watches the computer monitor as the starship emerges from the far
+side of the Asteroid Belt.</sd>
+         <sp spk="HAN">
+
+We're approaching one of the Forbidden Systems....</sp>
+         <sp spk="GENERAL">
+
+We've got to achieve orbit.</sp>
+         <sp spk="THREEPIO">
+
+We'll never make it.</sp>
+         <sd>The starship heads for a small blue-green planet in the distance.</sd>
+      </scene>
+      <scene n="122">
+         <setting>  AFT SECTION - STARSHIP - SPACE</setting>
+         <sd>Starkiller was considerably shaken in the destruction of his laserturret.  He
+is slightly dazed as Whitsun straps him into a lifepod with Artwo.</sd>
+         <sp spk="WHITSUN (to Artwo)">
+
+You watch him.  Make sure this pod gets off all right.</sp>
+         <sd>Artwo nods, and Whitsun moves to the second lifepod and straps himself in next
+to the princess.</sd>
+         <sp spk="LEIA">
+
+Will he be all right?</sp>
+         <sp spk="WHITSUN">
+
+I think so.. His feelings for you are dangerous.  You should discourage him.</sp>
+         <sd>She is surprised that Starkiller has any feeling for her, but keeps her
+emotions to herself.</sd>
+      </scene>
+      <scene n="123">
+         <setting>  BRIDGE - STARSHIP - YAVIN ORBIT</setting>
+         <sd>The general is strapped into the lifepod with the two micro-packs containing
+the young princes.  Han and Threepio are in the second lifepod.</sd>
+         <sp spk="HAN">
+
+We're in orbit.</sp>
+         <sp spk="THREEPIO">
+
+We've got to eject now!  Those reactors won't hold much longer.  This ship's
+going to end up in a million little pieces,... and I don't want to be one of
+them.</sp>
+         <sp spk="HAN">
+
+All lifepod systems are operative.</sp>
+         <sp spk="GENERAL (into intercom)">
+
+If you boys are ready back there, we'll get off this bucket.</sp>
+         <sp spk="WHITSUN">
+
+All systems operative...I have the signal.</sp>
+         <sp spk="ARTWO">
+
+All systems operative...We have the signal.</sp>
+         <sd>Han salutes the general, and his lifepod jettisons away from the crippled
+starship.  He is quickly followed by the general.</sd>
+      </scene>
+      <scene n="124">
+         <setting>  AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Artwo pushes the jettison switch, but nothing happens.  Starkiller slowly and
+with some difficulty, pushes the switch two or three times.  Nothing happens.
+He begins to look a little worried.</sd>
+         <sp spk="STARKILLER (into intercom)">
+
+We've got a problem...Wait a second...</sp>
+         <sd>Artwo pushes the switch again, and the lifepod blasts off in a cloud of smoke
+and debris.  Whitsun also seems to be having a problem.  Half the lights on
+his control panel have gone dead.  He struggles to reactivate them.</sd>
+         <sp spk="WHITSUN">
+
+My power's out!</sp>
+         <sp spk="GENERAL (over intercom)">
+
+Is it a faulty switch?</sp>
+         <sp spk="WHITSUN">
+
+No.  The whole bank is out.</sp>
+         <sd>Whitsun gives the princess a reassuring look, then punches some information
+into the computer.  The monitor flashes:  "Income line main power."  He looks
+outside the lifepod and sees a damaged cable.</sd>
+         <sp spk="WHITSUN">
+
+I've found it...</sp>
+         <sp spk="GENERAL">
+
+You haven't much time...The auxiliary units have already blown....</sp>
+         <sd>Whitsun scrambles out of the lifepod and rushes over to the severed connector.</sd>
+         <sd>He works on it for a few moments, then stops with a rather defeated look.  The
+princess watches him as he tries to think of a solution.  A great explosion is
+heard in the forward part of the ship.</sd>
+      </scene>
+      <scene n="125">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods containing the general, and Han and Threepio drift away from
+the disabled starship.</sd>
+         <sp spk="GENERAL">
+
+Where's Starkiller?</sp>
+         <sp spk="HAN">
+
+I can't see him either.</sp>
+         <sd>Starkiller uses the small rockets on his lifepod to maneuver back toward the
+burning starship.  He can hear the general over the intercom.</sd>
+         <sp spk="GENERAL">
+
+Starkiller, where are you?  Report in.</sp>
+         <sd>Starkiller reaches down and switches off the intercom.</sd>
+      </scene>
+      <scene n="126">
+         <setting>  AFT SECTION - STARSHIP - YAVIN ORBIT</setting>
+         <sd>Whitsun appears to have found a solution to his situation and rushes back to
+the princess.  He reaches in and locks on the power switch.</sd>
+         <sp spk="WHITSUN">
+
+There is only one possible solution, and we must use it.  Lock the hitch and
+make sure it is sealed.</sp>
+         <sp spk="PRINCESS">
+
+But what of...</sp>
+         <sd>Another explosion creates a large bulge in the wall of the aft section.</sd>
+         <sp spk="WHITSUN">
+
+We've no time!</sp>
+         <sd>He slams the hatch shut and runs to the power connector.  Smoke begins to fill
+the chamber, as Whitsun slams a large metallic dampening tool across the
+damaged connector terminals, and the lifepod jettisons away.</sd>
+      </scene>
+      <scene n="127">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The princess jettisons free, as Starkiller moves toward the crippled ship.
+Leia calls the general on the intercom.</sd>
+         <sp spk="LEIA">
+
+I'm all right, but Clieg is still on board.</sp>
+         <sp spk="GENERAL">
+
+Starkiller, stay out of there.</sp>
+         <sd>With a rumble, the starship disappears in a spectacular explosion, sending
+debris in all directions.  Starkiller stops his lifepod and it starts to
+drift.  He is weeping.  Han and the general helplessly watch the remains of
+the explosion drift away.</sd>
+         <sp spk="GENERAL">
+
+Starkiller, stay near Leia.  Use your beacon.  Coordinate with us.</sp>
+         <sd>Starkiller's intercom is weak, and there is a great deal of static.  The
+lifepods drift toward the awesome blue-green Yavin surface.  The general loses
+sight of the other lifepods as the descend through the cloud cover.</sd>
+         <sp spk="GENERAL">
+
+Captain, I'm losing your beacon.  Send me a new signal.</sp>
+         <sd>All he gets is static.  The planet surface rushes toward the falling lifepods.</sd>
+         <sd>Retrorockets automatically kick in and slow the pods.  Two of the small craft
+break through the clouds and land in the dense, steaming jungles.</sd>
+      </scene>
+      <scene n="128">
+         <setting>  VINE JUNGLE - YAVIN</setting>
+         <sd>The general's lifepod crashes through the foliage until it comes to rest in
+the middle of a large vine-covered tree.  He grabs the two micro-packs and
+climbs out of the lifepod, and onto a large moss-covered limb.  Han and
+Threepio run to the base of the huge tree.</sd>
+         <sp spk="HAN">
+
+Are you all right?</sp>
+         <sp spk="GENERAL">
+
+Fine...Any signal from Annikin?</sp>
+         <sp spk="HAN">
+
+Nothing yet.  I think they landed further south.</sp>
+         <sd>The general attaches a thin cable from his utility belt to the tree trunk, and
+slides to the ground.  Han takes the micro-packs from him.  The general looks
+around at the jungle.</sd>
+         <sp spk="GENERAL">
+
+This is dangerous country...We'd better stay together.</sp>
+         <sp spk="THREEPIO">
+
+The wildlife in the forbidden system is extremely hostile...Perhaps we should
+seek shelter?</sp>
+         <sd>Han inspects the power units of the micro packs.</sd>
+         <sp spk="HAN">
+
+Windy's unit is very low.  I can't tell if the unit is still functioning.</sp>
+         <sp spk="GENERAL">
+
+We have to find a place to revive them.  We'll start moving south.  We should
+find protection along that ridge.</sp>
+         <sd>The general grabs one of the micro-packs and starts off into the murky jungle.</sd>
+         <sd>Han and Threepio quickly follow.  The jungle is a strange and eerie, fog-laden
+purgatory.  Gruesome and unnatural sounds permeate this ghostly wasteland.
+Everyone is cautious, and on the alert for an unseen danger.</sd>
+      </scene>
+      <scene n="129">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Starkiller's lifepod is also caught in the limbs of a gargantuan tree.  The
+lifepod has been ripped in half by the crash landing.  The unconscious Jedi
+hangs half out of the damaged craft.  A two foot high insect-like creature
+scoots down a branch and onto the back of the dormant warrior.  The insect
+lets out a chilling hissing sound, and a slimy tube emerges from its hairy
+mouth, waking Starkiller.  He is immediately aware of the insect.  His eyes
+are open, but he doesn't move.  Suddenly, with one quick blow, he knocks the
+creature against the side of the spacecraft, and it is squashed lifeless.</sd>
+         <sd>Starkiller is a little groggy, but he manages to climb out of the wreckage.
+He looks around for Artwo.</sd>
+         <sp spk="STARKILLER">
+
+Artwo!  Artwo Detwo!</sp>
+         <sp spk="ARTWO">
+
+Help!</sp>
+         <sd>Starkiller turns and sees the little robot hanging upside down, one of his
+three feet caught in a vine.  He lifts Artwo out of his predicament and places
+him securely on a wide limb.</sd>
+         <sp spk="STARKILLER">
+
+Did you see Leia?</sp>
+         <sp spk="ARTWO">
+
+She landed on the other side of those trees, approximately eight hundred
+meters.</sp>
+         <sp spk="STARKILLER">
+
+Well, come on, old buddy.  Let's get ourselves out of this tree.</sp>
+      </scene>
+      <scene n="130">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general, Han and Threepio reach a shallow cave near the top of a steep
+ridge.  They quickly pull off the micro-packs and place them on a clear piece
+of ground at the mouth of the cave.</sd>
+         <sp spk="GENERAL (to Han)">
+
+Check out the inside.  Threepio, stand guard.  Keep your eyes on the
+countryside.</sp>
+         <sd>He looks at the power units on the micro-packs and shakes his head with a
+worried look.  Han returns from a survey of the inside of the cave.</sd>
+         <sp spk="HAN">
+
+It doesn't go very far.  There's nothing back there.</sp>
+         <sp spk="GENERAL">
+
+Help me with this.</sp>
+         <sd>Han helps the general lift the top from the case containing Windy, the younger
+of the two princes.  The small boy appears lifeless as the general pulls him
+from his encasement, and rests him on the cave floor.  Han pulls a small
+respiration out of the micro-packs and places it over the boy's nose.  The
+general attaches two electrodes over his heart.</sd>
+         <sp spk="HAN">
+
+He doesn't look good.</sp>
+         <sd>The little prince begins to turn blue.  The general grows tense.  Windy starts
+to regain consciousness, but begins coughing and choking, then goes limp
+again.  The general quickly props Windy's mouth open with a small plastic rod
+and checks the reading on his power pack.</sd>
+         <sp spk="GENERAL">
+
+We need more power...tap off Biggs' unit...Quickly!</sp>
+         <sd>He then places Windy's arms behind his back and starts pressing on his chest
+with sharp, rhythmic movements.  Han attaches new electrodes to the boy's
+heart.  Windy again comes to, choking and coughing.  Finally, he begins to
+cry.  The general takes the plastic tube from his mouth and tenderly pats him
+on the back.</sd>
+         <sp spk="GENERAL">
+
+Let's get Biggs out of there.  He shouldn't be a problem.</sp>
+      </scene>
+      <scene n="131">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Starkiller slams closed the hatch of Princess Leia's lifepod.  In the
+distance, the subhuman cries of lonesome tree beasts cut through the forest
+murmur.</sd>
+         <sp spk="ARTWO">
+
+Perhaps she went in search of us.</sp>
+         <sd>Starkiller studies the ground around the capsule.  There are a great many
+footprints, and much broken foliage.</sd>
+         <sp spk="STARKILLER">
+
+Someone's got her.  She put up quite a fight...It's an easy trail to follow.</sp>
+      </scene>
+      <scene n="132">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Both Biggs and Windy are sleeping restlessly on the floor of the cave.  Han
+watches over them as the general scans the valley below with a pair of
+electrobinoculars.</sd>
+         <sp spk="THREEPIO">
+
+It's about fourteen degrees below the horizon... a little to the left.</sp>
+         <sd>The electrobinoculars sweep the rich green landscape until the come to rest on
+a bright reflection, revealing some type of structure.</sd>
+         <sp spk="GENERAL">
+
+It's too small to be a military base...Could belong to a trapper.</sp>
+         <sp spk="THREEPIO">
+
+Highly unusual...</sp>
+         <sp spk="GENERAL">
+
+It's on the way.  Perhaps we should investigate.</sp>
+         <sd>Little Biggs wakes up with a giant yawn.</sd>
+         <sp spk="BIGGS">
+
+Hey!  Where are we?</sp>
+      </scene>
+      <scene n="133">
+         <setting>  FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>The gargantuan trees are shrouded in mist, and the ominous sounds of unearthly
+creatures fill the air.  Starkiller moves quietly and cautiously, followed by
+Artwo, who inadvertently makes a loud clicking sound.  The young warrior
+stops, and motions to the stubby little robot.</sd>
+         <sp spk="STARKILLER">
+
+Wait here.  If I don't return by zero two hundred, come looking for me.</sp>
+         <sd>The mechanical dwarf acknowledges with his computer light.  Starkiller moves
+swiftly and silently forward, until he hears laughing and voices.  He climbs
+up the bankside of a huge tree, and inches his way out onto one of the huge
+overhanging branches.  Below him, he can see a group of scruffy, alien
+trappers sitting around a nutron stove joking and telling stories.  Parked on
+either side of the group are two large, tank-like "jungle crawlers."  Behind
+the crawlers, five Wookees, (huge grey and furry beasts) hang upside down in a
+tree.  Occasionally, they thrash about in great anger and frustration.</sd>
+         <sd>The trappers speak in a strange language, and although they appear slightly
+human, they are slimy, deformed, hideous looking creatures.  Two of the
+trappers yell at one another in a friendly argument.  One shirtless creature
+goes into a "crawler," and the remaining eight laugh hysterically.  Starkiller
+moves further out on the limb to get a better view.  A couple of pieces of
+bark break loose, and float a hundred feet to the ground.  The trappers fail
+to notice.  Moments later, the shirtless trapper emerges from the crawler with
+Princess Leia held unconscious and half naked over his head.  Starkiller's
+rage knows no bounds.  With a terrifying Jedi war cry, the young captain jumps
+from the tree, sails over a hundred feet, and with great agility, lands in the
+middle of the startled trappers.  In one continuous rapid motion, he ignites
+his lasersword and cuts down three of the vile creatures.  The shirtless
+trapper swings the princess over his shoulder, and runs back into the huge
+"jungle crawler."  Two other trappers reach for their pistols, but the Jedi
+has killed them before their weapons can clear leather.  The three remaining
+creatures have their pistols out and start firing.  Explosions erupt all
+around Starkiller.  One blast hits the branch holding the Wookees, and they
+collapse with a loud screech in a heap.  One of the trappers is caught in the
+crossfire and is blown apart.</sd>
+         <sd>When the smoke clears, Starkiller lies unconscious amid the burning rubble.
+The jungle crawler begins to move out of the camp.  The last two trappers run
+after it.  One is able to jump on board, but the second trapper runs too close
+to the now freed Wookees.  Chewbacca, one of the furry giants, grabs him and
+snaps him in two, like a stick of wood.  The jungle crawler disappears in the
+forest mist.  The eight foot Chewbacca, who resembles a huge, grey bushbaby
+with fierce baboon-like fangs, struggles to free his companions.</sd>
+         <sd>Starkiller regains semiconsciousness, and attempts to get up, only to groan
+and collapse back into unconsciousness.  The Wookees gather around him and
+poke him a couple times to see if he is still alive.  They squawk and jabber,
+apparently in some kind of argument.  Finally, Dewanna, the largest of the
+Wookees, picks up Starkiller and puts him over his shoulder.  The group
+disappears into the jungle foliage.</sd>
+      </scene>
+      <scene n="134">
+         <setting>  TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Han and Threepio carry the two little boys on their shoulders.  The general
+stops on the edge of a clearing, and motions for the others to be still.
+Biggs turns around, and signals his little brother to be quiet.  On the
+opposite side of the clearing, a small metal structure is attached to one of
+the huge trees.  It is a small, weatherbeaten hut of futuristic design.  It
+appears deserted.  The general cautiously approaches the structure.</sd>
+         <sp spk="VOICE">
+
+Howdy stranger...What can I offer you?</sp>
+         <sd>The general spins around and sees Owen Lars, an aged and scruffy looking
+anthropologist.</sd>
+         <sp spk="LARS (con't)">
+
+I'm Owen Lars of Bastine.</sp>
+         <sd>The general takes the old man's extended hand.</sd>
+         <sp spk="GENERAL">
+
+I'm Luke Skywalker of Aquilae.</sp>
+         <sd>He signals for the others to join him in the clearing.</sd>
+      </scene>
+      <scene n="135">
+         <setting>  WOOKEE CAMP - YAVIN</setting>
+         <sd>The small caravan of Wookees, led by Chewbacca, enters a small clearing
+surrounded by many bark and mud hovels.  Young Wookees race ahead of the group
+yelling, and running in and out of the grubby little dwellings.  Giant,
+bushbaby-like Wookees of all ages and sizes, make their way into the clearing.</sd>
+         <sd>Many stand dumbfounded, but others let out a joyful scream and rush up to
+members of the group, hugging and kissing them.</sd>
+         <sd>Dewanna dumps the unconscious Starkiller on a raised area in the middle of the
+clearing.  Armed Wookees immediately surround the helpless human.  Chewbacca
+enters the largest of the lodges.  He is greeted by his father, Auzituck,
+Chief of the Kaapauku tribe; an old and feeble Wookee dressed in royal skins
+and headdress.</sd>
+      </scene>
+      <scene n="136">
+         <setting>  INTERIOR - ANTHROPOLOGIST HUT - YAVIN</setting>
+         <sd>Anthropologist Lars, the general, Han and the children sit around a large
+table eating.  Lars yells into the kitchen.</sd>
+         <sp spk="LARS">
+
+Beru!  Where's the thanta sauce?</sp>
+         <sd>Beru Lars, Owen's warm, plump wife, enters, carrying a small pitcher.  She
+smiles at Owen.</sd>
+         <sp spk="BERU">
+
+I swan!  I put it right here in front, so you'd see it...(to Han)  Here's some
+Bum Bum extract.  It's very mild...</sp>
+         <sp spk="LARS (to general)">
+
+There are no settlers to the south since the Dau family was wiped out... I'm
+afraid I couldn't even get in there to bury them... Those Wookees are the
+fiercest critters I've ever run across.  A new tribe moved in down there about
+a year ago...and it's been hell ever since.  Only Yourellian trappers venture
+in there now, and many of them don't even come back.</sp>
+         <sp spk="GENERAL">
+
+Where's the nearest city?</sp>
+         <sp spk="LARS">
+
+No cities at all...only a few scattered settlers and -- one Imperial
+outpost... But the troops are of no help.  They kill and plunder rather than
+protect...Enough...If your friends landed father south, I'd fear for them.</sp>
+         <sp spk="HAN">
+
+How far is the outpost from here?</sp>
+         <sp spk="LARS">
+
+Five leagues...an oppressive blight.</sp>
+         <sp spk="GENERAL">
+
+What class is it?  How many support craft?</sp>
+         <sp spk="LARS">
+
+It's very small, a class two....Only ten or twelve starraiders, I think.</sp>
+         <sd>Beru fusses over the boys, who refuse to eat their vegetables.  She makes up a
+game, which tricks them into eating.  The general ponders the situation.  Han
+eats, like he hasn't eaten in years.</sd>
+      </scene>
+      <scene n="137">
+         <setting>  WOOKEE CAMP - AQUILAE [??  Yavin?]</setting>
+         <sd>Starkiller is surrounded by Wookees.  Young ones push through to get a better
+look, as the adults jabber and argue about the human.  Starkiller regains
+consciousness with a groan, and a sudden hush sweeps over the gathering.
+Starkiller staggers to his feet, and the group of Wookees back away in mass.
+The young Jedi surveys the situation for a few moments.  The Wookees appear to
+be frightened of this brave warrior.  He reaches for his weapons, but they are
+gone.  Three guards with long spears attempt to contain Starkiller.  With a
+loud shout, he lunges at them, and they give him a little room.</sd>
+         <sd>Jommillia, a large, ferocious Wookee, steps forward.  He says something to the
+guards, and they quickly move away.  He struts before Starkiller, boasting and
+taunting him with his spear and battle ax.  The captain studies the Wookee
+warrior as he paces back and forth, his helmet plumes dancing and chest armor
+jangling.  Without warning, Starkiller lets out another loud yell, startling
+Jommillia into backing off.  Starkiller continues his verbal assault, calling
+the uncomprehending Wookee all manner of vile and degrading things.  Jommillia
+continues to back into the surrounding crowd, momentarily confused by this odd
+behaviour.  Slowly, Jommillia begins to grin.  He takes a defensive stance,
+then begins to laugh hysterically.  This stops Starkiller.  The giant Wookee
+swings his deadly, double-bladed battle ax over his head and expertly throws
+it directly at the young captain's head.  To the amazement of Jommillia and
+the other Wookees, Starkiller, with Jedi skill and concentration, catches the
+ax in mid-air, then charges his furry opponent.</sd>
+         <sd>Jommillia is caught off-guard, but manages to block Starkiller's attack with
+his spear.  The two warriors engage in a savage and fantastic duel.
+Starkiller cuts the Wookee's spear in half, but is hit along the side of the
+head by the shaft and is momentarily dazed.  The battle ax is knocked from his
+hands.  He grabs the spear shaft and rams the giant creature in the belly.  A
+loud command from outside the crowd stops the fight.  The Wookees part,
+revealing Chewbacca and his father, who approach the two warriors.  Jommillia
+bows before his chief, and is commanded to move away.  Chewbacca speaks to
+Starkiller.  He doesn't understand, but welcomes the chance to catch his
+breath.  Chewbacca then presents his father, who steps forward and bows before
+the mighty Jedi.  Chewbacca bows also, as the crowd of Wookees chatter in
+disbelief.  When the chief and his son rise, Starkiller bows down before them.</sd>
+         <sd>This pleases the Wookees, and they screech and cheer.</sd>
+      </scene>
+      <scene n="138">
+         <setting>  TREE HOUSE - FOREST OF THE GARGANTUANS - YAVIN</setting>
+         <sd>Mr. and Mrs. Lars stand on the balcony of their tree house with Threepio and
+the two little princes, Biggs, and Windy.  Han and the general emerge with
+large survival backpacks and multiplelaser weapons.</sd>
+         <sp spk="GENERAL (to Threepio)">
+
+We'll call for you when we've found them.</sp>
+         <sp spk="THREEPIO">
+
+Your orders are quite clear.  The boys will be quite safe.</sp>
+         <sp spk="LARS">
+
+Don't worry.  The patrols never come out this far.  We'll take good care of
+the boys.</sp>
+         <sp spk="GENERAL">
+
+Lars, your kindness will surely be rewarded.</sp>
+         <sp spk="LARS">
+
+Just be careful out there...</sp>
+         <sd>He pats Skywalker on the back as the old Jedi and the ever faithful Han
+descend from the tree house.  [something whited out?]  At the base of the huge
+tree, the warriors climb aboard two small rocket powered platforms.</sd>
+         <sp spk="LARS (yelling down to them)">
+
+They're pretty old.  I hope they'll be all right!</sp>
+         <sp spk="GENERAL">
+
+Out here, they're a wonderment.</sp>
+         <sd>Threepio and the kids wave as the jelsticks start with a whine.  They idle
+about five feet above the ground.</sd>
+         <sp spk="LARS">
+
+Good hunting.  May the force of others be with you.</sp>
+         <sd>Han and the general wave as they ride off into the foreboding Yavin sunset.</sd>
+      </scene>
+      <scene n="139">
+         <setting>  WOOKEE CAMP - YAVIN - NIGHT</setting>
+         <sd>A beautiful, but frenzied fire festival is underway.  Wookees perform the
+Waita Tar dance, and yodel in a barking fashion around a large fire.  The
+female Wookees arrive, carrying torches, and move in a circle around the
+males.  The giant creatures are too involved to notice that little Artwo makes
+his way around the dancers.  The stubby robot stops near one of the mud huts,
+and looks around.  He then wobbles off toward the large chief's quarters, and
+enters.</sd>
+      </scene>
+      <scene n="140">
+         <setting>  WOOKEE CAMP - YAVIN - MORNING</setting>
+         <sd>Artwo exits the chief's hut and looks around.  It is a quiet, grey morning.  A
+low mist hangs over the now deserted clearing.  He turns and signals back into
+the hut.  Starkiller cautiously emerges from the mud house.  he wears a crude
+backpack, and carries a large battle ax.  They start across the clearing.
+Suddenly, out of nowhere, Chewbacca is standing before them.  He says nothing,
+but scratches his head and then circles around Starkiller.</sd>
+         <sp spk="STARKILLER">
+
+We are leaving...We must go.  Stand away!</sp>
+         <sd>The huge Wookee kneels and bows down in front of the young Jedi.  Starkiller
+looks down and smiles.</sd>
+         <sp spk="STARKILLER">
+
+Rise my friend.  We will meet again.</sp>
+         <sd>Starkiller walks toward the jungle and Chewbacca scurries ahead of him and
+bows down once more.</sd>
+         <sp spk="ARTWO">
+
+What does he want?</sp>
+         <sd>Starkiller shakes his head, and rubs his several days growth of beard.  He
+leans down toward Chewbacca.</sd>
+         <sp spk="STARKILLER">
+
+Stand up so we can talk properly.</sp>
+         <sd>Chewbacca jabbers in a [something whited out] questioning fashion.</sd>
+         <sp spk="STARKILLER">
+
+I am grateful to you and your people, but I must go.  I wish you understood
+me.  It would make things so much easier.  Go!  Go!</sp>
+         <sd>Starkiller turns away, and begins to walk toward the jungle again.  Chewbacca
+gets to his feet, and runs after the Jedi, following a few paces behind.
+Starkiller notices the Wookee following them, and shakes his head.</sd>
+      </scene>
+      <scene n="141">
+         <setting>  FOREST OF THE GARGANTUANS - TRAPPER SIGHT [sic] - YAVIN</setting>
+         <sd>The bodies of the killed trappers are covered with rat-sized insects.  A laser
+explosion erupts in the middle of the slimy creatures and they scatter into
+the underbrush.  Han and the general turn over one of the dead trappers.</sd>
+         <sp spk="HAN">
+
+They ran into something.</sp>
+         <sp spk="GENERAL">
+
+It's strange they left their dead.  Something...</sp>
+         <sd>The constant cacophony of jungle creatures suddenly stops.  The two warriors
+scan the jungle for possible danger.  Han draws his laserpistol.  The
+cacophony starts again, as the general ignites his lasersword.</sd>
+         <sp spk="HAN">
+
+Two or three moving this way, from the east.</sp>
+         <sd>He listens more closely for a few moments.</sd>
+         <sp spk="HAN (con't)">
+
+It's Artwo!</sp>
+         <sd>Starkiller and Artwo break out of the dark foliage into the clearing.  He
+waves to Han and the general.  Artwo waddles a few paces behind.  Chewbacca
+sees the humans and stops at the edge of the jungle.  He watches as Starkiller
+and the general carry on an animated conversation.  Han sees the Wookee
+lurking in the shadows.</sd>
+         <sp spk="HAN">
+
+You were followed.</sp>
+         <sp spk="STARKILLER">
+
+He wouldn't stay.  He's one of the ones I saved...</sp>
+         <sd>Han calls out to Chewbacca in the Wookee's own language, and the huge,
+lumbering creature approaches the group.  Han and the Wookee talk for a few
+moments, then embrace as if they were old friends.  Starkiller is surprised.</sd>
+         <sp spk="HAN (to Starkiller)">
+
+This is Chewbacca, son of Auzituck, Prince of the Sawas, a very powerful
+tribe.  It seems they've made you a god.</sp>
+         <sd>The general smiles.  Starkiller is embarrassed.</sd>
+      </scene>
+      <scene n="142">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>Starkiller joins the general on a ridge overlooking the Imperial outpost of
+Mavassi.  All that can be seen of the fortress is a lone guard standing on a
+small pedastal, jutting out above the dense jungle.</sd>
+         <sp spk="GENERAL">
+
+Their trail leads directly to the outpost.  Patrols are probably out looking
+for us by now.</sp>
+         <sp spk="STARKILLER">
+
+Finding her in there isn't going to be easy.</sp>
+         <sp spk="GENERAL">
+
+Getting in there is going to be impossible.  We could sure use one of those
+starships.</sp>
+         <sd>Starkiller spots something moving in the jungle.  He scans the area with his
+electrobinoculars.</sd>
+         <sp spk="STARKILLER">
+
+Something's going on down there...Han!</sp>
+         <sd>Han moves up next to Starkiller, followed closely by Chewbacca.</sd>
+         <sp spk="STARKILLER">
+
+Your eyes are better than mine....What do you make of that?</sp>
+         <sp spk="HAN">
+
+They look like Wookees...hundreds of them.</sp>
+         <sd>Han turns and speaks to Chewbacca, gesturing toward the movement far below in
+the jungle.</sd>
+         <sp spk="HAN">
+
+Apparently, it's a siege.  They've been harassing the outpost for almost two
+years.</sp>
+         <sp spk="GENERAL">
+
+Have they ever tried to take the fortress?</sp>
+         <sd>Han relays this to Chewbacca.</sd>
+         <sp spk="HAN">
+
+He says they've made several assaults, but they are no match for the weapons.</sp>
+         <sp spk="GENERAL">
+
+It's only a class three fortress.  Maybe they just need a little help.</sp>
+         <sd>Starkiller grins, and Han says something to Chewbacca, who becomes excited and
+screeches loudly.</sd>
+      </scene>
+      <scene n="143">
+         <setting>  INTERIOR - TREEHOUSE - YAVIN</setting>
+         <sd>The incoming signal alarm on the anthropologist's radio system wails through
+the calm of the tree house.  Biggs, dragging an eight-legged, furry rodent,
+rushes up to the old radio and flips the receiver.</sd>
+         <sp spk="BIGGS">
+
+I'm reading yah.  Go ahead.</sp>
+         <sp spk="GENERAL">
+
+Biggs, how are you getting along?</sp>
+         <sp spk="BIGGS">
+
+Great!  I caught a thumper...a really big one.  Its name is "Amber."</sp>
+         <sd>He yanks on the leash, and the furry beast lets out a strained yelp.</sd>
+         <sp spk="GENERAL">
+
+Good, Biggs.  How's your brother?  Are you taking good care of him?</sp>
+         <sp spk="BIGGS">
+
+Oh, sure.  He's out collecting "Abas" with Owen and Beru.  I'm in charge here.</sp>
+         <sd>Did you find Leia?</sd>
+         <sp spk="GENERAL">
+
+Not yet.  We'll be away for a while.  You mind Lars until we return.  May the
+force of others be with you.</sp>
+         <sp spk="BIGGS">
+
+All right.  Take care.</sp>
+         <sd>Threepio enters the room, carrying a plate of steaming food.  Biggs turns the
+radio off, and puts the receiver away.  A crashing sound and voices are heard
+in the clearing below.</sd>
+         <sp spk="THREEPIO">
+
+Come and eat your dinner.</sp>
+         <sp spk="BIGGS">
+
+They're back!  They're back!  Come Amber!</sp>
+         <sd>The furry rodent jumps up onto its eight stubby legs and rushes over to the
+door, but stops short, and begins to growl.  Biggs stops behind the creature.</sd>
+         <sp spk="BIGGS">
+
+What is it, Amber?</sp>
+         <sd>Biggs peeks out the window, and sees a patrol of six Imperial stormtroopers
+climbing out of an airtank.  He ducks back, and tugs Amber away from the door.</sd>
+         <sp spk="BIGGS">
+
+Quiet, Amber.  Come here.  Come on.</sp>
+         <sp spk="THREEPIO">
+
+What's wrong?</sp>
+         <sp spk="BIGGS">
+
+Troopers.  We must hide!  Stay quiet.</sp>
+         <sd>Biggs and the robot scramble for a trap door near a large shelf.  The troops
+begin to climb the ladder to the tree house.  The trap door is heavy, and the
+robot and the little boy struggle to get it open.  The troops break in the
+door, just as Threepio closes the trap door.  The stormtroopers are led by a
+rough looking sergeant.  They poke around, tearing everything apart.  Biggs
+struggles to keep Amber quiet.  Suddenly he realizes something.</sd>
+         <sp spk="BIGGS">
+
+The food!</sp>
+         <sd>The sergeant takes the bowl of food from the table and studies it.  He then
+takes a small chrome ball from his pocket, and tosses it into the air.
+[something whited out?]  Antennae shoot from its surface as it floats around
+the room.  Eventually, it hovers over the trap door.  A sinister grin sweeps
+across the sergeant's face as he moves over to the trap door and puts the
+chrome ball back into his pocket.</sd>
+         <sd>Threepio puts his arm around Biggs who is desperately clutching the struggling
+thumper.  All the movement above them stops, and Biggs looks to the robot.</sd>
+         <sp spk="THREEPIO (quietly)">
+
+They're still up there.  Stay still.</sp>
+         <sd>The silence continues, then suddenly the trap door swings open with a loud
+bang.  Amber breaks away from Biggs, and attacks the sergeant.  One of the
+other troopers cuts the thumper in half with his lasersword.  The sergeant
+pulls Biggs out of his hiding place.  Biggs stares at the dead thumper.</sd>
+         <sp spk="SERGEANT">
+
+Well, well, here's one of them, anyway.  Send seekers in all directions.  Find
+the others!</sp>
+      </scene>
+      <scene n="144">
+         <setting>  VINE JUNGLE RIDGE - YAVIN</setting>
+         <sd>The general sits at the head of the large stone table, pushing small markers
+around.  Han explains what the general is doing, to ten or fifteen Wookee
+chiefs gathered around the table.  Occasionally, Chewbacca puts in a word of
+further explanation or answers a question.  Starkiller sits back silently
+watching the Wookee warriors and listens to the general's plan.</sd>
+         <sp spk="GENERAL">
+
+.... then they pull back to here.  That's where the trap will be set.  No-one
+must advance.  An assault on the perimeter is useless.  Our only hope is to
+use their weapons against them.</sp>
+         <sd>The general pauses, while Han and Chewbacca translate.</sd>
+         <sp spk="GENERAL (to Starkiller)">
+
+Once we acquire those tanks, our prime object must be to secure the starship.
+No-one must escape.</sp>
+      </scene>
+      <scene n="145">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three officers run along a row of giant air tnaks to a perimeter bunker.
+There, two stormtroopers are watching the jungle.  When the officers arrive,
+the troopers let them look through the powerful, mounted electrobinoculars.
+One of the troopers points out several areas in the dense jungle.</sd>
+      </scene>
+      <scene n="146">
+         <setting>  INTERIOR - CONTROL ROOM - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>A trooper sitting at an elaborate control panel, turns to an officer watching
+a monitor system.</sd>
+         <sp spk="TROOPER">
+
+A large concentration of trestuals at point E-2.</sp>
+         <sp spk="OFFICER">
+
+Alert squads one through six!</sp>
+      </scene>
+      <scene n="147">
+         <setting>  VINE JUNGLES - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands in a small clearing surrounded, by many armed Wookees
+carrying large shiny shields.  Han moves back and forth, barking orders to the
+assembled creatures.</sd>
+         <sp spk="GENERAL (to Han)">
+
+We're ready.  Give them the signal.</sp>
+         <sd>Han motions to a young Wookee, who takes off, running through the jungle.</sd>
+      </scene>
+      <scene n="148">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Three large air tanks slowly move toward the outpost perimeter.  The tank
+pilots sit on the hatch rims of the ponderous weapons, studying the movements
+of the Wookees.  The tank personnel talk to one another on an intercom system.</sd>
+         <sp spk="TANK PILOT">
+
+There is a large concentration....red two by C-3.  Let's break them up.</sp>
+         <sd>The pilots slip into the tanks and close the hatches.  The tanks open up with
+a barrage of laser bolts which create a wall of explosions.  The Wookies
+retreat, and the tanks follow.  The tank crews track the feeling creatures
+with various electronic scopes, and laugh at the fleeing creatures.</sd>
+      </scene>
+      <scene n="149">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The general stands on a limb of a jungle tree, watching the advancing tanks.
+Starkiller is on another branch a few feet away.</sd>
+         <sp spk="GENERAL">
+
+They've grown sloppy fighting Wookees.  The intra-fazer systems aren't on.
+They're in for a little surprise.</sp>
+         <sd>Starkiller flashes a signal mirror, which is received by a Wookee near the
+tanks.  The Wookees are in pairs, and they hold heavy stone wedges attached to
+woven vines; which in turn, are fastened high in the trees.  When the tanks
+pass directly under the Wookees, they let loose with the heavy stone
+pendulums.  The wedges fly through the air, neatly clipping off the antenna
+groupings protruding from the tops of the air tanks.</sd>
+      </scene>
+      <scene n="150">
+         <setting>  INTERIOR - AIR TANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Several of the lights and monitors go dark on the main control panel.  The
+pilot flips several switches in a panic.</sd>
+         <sp spk="PILOT">
+
+All high phasing units are out.  We've lost all contact....</sp>
+         <sp spk="SERGEANT">
+
+Send out a ground signal!</sp>
+         <sd>Suddenly, all of the monitors go white, and static fills the crowded tank
+interior.  An alarm signal sounds.</sd>
+         <sp spk="SERGEANT">
+
+What is it?!!!</sp>
+         <sp spk="PILOT">
+
+All signals...sensers....everything is coming right back to us.  Some kind of
+deflection screen.  It's a total blackout.</sp>
+         <sp spk="SERGEANT">
+
+Get out there and see if you can see anything.</sp>
+         <sd>The pilot pushes a button and the main hatch slowly slides away.</sd>
+      </scene>
+      <scene n="151">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The pilot pops out of the hatch and sses two rows of Wookee warriors holding
+reflective shields.  They form a circle that totally encompasses the massive
+air tank.  Han shouts a signal to a group of Wookees in another tree, and they
+cut loose a bent limb which is attached to a noose around the tank's hatch.
+The noose instantly tightens around the pilot, and he is plucked from the tank
+and suspended fifty feet in the air.  In an equally swift move, Starkiller
+drops a small gas grenade into the open hatch.  It explodes and engulfs the
+tank in a grey mist.</sd>
+         <sd>The Wookees let out a joyful yell, and charge the tank.  Han yells at them to
+stop, but several make it to the conquered craft before the gas cloud
+dissipates and they are felled by the fumes.  Starkiller shakes his head, then
+after the smoke clears, jumps on the back of the immobile tank.</sd>
+         <sd>Several signal mirrors flash their messages to Han and the general.</sd>
+         <sp spk="HAN">
+
+That makes four captured.</sp>
+         <sp spk="GENERAL">
+
+Have them camouflaged.  I'm going with Starkiller.</sp>
+      </scene>
+      <scene n="152">
+         <setting>  INTERIOR - AIR-TANK - VINE JUNGLE - YAVIN</setting>
+         <sd>Wookees are removing the tank crew as Starkiller checks out the power
+controls.  The general slides through the main hatch.</sd>
+         <sp spk="GENERAL">
+
+Any damage?</sp>
+         <sp spk="STARKILLER">
+
+She's fine...We're ready to move.</sp>
+         <sp spk="GENERAL">
+
+Then let's go...</sp>
+         <sd>The general yells for the Wookees to clear the tanks, and they scramble out of
+the hatch.</sd>
+      </scene>
+      <scene n="153">
+         <setting>  VINE JUNGLE - OUTPOST PERIMETER - YAVIN</setting>
+         <sd>The tank starts up with a loud roar, startling the many Wookees resting on the
+mighty vehicle.  Chewbacca yells at the warriors and they fall a few feet
+behind the tank, their shields forming a shiny protective wall.</sd>
+      </scene>
+      <scene n="154">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>Several officers stand on a parked air-tank trying to get a better view of the
+operation.  A light landspeeder pulls up next to the group, and a general gets
+out.  The officers snap to attention.</sd>
+         <sp spk="GENERAL">
+
+Can you see anything?</sp>
+         <sp spk="OFFICER">
+
+No Sir, but they've stopped firing.</sp>
+         <sp spk="AID [sic]">
+
+Communications still can't reach them, Sir.</sp>
+         <sp spk="GENERAL">
+
+Nobody seems to know what's going on.</sp>
+         <sp spk="OFFICER">
+
+I'm sure they've got them on the run, Sir.</sp>
+         <sd>A laserbolt flashes out of the jungle and knocks out a guard tower about a
+quarter of a mile from where the men are standing.  Seconds later, the air-
+tank on which they are standing explodes into a million pieces.  Out of the
+jungle, rumbles the captured air-tank, driven by Starkiller and followed by a
+column of Wookee warriors.</sd>
+         <sd>Alarms sound, troops rush from the low block houses, and a battle rages inside
+the outpost.  Wookees with spears, axes, and arrows, manage to hold their own
+against the laser weapons of the stormtroopers.  Explosions erupt everywhere,
+as the Wookees begin to use captured laserrifles.  They are much fiercer
+fighters than the soft Imperial troops.</sd>
+      </scene>
+      <scene n="155">
+         <setting>  INTERIOR - AIR-TANK - OUTPOST - YAVIN</setting>
+         <sd>Starkiller works the controls of the air-tank as the general watches the
+monitors, and works the laserguns.</sd>
+         <sp spk="GENERAL">
+
+Swing left.  They're trying to cut us off.</sp>
+      </scene>
+      <scene n="156">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Starkiller maneuvers the air-tank in front of a line of ten starships, cutting
+off a platoon of stormtroopers.  The troops open fire on the tank, but are cut
+down by a group of Wookees who have moved in behind them.  Han and Artwo run
+up to the tank as Starkiller and the general climb out of the hatch.</sd>
+         <sp spk="HAN">
+
+We've taken the main control center.  All power units have been shut down.
+They're helpless.</sp>
+         <sp spk="STARKILLER">
+
+Have they found Leia?</sp>
+         <sp spk="HAN">
+
+They've taken her back to Aquilae.  The ship left not more than ten hours ago.</sp>
+         <sp spk="GENERAL (to Han)">
+
+Set up a perimeter around these starships...Use as many men as you need.</sp>
+      </scene>
+      <scene n="157">
+         <setting>  STAFF OFFICE - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Starkiller and the general sit at a large table in the deserted office of the
+Imperial Chief of Staff.  The room is in a state of disarray; papers are
+scattered everywhere.  Artwo stands on a chair, projecting an image of the
+"death star" fortress orbiting Aquilae, on the table top.</sd>
+         <sp spk="ARTWO">
+
+....And are connected to the central system by a series of crossing networks
+similar to section TB4 or F687.</sp>
+         <sd>The projection switches to a close-up view of the transformer.  The general
+studies it carefully, then leans back in his chair.  Artwo turns off the
+projector.</sd>
+         <sp spk="GENERAL">
+
+I'm not going to stop you, but I think it's a reckless move.  Even if you
+could get in, you'd never be able to get out... Just be patient.  We now have
+enough ships to attack in force.</sp>
+         <sp spk="STARKILLER">
+
+But no pilots...</sp>
+         <sd>Han and Chewbacca enter the office.</sd>
+         <sp spk="HAN">
+
+Still no contact with Owen Lars or the kids...I'm afraid something's happened.</sp>
+         <sp spk="GENERAL">
+
+Have Chewbacca send two of his best warriors out there to get them.</sp>
+         <sd>Han relates this to Chewbacca.  The general turns back to Starkiller, who
+watches Chewbacca leave the room.</sd>
+         <sp spk="STARKILLER (mocking)">
+
+They're fierce warriors, but you'll never teach them to fly.</sp>
+         <sd>The general gives him a stern look.</sd>
+         <sp spk="GENERAL">
+
+They'll fly, and Aquilae will be free.</sp>
+         <sp spk="STARKILLER">
+
+May the force of others be with you.</sp>
+         <sd>The general embraces the young Jedi.</sd>
+         <sp spk="GENERAL">
+
+Bring her back safely.</sp>
+      </scene>
+      <scene n="158">
+         <setting>  OUTPOST RUNWAY - STARSHIP - YAVIN</setting>
+         <sd>Starkiller, dressed as an Imperial skyraider, and Artwo climb aboard one of
+the giant four-man starships.  A crowd of Wookees, lead by Chewbacca, give a
+rousing cheer for the departing Jedi.  Starkiller breaks into a smile and
+waves to the joyous warriors.  The general watches the proceedings from a
+bunker turret.  He is lost in thought.</sd>
+      </scene>
+      <scene n="159">
+         <setting>  SPACE FORTRESS - AQUILAE</setting>
+         <sd>Three Imperial space transports dock inside the huge artificial moon.  Two
+smaller convoy starships circle the larger craft until the three ships are
+safely inside the vast fortress.</sd>
+      </scene>
+      <scene n="160">
+         <setting>  CONFERENCE ROOM - INTERIOR SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader of the Imperial Space Fleet, hurries down a hallway, followed by
+a group of officers.  They enter the large conference room where Leia is held
+under heavy squad.  She appears well, but saddened.  Vader approaches her and
+bows  before her.</sd>
+         <sp spk="VADER">
+
+I pray you have been treated honorably?  I am your servant, Darth Vader.  It
+won't be long before we will be able to return you to your people.  (to an
+aide)  Are the chambers ready?</sp>
+         <sp spk="AIDE">
+
+They are working on it, Sir.</sp>
+         <sd>Leia stares defiantly at him.  She starts to speak, but a powerful electric
+shock engulfs her body, and she whines in extreme pain.</sd>
+         <sp spk="VADER">
+
+Just relax, and everything will be fine.  (to guards)  Take her to section
+twenty-five.</sp>
+         <sd>Leia is forcibly taken from the room.</sd>
+         <sp spk="VADER (to officer)">
+
+What time do the doctors from Alderaan arrive?</sp>
+         <sp spk="OFFICER">
+
+Sixty-five hours, Sir.</sp>
+         <sp spk="VADER">
+
+Put all security stations on alert until they arrive.</sp>
+         <sd>The officer salutes smartly, and exits.</sd>
+      </scene>
+      <scene n="161">
+         <setting>  IMPERIAL OUTPOST - VINE JUNGLE - YAVIN</setting>
+         <sd>A huge air tank rumbles along the approach to the Imperial outpost.  The pilot
+sits on the main hatch of the tank, talking to his crew, by headphones.</sd>
+         <sp spk="PILOT">
+
+Any contact yet?... It appears deserted...I don't like it.</sp>
+         <sd>The tank enters the outpost perimeter and smoking rubble from the recent
+battle comes into view.  The pilot becomes alarmed.</sd>
+         <sp spk="PILOT">
+
+There has been an attack!  Reverse direction.</sp>
+         <sd>The tank comes to a grinding halt, but before it can start up again, it is
+surrounded by the Wookee army.  From out of nowhere, a Wookee is on the back
+of the air-tank and has the pilot in a powerful armlock.</sd>
+         <sd>A Wookee chieftain rushes from a bunker, followed by an excited, jabbering
+warrior.  They reach the captured air-tank just as the last crewman is hauled
+out, and little Biggs pokes his head out of the hatch.  He is frightened.  His
+younger brother, Windy, follows him out of the tank.  Below them, the Wookees
+bully the captured crewmen.</sd>
+         <sp spk="WINDY">
+
+What will they do to us?</sp>
+         <sp spk="BIGGS">
+
+I don't know, but it don't look good.</sp>
+         <sd>Threepio pulls himself out of the air-tank, followed by Owen Lars and his
+wife.  The Wookee chieftain climbs on board, and starts to jabber at the
+group.  The Wookee carries on for some time, gesturing wildly, and continually
+pointing at the sky.  The two boys are too scared to say anything.  Finally,
+the Wookee kneels before them.  Threepio politely returns a short bow.</sd>
+         <sp spk="BIGGS">
+
+I don't get it.</sp>
+         <sd>The Wookee rises and again gestures skyward, just then a starship wildly
+buzzes the field, upsidedown.  All the Wookees run for cover.  The chief
+Wookee points to the crafts, and jabbers incessantly.</sd>
+      </scene>
+      <scene n="162">
+         <setting>  INTERIOR - IMPERIAL STARSHIP - SKY OVER YAVIN</setting>
+         <sd>Chewbacca sits at the controls of a four-man starship.  His face is a twisted
+combination of complete panic and an awesome religious experience.  The
+general, sitting next to him, calmly switches a few buttons on the control
+panel, as Han watches from the seat directly behind the Wookee.</sd>
+         <sp spk="GENERAL">
+
+You'll get the hang of it.</sp>
+         <sd>Han also gives the Wookee a few words of encouragement.</sd>
+         <sp spk="GENERAL">
+
+Now, let's see if we can get into orbit...Push this, then ease her up.</sp>
+         <sd>Chewbacca follows the instructions, but pulls back on the lever too fast and
+the ships begins to vibrate and bounce violently.  Chewbacca thinks it's
+funny, and begins to laugh hysterically.  Han becomes nervous and quiet.</sd>
+         <sp spk="GENERAL">
+
+Not so fast - Back off!  Back off!</sp>
+         <sd>Han yells at the Wookee, who can't respond because he is laughing so hard.
+The general pulls back on the lever.  Han shakes his head, and gives the
+general a worried look.</sd>
+         <sp spk="GENERAL">
+
+Don't worry.  Ignorance is on their side.</sp>
+         <sd>Han is beginning to look a little sick.  He gets up and rushes to the back of
+the ship.</sd>
+      </scene>
+      <scene n="163">
+         <setting>  IMPERIAL SPACE FORTRESS - DOCKING AREA - AQUILAE</setting>
+         <sd>The canopy on the starship pops open, and Artwo and the young Jedi, disguised
+as a starraider, climb out onto the docking platform.  An officer and two
+groundcrew approach him and salute.  Starkiller hands him his papers.</sd>
+         <sp spk="STARKILLER">
+
+I'm here to check the vent ports in the rim tracks.</sp>
+         <sp spk="OFFICER">
+
+Your ship is from Yavin... We've lost all contact with them.  What's going on
+out there?</sp>
+         <sp spk="STARKILLER">
+
+There is a fierce inversion just east of Bull Pup station... It's really a
+mess out there.</sp>
+         <sd>The officer smiles and the ground crew starts to check out the starship.
+Starkiller heads for the main docking exit, followed by Artwo.  He remembers
+something as he passes the control station, and calls out to the officer.</sd>
+         <sp spk="STARKILLER">
+
+Do you mind if I use your com-link?</sp>
+         <sp spk="OFFICER">
+
+No.  Go ahead.</sp>
+         <sd>Starkiller walks into the small control area and pretends to talk on an
+intercom system.</sd>
+         <sp spk="STARKILLER (to Artwo)">
+
+Find the highest security area.</sp>
+         <sd>Artwo punches his claw arm into a computer socket, and the brain comes to
+life, feeding information to the little robot.</sd>
+         <sd>Starkiller watches the officer as he directs the crewmen in the securing of
+the starship.  Artwo removes his arm from the computer, and the duo leave the
+control station.</sd>
+         <sp spk="ARTWO">
+
+Station 325 is the highest security area on board.  It's a detention area.</sp>
+         <sd>They disappear into a chamber lock hallway.</sd>
+      </scene>
+      <scene n="164">
+         <setting>  ELEVATOR TUBE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller, trying to look inconspicuous, waits for a horizontal elevator.
+Troops and fortress personnel come and go, but no-one seems to pay any
+attention to the pair.  Finally a small car arrives, and Starkiller follows
+Artwo into the podlike vehicle, and it takes off through a vacuum tunnel.</sd>
+      </scene>
+      <scene n="165">
+         <setting>  DETENTION AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller and Artwo enter a security station.  Guards and electronic cutters
+are everywhere.  An officer approaches Starkiller, and checks his papers.</sd>
+         <sp spk="OFFICER">
+
+The B-23 can't enter this station.</sp>
+         <sp spk="STARKILLER">
+
+But I need him.</sp>
+         <sp spk="OFFICER">
+
+Sorry.  No mechanical personnel.  It's restricted.</sp>
+         <sd>Starkiller watches helplessly, as Artwo is led into a waiting area.</sd>
+         <sp spk="OFFICER">
+
+You may proceed, but you'll have to be escorted.</sp>
+         <sd>A trooper joins Starkiller and leads him through a series of hallways.
+Starkiller carefully surveys the area as he follows the guard.</sd>
+         <sp spk="TROOPER">
+
+Mathusians just beat the PDR's again.  They should be in another league.  Do
+you follow the ecometrics?</sp>
+         <sd>The guard turns to discover that Starkiller has disappeared.  He is stunned,
+then manages to pull out a small ring radio.</sd>
+         <sp spk="TROOPER">
+
+Code six - Alert.</sp>
+      </scene>
+      <scene n="166">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Six Wookees sit before Han and the general, listening to Han explain something
+about space fighting.  Owen Lars approaches the general.</sd>
+         <sp spk="LARS">
+
+We've made contact with the underground on Aquilae.  Things are tighter.  They
+can only get one man out.  Datos is on his way.</sp>
+         <sp spk="GENERAL">
+
+We should be ready by the time he arrives.</sp>
+         <sd>Han turns to the general.</sd>
+         <sp spk="HAN">
+
+They're ready to go up.</sp>
+         <sd>The general makes a short statement to the Wookes in their own language.  They
+let out a loud cheer, and run for the row of starships.</sd>
+      </scene>
+      <scene n="167">
+         <setting>  STARSHIP - SPACE - YAVIN</setting>
+         <sd>The general sits next to Chewbacca, as he leads two other Wookee piloted
+starships in a tight formation.  They head for a small cluster of asteroids
+orbiting near the planet's surface.  The general quietly gives Chewbacca some
+reassuring instructions.  Han leads a second formation of three ships,
+following Chewbacca's group.  The two formations of starships make an attack
+run on the asteroids.  The general watches as Chewbacca lines up and fires at
+an asteroid blowing it into a million pieces.  The general smiles, and slaps
+Chewbacca on the back.  The Wookees excitedly chatter among themselves over
+the intercom system.</sd>
+      </scene>
+      <scene n="168">
+         <setting>  DETENTION AREA HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>A patrol of ten men marches through one of the long hallways in the detention
+area.  They stop at an intersection.  The officer in charge reports on the
+intercom.</sd>
+         <sp spk="OFFICER">
+
+Ben Five to Moma.  All clear.</sp>
+         <sd>The troops relax, some stand in groups, others wander a distance away, poking
+into the various small alleyways running off the main hallway.  One trooper
+notices a small reflected light in one of the narrow corridors, and carefully
+moves down the dark passageway to check it out.  Out of no-where, a fist
+knocks the trooper unconscious and drags him into a small alcove.</sd>
+         <sd>The officer finishes his report on the intercom and yells for the troops to
+fall-in.  Men scurry in all directions and out of a narrow corridor emerges
+Starkiller, dressed in the uniform of an Imperial startrooper.  He joins the
+platoon, and they march away.</sd>
+      </scene>
+      <scene n="169">
+         <setting>  GENERAL'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader and several officers watch the progress of the search on TV
+monitors.  The general speaks into an intercom.</sd>
+         <sp spk="VADER">
+
+Have them clear the area.  Bring in the seekers.</sp>
+         <sd>On the monitors, the troops are assembled in the main entry-way and several
+small chrome balls are thrown into the hallway.  Small antennae pop from the
+chrome surface, and the small balls float down the hallways.  Valorum, once a
+proud Knight of the Sith, enters wearing the uniform of a stormtrooper.  He
+snaps to attention before the general, and hands him a report.  Vader gives
+Valorum a sly grin.</sd>
+         <sp spk="VALORUM">
+
+Contact has been lost with the ship carrying the doctors from Alderaan.  The
+princess' treatment will have to be delayed.</sp>
+         <sp spk="VADER">
+
+We've just trapped your own friend Starkiller.  Watch us accomplish what you
+found to be impossible.</sp>
+         <sd>Valorum is humiliated, but stays at attention.  Valorum [Vader?] gets an
+emergency call on the intercom.</sd>
+         <sp spk="VADER">
+
+Yes...Yes... Put it on the view screen.</sp>
+         <sd>One of the TV monitors switches to an image of the unconscious trooper
+Starkiller stripped.</sd>
+         <sp spk="VADER">
+
+Get me the Captain of the Guard.</sp>
+      </scene>
+      <scene n="170">
+         <setting>  DETENTION AREA - MAIN ENTRY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Three squads of troops including Starkiller, stand at attention in the main
+entrance to the detention center, while the Captain of the Guard gets new
+orders over his headphones.  Starkiller studies the situation carefully,
+looking for a way out of his predicament.  The Captain of the Guard calls up
+the platoon sergeants and gives them a series of orders.  They return to their
+squads and begin to inspect the troops.  Starkiller begins to get worried.</sd>
+         <sd>The sergeant works his way down the line until he gets to the trooper next to
+Starkiller.  He sees no chance of escape, but surprise.  Suddenly, he bolts
+from the ranks and races down the hallway.</sd>
+         <sp spk="CAPTAIN OF THE GUARD">
+
+Squad leaders!</sp>
+         <sd>Ten troopers break out of the ranks and take up the chase.  Starkiller runs
+down a corridor and rounds a corner, reaching a dead end.  The troops round
+the corner and confront the trapped Jedi.  The sound of igniting laserswords
+fills the hallway.  Starkiller takes a defensive stance, his huge lasersword
+buzzing loudly.  The troops attack.  They fight with skill and bravery, but
+are eventually all cut down by the invincible Jedi warrior.</sd>
+         <sd>Starkiller breaks away from the troops and runs down a long hallway.  A safety
+door slides shut, closing off his escape.  He turns around in time to see
+another door seal off the opposite end of the hallway.  Before he can make any
+attempt to pry open the door, gas fills the sealed corridor.  Starkiller
+collapses in a heap on the floor.</sd>
+      </scene>
+      <scene n="171">
+         <setting>  GENERAL'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Vader laughs as he watches the unconscious Starkiller on the TV monitors.  All
+of the other officers in the room are [something whited out] laughing and
+joking, except Valorum, who remains grimly at attention.</sd>
+         <sp spk="GENERAL (to Valorum)">
+
+Take him to the special section.</sp>
+         <sd>Valorum salutes, and exits the offices.  Vader laughs again.</sd>
+      </scene>
+      <scene n="172">
+         <setting>  STARSHIP RUNWAY - IMPERIAL OUTPOST - YAVIN</setting>
+         <sd>Nine gleaming starships sit in a row along the edge of the vast jungle runway.</sd>
+         <sd>Bizarre and colorful Wookee designs have been painted across the large
+deflector fins of the spacecraft.  Some designs transform the ships into huge
+and grotesque animals, while others create unique mosaic patterns.  The four-
+man Wookee crews stand proudly at attention in front of their ships.  The
+general, along with Han and the underground leader, Datos, review the
+assembled Wookees.</sd>
+         <sd>In one of the Wookee crews, a pilot is picking fleas off the back of his tail
+gunner.  When the general passes, he snaps to attention.  There is a gleam in
+the general's eye as he shows off his strike force to the crusty old
+underground leader.  When they've inspected the last starship, Datos turns to
+the general.</sd>
+         <sp spk="DATOS">
+
+I'm speechless.  It's amazing.  A most impressive display.  For the first time
+since the take-over, I feel real hope.</sp>
+         <sp spk="GENERAL">
+
+Will your people be ready?</sp>
+         <sp spk="DATOS">
+
+Our forces have already started sabotaging their com-link set ups.  A refugee
+camp on Mananyo has been conducting raids on shipping from Alderaan.  That's
+how we intercepted those doctors...</sp>
+         <sp spk="GENERAL (to Han)">
+
+Get them in the ships... We're on our way.  (to Datos)  Send the code signal.</sp>
+      </scene>
+      <scene n="173">
+         <setting>  DETENTION CELL - SPACE FORTRESS - AQUILAE</setting>
+         <sd>General Vader and Valorum watch as a medic revives Starkiller, who has been
+strapped to an upright slab, protected by cutter-rays.</sd>
+         <sp spk="MEDIC">
+
+He's coming round.</sp>
+         <sd>The medic backs away, and throws the switch which activates the cutters.  A
+blue glow surrounds Starkiller as he wakes up and sees Vader and Valorum.</sd>
+         <sp spk="VADER">
+
+For all the myths and the trouble, you don't seem like much...</sp>
+         <sd>He laughs and leaves Valorum alone in the room with the young Jedi.  Valorum
+appears sad and frustrated at the capture of the noble warrior.  They stare at
+one another for a few moments.</sd>
+         <sp spk="VALORUM">
+
+You were insane to come here.  The security on this... this thing is
+impossible.  Why?....For her?  I can't believe your loyalty is that strong.
+You're a great warrior... but you're a greater fool.  This is a place for
+androids, no codes, no honor.  Our ways are useless here.  Why couldn't you
+have stayed away?</sp>
+         <sd>He storms out of the cell.  Starkiller struggles to free himself.</sd>
+      </scene>
+      <scene n="174">
+         <setting>  SLUM DWELLING - GORDON SPACEPORT - AQUILAE</setting>
+         <sd>The young partisan, Occo, listens to a small transmitter in a secret closet
+behind the main room in a slum dwelling.  He jumps up and runs into the main
+room, where Quist and several other men are sitting around a table covered
+with maps and plans.</sd>
+         <sp spk="OCCO">
+
+It's Datos.  We've got the go ahead.</sp>
+         <sd>Everyone cheers and starts hugging and slapping each other on the back.
+Finally, they settle down.</sd>
+         <sp spk="QUIST">
+
+Go to your organizations.  (to Occo)  What's the code time?</sp>
+         <sp spk="OCCO">
+
+Zero three thirty...</sp>
+         <sp spk="QUIST">
+
+May the force of others be with you.</sp>
+         <sd>The men solemnly shake hands and leave the room.</sd>
+      </scene>
+      <scene n="175">
+         <setting>  GOVERNOR'S OFFICE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller stands on a small platform before Governor Hoedaack and the High
+Consul.  His hands are held behind his back by electric bonds.</sd>
+         <sp spk="GOVERNOR">
+
+.... And I'm sure the emperor will enjoy your execution.  I only regret I
+won't be there myself.  This should end the Jedi myth once and for all.  Take
+him to Alderaan.</sp>
+         <sd>Valorum steps forward with a squad of stormtroopers and escorts the prisoner
+away.  Vader and the governor seem very pleased with themselves.  Valorum
+looks back in disgust.</sd>
+      </scene>
+      <scene n="176">
+         <setting>  CONTROL CENTER - SPACE FORTRESS - AQUILAE</setting>
+         <sd>In the large central control room, two officers sit above a row of monitors
+and giant read-outs.</sd>
+         <sp spk="FIRST OFFICER">
+
+Look!  That whole sector just went dead.  We're losing contact with the
+surface.  Use the IF link and find out what's going on.</sp>
+      </scene>
+      <scene n="177">
+         <setting>  DOCKING AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Valorum halts the squad guarding Starkiller on an observation deck overlooking
+a starship docking port.  Valorum reports to the officer in charge.</sd>
+         <sp spk="VALORUM">
+
+Where is the ship?</sp>
+         <sp spk="OFFICER">
+
+It's on its way in.  It will just be a few minutes.</sp>
+         <sd>Valorum returns to his squad and watches the large starship slowly move into
+the docking area.  He glances at Starkiller, who stands defiant, ready to meet
+his fate.</sd>
+         <sd>Valorum continues to study Starkiller.  The young Jedi returns his gaze.
+Slowly, the spacecraft locks onto the docking port with a loud jolt.  The
+troops snap to attention, but Valorum grabs two laserswords and in one swift
+move, switches off Starkiller's bonds and tosses him one of the laserswords.
+Starkiller assumes a defensive stance, as the troops realize what has happened
+and draw their swords.</sd>
+         <sp spk="VALORUM">
+
+This way!</sp>
+         <sd>The two warriors fight their way through a side exit.  The door slides closed
+behind them, and Valorum throws the lock, trapping the troops on the
+observation platform.  They race down the hallway and stop at an intersection.</sd>
+         <sp spk="VALORUM">
+
+This way!  We can get a starship and be out of here before they've
+discovered...</sp>
+         <sp spk="STARKILLER">
+
+I'm not leaving without the princess.</sp>
+         <sp spk="VALORUM">
+
+It's impossible; there are traps everywhere... You're mad!</sp>
+         <sd>Starkiller just grins and runs down the passageway leading to the detention
+area.  Valorum rushes and catches up.  An alarm signal wails through the
+hallways.</sd>
+      </scene>
+      <scene n="178">
+         <setting>  WOOKEE STARSHIPS - SPACE</setting>
+         <sd>The general leads three squads, of three starships each toward the glowing
+planet of Aquilae.</sd>
+         <sp spk="GENERAL">
+
+There she is.  Activate your deflection shields.</sp>
+      </scene>
+      <scene n="179">
+         <setting>  DETENTION AREA - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Valorum talks with the Captain of the Guard.  He gestures wildly, like
+something important had happened.  Four troops run into the central detention
+area leading the bound Princess Leia.  The Captain of the Guard salutes
+Valorum, and the Sith knight, followed by the four troops and Leia, leave the
+main area.</sd>
+      </scene>
+      <scene n="180">
+         <setting>  DETENTION HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller appears boldly at the end of the hallway, facing Valorum and the
+troops.</sd>
+         <sp spk="VALORUM">
+
+Get him!</sp>
+         <sd>The troops rush for Starkiller, swords drawn.  They are no match for the
+skilled Jedi.  He makes short work of them, as Valorum frees the princess.
+The trio then run into another hallway.  The princess embraces Starkiller.</sd>
+         <sp spk="VALORUM">
+
+We only have a few seconds before they find us.  All of these hallways are
+sealable...</sp>
+         <sd>Starkiller spots a small garbage chute on the corridor wall.  He goes and
+looks into it.</sd>
+         <sp spk="STARKILLER">
+
+Is this pressurized?</sp>
+         <sd>Valorum nods yes, and they lift the princess into the chute and quickly
+follow.</sd>
+      </scene>
+      <scene n="181">
+         <setting>  GARBAGE CHUTE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The trio slides through a series of chutes, until they end up in a large room
+full of garbage.  Starkiller spots a doorway and struggles to get it open.</sd>
+         <sp spk="VALORUM">
+
+They're power sealed...We'll have to find another way, or some way to shut the
+power off...</sp>
+         <sd>They search the smooth-walled room for another exit.</sd>
+      </scene>
+      <scene n="182">
+         <setting>  GOVERNOR'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Governor Hoedaack watches General Vader as he supervises the hunt for
+Starkiller and Valorum.  They watch troops move through the detention area via
+TV monitors.  Seekers buzz through the hallways.  The general gets a report
+from an officer on another monitor.</sd>
+         <sp spk="OFFICER">
+
+We've lost contact with the surface.  There is a good probability of an
+uprising.  Even the IF links are out.</sp>
+         <sp spk="GENERAL">
+
+Use a substandard relay and put all units on alert.</sp>
+         <sd>The officer disappears from the monitor and is replaced with the Captain of
+the Guard.</sd>
+         <sp spk="CAPTAIN">
+
+All sections D through P-12 are clear.  We have reason to suspect they escaped
+through the disposal system.  We are checking....(he is interrupted by an
+excited trooper who tells him something)....We've found them in Receptacle B-
+29.  You should....</sp>
+         <sd>A red light flashes on one of the other monitors.</sd>
+         <sp spk="GENERAL">
+
+Hold on...</sp>
+         <sd>A controller appears on the second monitor.</sd>
+         <sp spk="CONTROLLER">
+
+Starships approaching, three squads.  Imperial design, but no clearance...</sp>
+         <sp spk="GENERAL">
+
+Full alert.  Battle stations....</sp>
+         <sd>The general turns back to the Captain of the Guards.</sd>
+         <sp spk="CAPTAIN">
+
+You should have them on your screen.</sp>
+         <sd>Alarms sound throughout the fortress.  Lights flash a warning.</sd>
+      </scene>
+      <scene n="182.2">
+         <setting>  [SECOND 182] GARBAGE RECEPTACLE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>A floodlight switches on, revealing Valorum and Starkiller attempting to cut
+open the door.  The princess stands up and stares into the floodlight.
+Vader's voice comes over an intercom.</sd>
+         <sp spk="VADER">
+
+I'm afraid I have no more time to deal with you.  A senseless and futile
+attack by your friends has forced me to take a rather unpleasant course of
+action.  Your execution will have to be expedited.</sp>
+         <sd>The intercom clicks off, and a loud rumbling begins to shake the room.  With a
+loud shriek, the princess points to the far wall; which starts to move toward
+the trio.  The situation looks desperate.</sd>
+      </scene>
+      <scene n="183">
+         <setting>  SPACE - WOOKEE STARSHIPS - AQUILAE</setting>
+         <sd>Laserfire from the space fortress creates a wall of death, which the three
+squadrons of Wookee starships miraculously emerge through undamaged.  The
+general barks orders to the Wookee craft, and Chewbacca and his squadron break
+off and start an attack dive.  Laser fire from Chewbacca's brightly colored
+ship hits one of the prime power terminals on the fortress surface.  It
+explodes, creating weird electric arcs, as it goes.</sd>
+         <sd>Han and the general also concentrate fire on the distinctive black power
+terminals.  Two more are destroyed in an arcing spectacle.  A chain reaction
+is set off, creating a series of explosions leaping across the surface of the
+fortress from power terminal to power terminal.</sd>
+      </scene>
+      <scene n="184">
+         <setting>  GARBAGE RECEPTACLE - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The shock of the explosion can be felt over the rumbling of the trash masher.
+The wall has moved within a few yards of squashing Valorum, Starkiller and the
+princess.  They are still frantically trying to somehow stop the relentless
+wall, to no avail.  The lights blink off, then on again, and the moving wall
+rumbles to a halt.  Leia breathes a sigh of relief.</sd>
+         <sp spk="STARKILLER">
+
+They must have knocked the power out.</sp>
+         <sd>Valorum runs over to the door, and kicks it open.  They rush out of the would-
+be death trap.</sd>
+      </scene>
+      <scene n="185">
+         <setting>  SPACE - WOOKEE STARSHIPS - AQUILAE</setting>
+         <sd>One of the Wookee starships is caught in a crossfire and disappears in a cloud
+of smoke.  Another ship for some unknown reason dives headlong into the
+surface of the fortress, creating a huge explosion.</sd>
+      </scene>
+      <scene n="186">
+         <setting>  MAIN HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Starkiller, Valorum, and the princess are thrown to a hallway floor by the
+explosion.  They get up and start down the hallway again.  A voice calls out
+from a connecting corridor.</sd>
+         <sp spk="ARTWO">
+
+Hey!  Over here.</sp>
+         <sd>The trio turns and see little Artwo standing at the other end of the corridor.</sd>
+         <sd>He waves his claw arm at them, and wobbles toward them.</sd>
+         <sp spk="ARTWO">
+
+The power core has exceeded the normal stress quotient by point eight.  The
+magnetic fusion pods have evaporated.  There appears to be an immediate
+danger.</sp>
+         <sp spk="VALORUM">
+
+There is a lifepod station at the other end of this sector... Hurry.</sp>
+         <sd>The group, followed by Artwo, make a dash for the lifepod, but are knocked to
+the ground by another explosion, which rocks the hallway.  A hole is ripped in
+one wall, sucking debris into space.  Everyone holds on to wall fixtures for
+dear life.</sd>
+      </scene>
+      <scene n="187">
+         <setting>  GOVERNOR'S QUARTERS - SPACE FORTRESS - AQUILAE</setting>
+         <sd>Aides and officers rush through the office, as Vader tries to keep things
+under control.  Governor Hoedaack remains calm, watching the progress of the
+battle.  Vader turns to the governor.</sd>
+         <sp spk="VADER">
+
+They've pinpointed every terminal.  It's impossible.  What are they?  Where
+did they come from?  An electromagnetic transfer has started....There's no
+stopping it...</sp>
+         <sp spk="GOVERNOR">
+
+Continue the fight...</sp>
+         <sp spk="VADER">
+
+We've already lost control of the planet.  We must abandon ship while there is
+still time...Conditions are much worse than...</sp>
+         <sp spk="GOVERNOR">
+
+Continue the fight...This fortress is invincible.  I will not give up.</sp>
+         <sd>A giant explosion sweeps through the office.</sd>
+      </scene>
+      <scene n="188">
+         <setting>  SPACE - WOOKEE STARSHIPS</setting>
+         <sd>The tiny starships race the chain reaction explosions across the surface of
+the fortress.  Laserfire is everywhere.  one of the starships skimming across
+the surface, lags behind and is caught in an explosion and disappears.</sd>
+         <sp spk="GENERAL">
+
+Han!  Get everyone out of there.  The whole thing's going to go....Return to
+Gordon... Get them out.</sp>
+         <sd>Han relays the order to the Wookees, and then starships pull away from the
+crippled fortress.</sd>
+      </scene>
+      <scene n="189">
+         <setting>  MAIN HALLWAY - SPACE FORTRESS - AQUILAE</setting>
+         <sd>The group has made its way past the hole in the wall and is climbing into the
+lifepods.  Starkiller helps the princess into one, while Valorum and Artwo get
+into the other.  Warning sirens scream throughout the hallways.  Three troops
+run toward the lifepods, firing laserpistols.  Valorum returns the fire,
+stopping the oncoming troops.  Hatches are closed, and the lifepods eject into
+space.</sd>
+      </scene>
+      <scene n="190">
+         <setting>  LIFEPODS - SPACE - YAVIN ORBIT</setting>
+         <sd>The two lifepods drift toward the calm of the planet's surface.  Starkiller
+and the princess embrace, and he kisses her tenderly.  They watch the ominous
+fortress grow smaller and smaller as they drift away.  Suddenly, a great flash
+replaces the fortress and rubble streaks past the lifepods.  Several giant
+explosions follow, then there is only a smoke cloud where the mighty fortress
+once orbited Aquilae.</sd>
+      </scene>
+      <scene n="191">
+         <setting>  THRONE ROOM - PALACE OF LITE - AQUILAE</setting>
+         <sd>Queen Leia, in all her grandeur, sits on the magnificent throne of Aquilae.
+Starkiller and the general stand to her right.  Several old advisors stand to
+her left.  Han presents Chewbacca and a delegation of Wookees with a treaty,
+gifts, and a medal of honor.  They bow and exit.  Han moves to one side of the
+crowded court.  Valorum stands next to him.  They watch as the two robots,
+Artwo and Threepio, approach the queen, and bow.</sd>
+         <sp spk="QUEEN">
+
+Your service to Aquilae is greatly appreciated.  You are designated class A-4,
+and will serve Annikin Starkiller, the new Lord Protector of Aquilae.  Rise!</sp>
+         <sd>The robots rise and exit through the long entrance hall to the throne.  The
+queen turns and smiles at Starkiller and the general.  The general and
+Starkiller salute their new queen.</sd>
+         <sd>FADE OUT</sd>
+         <sd>END CREDITS</sd>
+      </scene>
+   </body>
+</xml>


### PR DESCRIPTION
@jbg5721 Here's my pull request for an XSLT conversion of your scripts to:
1) number scenes if they are not already numbered,
2) Move `<speaker>` elements into `@spk` attributes on `<sp>`,
3) Run `<xsl:analyze-string/>` to find in the `<sp>` elements the regex of `\((.+?)\)` and wrap the inner contents in `<sd>`. I did this in a second XSLT b/c this had to be based on the output of the first one.

The finished output is in a new folder: **XMLtransformed**